### PR TITLE
chore: add marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,14 +1,20 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "lossless-claude",
-  "plugins": [
-    {
-      "name": "lossless-claude",
-      "source": "./",
-      "description": "Lossless context management — DAG-based summarization that preserves every message"
-    }
-  ],
   "owner": {
     "name": "lossless-claude",
     "url": "https://github.com/lossless-claude"
-  }
+  },
+  "plugins": [
+    {
+      "name": "lossless-claude",
+      "source": {
+        "source": "github",
+        "repo": "lossless-claude/lcm"
+      },
+      "description": "Lossless context management — DAG-based summarization that preserves every message",
+      "version": "0.1.0",
+      "strict": true
+    }
+  ]
 }


### PR DESCRIPTION
Adds `.claude-plugin/marketplace.json` so `lossless-claude/lcm` can serve as its own Claude Code marketplace.

This enables `lossless-claude@lossless-claude` plugin key without needing a separate marketplace repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)