### PR TITLE
chore: bump version to 0.2.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "repo": "lossless-claude/lcm"
       },
       "description": "Lossless context management — DAG-based summarization that preserves every message",
-      "version": "0.1.0",
+      "version": "0.2.1",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lossless-claude",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Lossless context management — DAG-based summarization that preserves every message",
   "author": {
     "name": "Pedro Almeida",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lossless-claude/lcm",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Never lose context again. lossless-claude compresses Claude Code sessions into searchable memory — every message preserved, every insight remembered.",
   "type": "module",
   "main": "dist/src/memory/index.js",


### PR DESCRIPTION
0.2.0 was published manually — CI needs a fresh version.