### PR TITLE
release: v0.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "repo": "lossless-claude/lcm"
       },
       "description": "Lossless context management — DAG-based summarization that preserves every message",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lossless-claude",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Lossless context management — DAG-based summarization that preserves every message",
   "author": {
     "name": "Pedro Almeida",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lossless-claude/lcm",
-  "version": "0.1.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lossless-claude/lcm",
-      "version": "0.1.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",
@@ -310,7 +310,7 @@
       }
     },
     "node_modules/@changesets/errors": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@changesets/errors/-/errors-0.2.0.tgz",
       "integrity": "sha512-6BLOQUscTpZeGljvyQXlWOItQyU71kCdGz7Pi8H8zdw6BI0g3m43iL4xKUVPWtG+qrrL9DTjpdn8eYuCQSRpow==",
       "dev": true,
@@ -2695,7 +2695,7 @@
       }
     },
     "node_modules/forwarded": {
-      "version": "0.2.0",
+      "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lossless-claude/lcm",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Never lose context again. lossless-claude compresses Claude Code sessions into searchable memory — every message preserved, every insight remembered.",
   "type": "module",
   "main": "dist/src/memory/index.js",


### PR DESCRIPTION
## Summary
First minor release on the new lcm repo.

### Highlights
- **E2E test suite** — harness + 9 test flows
- **lcm-context skill** — multi-platform memory guidance
- **lcm import --replay** — session transcript replay
- **Plugin fixes** — commands path, MCP registration
- **Curated docs** — 13 specs/plans kept, 36 dropped
- **lcm-dogfood** — self-test skill (39 checks, 10 phases)
- **Promote + status routes** — new daemon endpoints
- **Mock summarizer** — deterministic testing
- **Copilot review fixes** — CLI commands, assertions, status hardening
- **Website** — rebuilt on gh-pages with lcm branding

🤖 Generated with [Claude Code](https://claude.com/claude-code)