### PR TITLE
docs: add binary fallback for plugin-only installs

### DIFF
--- a/.claude-plugin/commands/lcm-compact.md
+++ b/.claude-plugin/commands/lcm-compact.md
@@ -13,7 +13,7 @@ Compact unprocessed conversation messages into summarized DAG nodes.
 If `lcm` is not on PATH, use the plugin's bundled binary instead:
 
 ```bash
-node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs
+node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs
 ```
 
 Replace `lcm` with the command above in all instructions below.

--- a/.claude-plugin/commands/lcm-curate.md
+++ b/.claude-plugin/commands/lcm-curate.md
@@ -13,7 +13,7 @@ Run the full memory curation pipeline: import, compact, and promote.
 If `lcm` is not on PATH, use the plugin's bundled binary instead:
 
 ```bash
-node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs
+node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs
 ```
 
 Replace `lcm` with the command above in all instructions below.

--- a/.claude-plugin/commands/lcm-diagnose.md
+++ b/.claude-plugin/commands/lcm-diagnose.md
@@ -13,7 +13,7 @@ Inspect recent Claude Code transcripts for historical lcm issues.
 If `lcm` is not on PATH, use the plugin's bundled binary instead:
 
 ```bash
-node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs
+node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs
 ```
 
 Replace `lcm` with the command above in all instructions below.

--- a/.claude-plugin/commands/lcm-doctor.md
+++ b/.claude-plugin/commands/lcm-doctor.md
@@ -20,4 +20,4 @@ End with one of:
 - *All checks passed — lossless-claude is healthy.*
 - *N check(s) need attention — see Fix section above.*
 
-If `lcm_doctor` is unavailable, run `lcm doctor` via Bash and display the output verbatim. If `lcm` is not on PATH, use `node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs doctor` instead.
+If `lcm_doctor` is unavailable, run `lcm doctor` via Bash and display the output verbatim. If `lcm` is not on PATH, first try to install it by running `node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs install`, then retry `lcm doctor`. If `lcm` is still unavailable, run `node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs doctor` instead.

--- a/.claude-plugin/commands/lcm-import.md
+++ b/.claude-plugin/commands/lcm-import.md
@@ -13,7 +13,7 @@ Import Claude Code session transcripts into lcm memory.
 If `lcm` is not on PATH, use the plugin's bundled binary instead:
 
 ```bash
-node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs
+node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs
 ```
 
 Replace `lcm` with the command above in all instructions below.

--- a/.claude-plugin/commands/lcm-promote.md
+++ b/.claude-plugin/commands/lcm-promote.md
@@ -13,7 +13,7 @@ Promote durable insights from summaries into cross-session memory.
 If `lcm` is not on PATH, use the plugin's bundled binary instead:
 
 ```bash
-node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs
+node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs
 ```
 
 Replace `lcm` with the command above in all instructions below.

--- a/.claude-plugin/commands/lcm-sensitive.md
+++ b/.claude-plugin/commands/lcm-sensitive.md
@@ -24,7 +24,7 @@ Manage the sensitive patterns used by lossless-claude to redact secrets before s
 If `lcm` is not on PATH, use the plugin's bundled binary instead:
 
 ```bash
-node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs
+node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs
 ```
 
 Replace `lcm` with the command above in all instructions below.

--- a/.claude-plugin/commands/lcm-stats.md
+++ b/.claude-plugin/commands/lcm-stats.md
@@ -14,6 +14,6 @@ When invoked, call the `lcm_stats` MCP tool with `{"verbose": true}`.
 
 The tool returns pre-formatted markdown with Memory and Compression tables. Display the output verbatim — it is already formatted correctly.
 
-If `lcm_stats` is unavailable, run `lcm stats -v` via Bash and display the output verbatim. If `lcm` is not on PATH, use `node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs stats -v` instead.
+If `lcm_stats` is unavailable, run `lcm stats -v` via Bash and display the output verbatim. If `lcm` is not on PATH, use `node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs stats -v` instead.
 
 Do not add commentary — just the stats output.

--- a/.claude-plugin/commands/lcm-status.md
+++ b/.claude-plugin/commands/lcm-status.md
@@ -13,7 +13,7 @@ Show daemon state and project memory statistics.
 If `lcm` is not on PATH, use the plugin's bundled binary instead:
 
 ```bash
-node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs
+node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs
 ```
 
 Replace `lcm` with the command above in all instructions below.

--- a/.claude-plugin/skills/lcm-context/SKILL.md
+++ b/.claude-plugin/skills/lcm-context/SKILL.md
@@ -77,7 +77,13 @@ These three tools **chain** from broad to deep:
 
 ## Binary Resolution
 
-If any Bash command below uses `lcm` and it is not on PATH, use the plugin's bundled binary instead: `node ~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs`
+If `lcm` is not on PATH, first try to install it by running:
+
+```bash
+node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs install
+```
+
+If install succeeds, `lcm` should now be available on PATH. If it is still not available, use the bundled binary directly: `node ~/.claude/plugins/cache/*/lossless-claude/*/lcm.mjs`
 
 ## Error Self-Healing
 


### PR DESCRIPTION
## Summary

When lcm is installed only as a Claude Code plugin (without `npm install -g`), the `lcm` binary isn't on PATH. All command/skill files that tell agents to run `lcm <subcommand>` via Bash fail with "command not found".

This PR adds a **Binary Resolution** fallback to all affected files, instructing agents to use the plugin's bundled binary at `~/.claude/plugins/cache/lossless-claude/lcm/*/lcm.mjs` when `lcm` is not available globally.

### Changes

- **7 command files** (import, compact, status, curate, promote, diagnose, sensitive): added "Binary Resolution" section before Instructions
- **2 command files** (doctor, stats): added inline fallback to their existing CLI fallback paths
- **1 skill file** (lcm-context): added fallback note before the error recovery table

## Test plan

- [ ] Install lcm as plugin only (no global npm install)
- [ ] Run `/lcm-import --dry-run` — agent should resolve the binary and succeed
- [ ] Run `/lcm-doctor` — should use MCP tool, fallback to bundled binary if needed