### PR TITLE
ci: simplify publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,7 +43,7 @@ jobs:
           if npm view "$name@$version" version >/dev/null 2>&1; then
             echo "Package $name@$version already published to npm — skipping publish"
             printf 'skip=true\n' >> "$GITHUB_OUTPUT"
-          elif git rev-parse "$tag" >/dev/null 2>&1; then
+          elif git rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1; then
             echo "Git tag $tag already exists (but npm version not found) — skipping publish"
             printf 'skip=true\n' >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- Trigger publish on push to main when `package.json` changes (auto-publish on release merge)
- Keep `workflow_dispatch` for manual runs
- Remove push-back step that tried to commit to main (blocked by branch protection)
- Versions are bumped pre-release, no post-publish sync needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)