### PR TITLE
fix: ignore untracked files in release script dirty check

### DIFF
--- a/.agents/skills/lcm-release/scripts/release.sh
+++ b/.agents/skills/lcm-release/scripts/release.sh
@@ -112,7 +112,7 @@ fi
 if run_step 0; then
   step "Step 0 — Clean state"
 
-  [[ -n "$(git status --porcelain)" ]] && \
+  [[ -n "$(git status --porcelain | grep -v '^??')" ]] && \
     err "Working tree is dirty. Commit or stash changes first."
   ok "Working tree is clean."
 


### PR DESCRIPTION
Release script was treating untracked files as dirty, blocking release on repos with local-only artifacts.