### PR TITLE
fix: resolve plugin commands path from repo root

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,7 +10,7 @@
   "repository": "https://github.com/lossless-claude/lcm",
   "license": "MIT",
   "keywords": ["context", "memory", "compaction", "summarization", "lcm"],
-  "commands": "./commands/",
+  "commands": "./.claude-plugin/commands/",
   "mcpServers": {
     "lcm": {
       "command": "lcm",


### PR DESCRIPTION
## Summary
- Claude Code resolves relative paths in `plugin.json` from the **repo root**, not from `plugin.json`'s parent directory
- `./commands/` resolved to `/repo-root/commands/` (doesn't exist) instead of `/repo-root/.claude-plugin/commands/`
- Changed to `./.claude-plugin/commands/` so it resolves correctly from repo root

## Test plan
- [x] Patched local plugin cache — `/doctor` shows no plugin errors after reload


🤖 Generated with [Claude Code](https://claude.com/claude-code)