### PR TITLE
fix: use regular merge in pre-release sync (not --ff-only)

### DIFF
--- a/.claude/skills/lcm-release/scripts/release.sh
+++ b/.claude/skills/lcm-release/scripts/release.sh
@@ -133,8 +133,8 @@ if run_step 0; then
     fi
 
     git checkout -b "$PRE_BRANCH"
-    git merge origin/main --no-edit --ff-only 2>/dev/null || \
-      err "develop has diverged from main and cannot be fast-forwarded. Resolve manually."
+    git merge origin/main --no-edit 2>/dev/null || \
+      err "develop has conflicts with main. Resolve conflicts manually, then rerun."
 
     git push -u origin "$PRE_BRANCH"
     PRE_PR=$(gh pr create \


### PR DESCRIPTION
## Summary

- The pre-release sync (Step 0) used `--ff-only` when merging `origin/main` into the sync branch
- This fails when `develop` has commits ahead of `main` (e.g., after feature PRs are merged but main hasn't been synced back yet)
- Changed to a regular `git merge origin/main --no-edit` so the sync works regardless of branch divergence

## Test plan
- [ ] Run `release.sh 0.4.2` — Step 0 pre-release sync should complete without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)