### PR TITLE
fix: widen resolveBinaryPath type, clarify MCP ownership, align plan to ESM

### DIFF
--- a/.xgh/plans/2026-03-23-lcm-context-skill-distribution.md
+++ b/.xgh/plans/2026-03-23-lcm-context-skill-distribution.md
@@ -113,7 +113,7 @@ Add support for global install to `~/.claude/skills/lcm-context/` so the skill i
 ```typescript
 import { describe, it, expect } from 'vitest';
 import { installConnector } from '../../src/connectors/installer.js';
-import { readFileSync } from 'fs';
+import { readFileSync } from 'node:fs';
 
 describe('global skill install', () => {
   it('resolves ~ paths for claude-code skill type', () => {
@@ -153,7 +153,7 @@ export interface InstallOptions {
 In `src/connectors/installer.ts`, modify `resolveConfigPath()`:
 - If `options.global` is true and agent is `claude-code` and type is `skill`:
   - Resolve to `~/.claude/skills/lcm-context/SKILL.md` instead of `.claude/skills/`
-- For Claude Code global skill, read content from `src/connectors/configs/claude-code/SKILL.md` (use `path.resolve(__dirname, '../connectors/configs/claude-code/SKILL.md')` or equivalent for the built package)
+- For Claude Code global skill, read content from `src/connectors/configs/claude-code/SKILL.md` using the existing ESM pattern, e.g. `path.resolve(dirname(fileURLToPath(import.meta.url)), '../connectors/configs/claude-code/SKILL.md')` (consistent with how `doctor.ts` and `doctor.ts` resolve paths in the built package)
 
 - [ ] **Step 5: Run test to verify it passes**
 

--- a/installer/install.ts
+++ b/installer/install.ts
@@ -95,7 +95,12 @@ async function readlinePrompt(question: string): Promise<string> {
 
 const defaultDeps: ServiceDeps = { spawnSync: spawnSync as any, readFileSync: (path, encoding) => readFileSync(path, encoding as BufferEncoding) as string, writeFileSync, mkdirSync, existsSync, promptUser: readlinePrompt };
 
-export function resolveBinaryPath(deps: Pick<ServiceDeps, "spawnSync" | "existsSync"> = defaultDeps): string {
+export interface ResolveBinaryDeps {
+  spawnSync: (cmd: string, args: string[], opts?: object) => { status: number | null; stdout: string | Buffer };
+  existsSync: (path: string) => boolean;
+}
+
+export function resolveBinaryPath(deps: ResolveBinaryDeps = defaultDeps): string {
   const result = deps.spawnSync("sh", ["-c", "command -v lcm"], { encoding: "utf-8" });
   if (result.status === 0 && typeof result.stdout === "string" && result.stdout.trim()) {
     return result.stdout.trim();

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -230,7 +230,8 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>): Promise<CheckR
   let currentSettings: Record<string, unknown> = {};
   try { currentSettings = JSON.parse(deps.readFileSync(settingsPath, "utf-8")); } catch {}
   const mcpServers = currentSettings.mcpServers as Record<string, unknown> | undefined;
-  // MCP server is owned by settings.json (written by lcm install / doctor)
+  // For local installs, settings.json is the canonical source for MCP servers (written by lcm install / doctor);
+  // plugin.json may also declare mcpServers.lcm but is a secondary/optional registration path.
   if (mcpServers?.["lcm"]) {
     results.push({ name: "mcp-lcm", category: "Settings", status: "pass", message: "mcpServers.lcm registered in settings.json" });
   } else {
@@ -238,10 +239,7 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>): Promise<CheckR
       const merged = mergeClaudeSettings(currentSettings);
       if (typeof merged.mcpServers !== "object" || merged.mcpServers === null) merged.mcpServers = {};
       // Use resolveBinaryPath for consistent binary resolution with installer
-      const lcmBinary = resolveBinaryPath({
-        spawnSync: (cmd, args, opts) => deps.spawnSync(cmd, args, opts) as any,
-        existsSync: deps.existsSync,
-      });
+      const lcmBinary = resolveBinaryPath(deps);
       (merged.mcpServers as Record<string, unknown>)["lcm"] = { command: lcmBinary, args: ["mcp"] };
       deps.writeFileSync(settingsPath, JSON.stringify(merged, null, 2));
       results.push({ name: "mcp-lcm", category: "Settings", status: "warn", message: "mcpServers.lcm missing from settings.json — re-added automatically", fixApplied: true });


### PR DESCRIPTION
## Summary

Cherry-pick of Copilot's PR #9 (auto-closed when #8 merged):

- Extract `ResolveBinaryDeps` interface so doctor doesn't need `as any` casts
- Clarify MCP server ownership comment in doctor
- Fix plan to use ESM `import.meta.url` pattern instead of `__dirname`

## Test plan

- [x] All 467 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)