### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -13,7 +13,7 @@
         "repo": "lossless-claude/lcm"
       },
       "description": "Lossless context management — DAG-based summarization that preserves every message",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lcm",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Lossless context management — DAG-based summarization that preserves every message",
   "author": {
     "name": "Pedro Almeida",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lossless-claude/lcm",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Never lose context again. lossless-claude compresses Claude Code sessions into searchable memory — every message preserved, every insight remembered.",
   "type": "module",
   "main": "dist/src/memory/index.js",


### PR DESCRIPTION
## Summary
- Bump version to 0.3.2 in `package.json`, `plugin.json`, and `marketplace.json`

## Included in this release
- `fix: self-bootstrap plugin on fresh install` — `mcp.mjs` and new `lcm.mjs` launcher auto-run `npm install` + `npm run build` if `dist/` is absent, so the plugin works on machines without a global `lcm` binary
- Plugin hooks and MCP server now reference `${CLAUDE_PLUGIN_ROOT}` instead of bare `lcm` binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)