### PR TITLE
feat: automated post-release sync-develop workflow

### DIFF
--- a/.github/workflows/sync-develop.yml
+++ b/.github/workflows/sync-develop.yml
@@ -57,6 +57,9 @@ jobs:
           # Always create/reset local branch to current main HEAD so the
           # sync branch is up to date even if a prior run left it on remote.
           git fetch origin main
+          # Fetch the sync branch if it exists so --force-with-lease has a
+          # local tracking ref and can verify nothing unexpected was pushed.
+          git fetch origin "$BRANCH" || true
           git checkout -B "$BRANCH" origin/main
           git push origin "$BRANCH" --force-with-lease
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sync-develop.yml` as a safety net for the post-release develop sync
- Triggers on push to main that touches `package.json` **and** whose merge commit message contains `release/v` (i.e. a merge from a `release/vX.Y.Z` branch — non-release package.json changes won't match)
- Checks if develop already contains the commit (Step 9 of `release.sh` may have already synced it) — skips if so
- Opens and merges a sync PR only when needed; uses `--auto` to handle required CI checks on develop

## Why

If `release.sh` is interrupted after Step 7 (merge to main) but before Step 9 (develop sync), develop silently diverges. This workflow catches that case automatically without any manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)