### PR TITLE
fix: rename plugin to lcm — prevent cache recursion (0.3.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,13 +7,13 @@
   },
   "plugins": [
     {
-      "name": "lossless-claude",
+      "name": "lcm",
       "source": {
         "source": "github",
         "repo": "lossless-claude/lcm"
       },
       "description": "Lossless context management — DAG-based summarization that preserves every message",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
-  "name": "lossless-claude",
-  "version": "0.3.0",
+  "name": "lcm",
+  "version": "0.3.1",
   "description": "Lossless context management — DAG-based summarization that preserves every message",
   "author": {
     "name": "Pedro Almeida",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@lossless-claude/lcm",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@lossless-claude/lcm",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.12.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lossless-claude/lcm",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Never lose context again. lossless-claude compresses Claude Code sessions into searchable memory — every message preserved, every insight remembered.",
   "type": "module",
   "main": "dist/src/memory/index.js",


### PR DESCRIPTION
## Summary

- Renamed plugin from `lossless-claude` to `lcm` in `plugin.json` and `marketplace.json`
- Bumped version to 0.3.1

## Root cause

Claude Code's plugin cache structure is `cache/<marketplace>/<plugin>/<version>/`. When both marketplace and plugin are named `lossless-claude`, the install path `cache/lossless-claude/lossless-claude/0.3.0/` is created *inside* the git clone at `cache/lossless-claude/`. This copies the clone into itself, creating infinite recursive nesting until `ENAMETOOLONG`.

The MCP server never registers because the plugin fails to load.

## Fix

Rename plugin to `lcm` → cache path becomes `cache/lossless-claude/lcm/0.3.1/` — no collision.

## Test plan

- [ ] Install plugin from marketplace after merge
- [ ] Verify no recursive directories in `~/.claude/plugins/cache/lossless-claude/`
- [ ] Verify MCP server appears in `/mcp`
- [ ] Verify `/lcm-doctor` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)