### PR TITLE
feat: lcm import --replay + fix MCP registration tug-of-war

### DIFF
--- a/.xgh/plans/2026-03-22-import-replay.md
+++ b/.xgh/plans/2026-03-22-import-replay.md
@@ -165,22 +165,23 @@ function makeMinimalStores(): { conversationStore: ConversationStore; summarySto
   const summaryStore = {
     getContextTokenCount: vi.fn().mockResolvedValue(50_000),
     getContextItems: vi.fn().mockResolvedValue([
-      { ordinal: 0, itemType: "message", messageId: "msg-1", summaryId: null, tokenCount: 50_000 },
+      { ordinal: 0, itemType: "message", messageId: 1, summaryId: null, tokenCount: 50_000 },
     ]),
     insertSummary: vi.fn().mockResolvedValue(undefined),
     linkSummaryToMessages: vi.fn().mockResolvedValue(undefined),
     replaceContextRangeWithSummary: vi.fn().mockResolvedValue(undefined),
-    getMessageContent: vi.fn().mockResolvedValue([{
-      messageId: "msg-1", role: "user", content: "hello", tokenCount: 50_000,
-      createdAt: new Date(), fileIds: [],
-    }]),
+    getDistinctDepthsInContext: vi.fn().mockResolvedValue([0]),
   } as unknown as SummaryStore;
 
   const conversationStore = {
     getConversation: vi.fn().mockResolvedValue({ conversationId: 1, sessionId: "sess-1" }),
     getMaxSeq: vi.fn().mockResolvedValue(0),
-    createMessage: vi.fn().mockResolvedValue({ messageId: "evt-1" }),
+    createMessage: vi.fn().mockResolvedValue({ messageId: 1 }),
     createMessageParts: vi.fn().mockResolvedValue(undefined),
+    getMessageById: vi.fn().mockResolvedValue({
+      messageId: 1, role: "user", content: "hello",
+      createdAt: new Date(), fileIds: [],
+    }),
     withTransaction: vi.fn().mockImplementation((fn: () => Promise<void>) => fn()),
   } as unknown as ConversationStore;
 
@@ -203,7 +204,6 @@ describe("CompactionEngine.compact — previousSummaryContent seeding", () => {
     const engine = new CompactionEngine(conversationStore, summaryStore, {
       contextThreshold: 0.5,
       freshTailCount: 0,
-      freshTailTokens: 0,
       leafMinFanout: 1,
       condensedMinFanout: 10,
       condensedMinFanoutHard: 5,
@@ -338,7 +338,7 @@ Find the `engine.compact({...})` call and add:
 ```ts
 const compactResult = await engine.compact({
   conversationId: conversation.conversationId,
-  tokenBudget: config.compaction.contextBudgetTokens,
+  tokenBudget: 200_000,
   summarize,
   force: true,
   hardTrigger: true,
@@ -621,7 +621,7 @@ Expected: all tests pass, no regressions.
 - [ ] **Step 2: Find the lcm-import skill file and add `--replay` docs**
 
 ```bash
-find /Users/pedro/Developer/lossless-claude -name "lcm-import*" | grep -v node_modules | head -5
+find . -name "lcm-import*" -not -path "*/node_modules/*" | head -5
 ```
 
 Open whichever `.md` file is returned. In the **Options** section, add:

--- a/src/hooks/auto-heal.ts
+++ b/src/hooks/auto-heal.ts
@@ -44,11 +44,9 @@ export function validateAndFixHooks(deps: AutoHealDeps = defaultDeps()): void {
       const entries = hooks[event];
       return Array.isArray(entries) && hasHookCommand(entries, command);
     });
-    const hasManagedMcpServer = !!settings.mcpServers?.lcm;
+    if (!hasDuplicates) return;
 
-    if (!hasDuplicates && !hasManagedMcpServer) return;
-
-    // Clean up: remove lcm hooks and MCP config from settings.json
+    // Clean up: remove lcm hooks from settings.json (MCP config is preserved)
     const merged = mergeClaudeSettings(settings);
     deps.mkdirSync(dirname(deps.settingsPath), { recursive: true });
     deps.writeFileSync(deps.settingsPath, JSON.stringify(merged, null, 2));

--- a/test/hooks/auto-heal.test.ts
+++ b/test/hooks/auto-heal.test.ts
@@ -46,10 +46,11 @@ describe("validateAndFixHooks", () => {
     expect(deps.writeFileSync).not.toHaveBeenCalled();
   });
 
-  it("removes leaked mcpServers.lcm even when no managed hooks are present", () => {
+  it("preserves mcpServers.lcm when cleaning duplicate hooks", () => {
     const deps = makeDeps({
       readFileSync: vi.fn().mockReturnValue(JSON.stringify({
         hooks: {
+          PreCompact: [{ matcher: "", hooks: [{ type: "command", command: "lcm compact" }] }],
           PostToolUse: [{ matcher: "", hooks: [{ type: "command", command: "other" }] }],
         },
         mcpServers: {
@@ -63,10 +64,29 @@ describe("validateAndFixHooks", () => {
 
     expect(deps.writeFileSync).toHaveBeenCalledTimes(1);
     const written = JSON.parse((deps.writeFileSync as ReturnType<typeof vi.fn>).mock.calls[0][1]);
+    expect(written.hooks.PreCompact).toBeUndefined();
     expect(written.hooks.PostToolUse).toEqual([{ matcher: "", hooks: [{ type: "command", command: "other" }] }]);
-    // mcpServers.lcm is now preserved (owned by settings.json)
+    // mcpServers.lcm is preserved (owned by settings.json, not removed during hook cleanup)
     expect(written.mcpServers.lcm).toEqual({ command: "lcm", args: ["mcp"] });
     expect(written.mcpServers.other).toEqual({ command: "other", args: ["mcp"] });
+  });
+
+  it("no-ops when only mcpServers.lcm is present without duplicate hooks", () => {
+    const deps = makeDeps({
+      readFileSync: vi.fn().mockReturnValue(JSON.stringify({
+        hooks: {
+          PostToolUse: [{ matcher: "", hooks: [{ type: "command", command: "other" }] }],
+        },
+        mcpServers: {
+          lcm: { command: "lcm", args: ["mcp"] },
+        },
+      })),
+    });
+
+    validateAndFixHooks(deps);
+
+    // No duplicate hooks → no write needed (mcpServers.lcm alone doesn't trigger cleanup)
+    expect(deps.writeFileSync).not.toHaveBeenCalled();
   });
 
   it("does not throw on fs errors", () => {

--- a/test/installer/install.test.ts
+++ b/test/installer/install.test.ts
@@ -345,5 +345,7 @@ describe("install — MCP registration", () => {
     const settings = JSON.parse(written);
     expect(settings.mcpServers?.lcm).toBeDefined();
     expect(settings.mcpServers.lcm.args).toContain("mcp");
+    expect(typeof settings.mcpServers.lcm.command).toBe("string");
+    expect(settings.mcpServers.lcm.command.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `.xgh/plans/2026-03-22-import-replay.md` — implementation plan for `lcm import --replay`
- Fixes MCP registration tug-of-war: `lcm install` now writes `mcpServers.lcm` into `settings.json` and auto-heal/doctor no longer delete it
- Removes `mcpServers` from `.claude-plugin/plugin.json` (settings.json is now authoritative)

## What the feature does (`lcm import --replay`)

`lcm import --replay` imports sessions in chronological (mtime) order and compacts each one immediately, threading the resulting summary content as context into the next session's compaction. This produces a **temporal DAG** in memory rather than isolated per-conversation compression trees.

## Key design decisions in the plan

1. **mtime sort** — `findSessionFiles` gains `statSync` + sort by `mtimeMs`
2. **Engine seed** — `CompactionEngine.compact()` and `compactFullSweep()` accept `previousSummaryContent?` to seed the first leaf pass
3. **Real summary content** — `/compact` route fetches actual LLM summary text via `summaryStore.getSummary(createdSummaryId)` and returns it as `latestSummaryContent` (distinct from the existing `summary` stats string)
4. **Idempotent replay** — compact fires for all sessions, not just freshly ingested ones
5. **Per-project chain** — `previousSummary` resets between projects

## MCP registration fix (shipped in this PR)

- `installer/install.ts` — writes `mcpServers.lcm` with resolved binary path into `settings.json`
- `src/hooks/auto-heal.ts` — no longer removes `mcpServers.lcm`; only cleans up duplicate hooks
- `src/doctor/doctor.ts` — auto-fix uses `resolveBinaryPath()` instead of hardcoded `"lcm"`
- Tests updated to match new behavior

## Files to be touched (in `--replay` implementation)

- `src/import.ts`
- `src/compaction.ts`
- `src/daemon/routes/compact.ts`
- `bin/lcm.ts`
- `test/compaction.test.ts` (new)
- `test/import.test.ts`
- `test/daemon/routes/compact.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)