### PR TITLE
fix: rewrite setup.sh for current SQLite-only architecture

### DIFF
--- a/installer/setup.sh
+++ b/installer/setup.sh
@@ -140,9 +140,9 @@ fi
 
 # ── Write config.json ──
 # Uses node for proper JSON encoding.
-# Merges into any existing config file: replaces only the "llm" block in-place
-# if it already exists (preserving key order/formatting), otherwise appends it
-# or creates a new file. Existing non-llm keys are always preserved.
+# Merges into any existing config file: parses the JSON, updates the "llm"
+# block, and rewrites the whole file (reformats + normalises key order).
+# Existing non-llm keys are always preserved.
 
 mkdir -p "$CONFIG_DIR"
 


### PR DESCRIPTION
## Summary

- **Removed** all references to infrastructure that no longer exists: \`vllm-mlx\`, \`Ollama\`, \`Qdrant\`, embedding models (ModernBERT / MiniLM), \`claude-server\` / \`claude-max-api-proxy\` npm packages, \`~/.cipher/cipher.yml\`, and \`EMBEDDING_PORT\`.
- **Replaced** the two-stage backend+summarizer+embedding menu with a single, focused LLM provider selection (6 options: \`auto\`, \`claude-process\`, \`codex-process\`, \`anthropic\`, \`openai\`, \`disabled\`).
- **Writes** \`~/.lossless-claude/config.json\` with the \`llm\` config block; for \`anthropic\`/\`openai\` providers, the key is read from the environment (\`ANTHROPIC_API_KEY\` / \`OPENAI_API_KEY\`) and stored as an env-var placeholder (\`\${VAR}\`) that \`config.ts\` expands at runtime — no plaintext secrets on disk.
- **Exits early** with a clear error if a required API key env var is not set, rather than writing a placeholder that would fail at runtime.
- **Runs** \`lcm install\` (hook installation) and \`lcm doctor\` (verification) at the end.
- Non-TTY / CI mode skips interactive prompts and falls through with \`provider=auto\` default. \`lcm install\` and \`lcm doctor\` still run (and produce their own output) in non-TTY mode.
- Supports \`XGH_DRY_RUN=1\` used by \`installer/dry-run-deps.ts\`.
- Config merge uses \`JSON.parse\` + \`JSON.stringify\` — the whole file is rewritten (normalised formatting/key order); existing non-\`llm\` keys are always preserved.

## Test plan

- [ ] Run \`bash installer/setup.sh\` interactively and step through each of the 6 provider options
- [ ] Verify \`~/.lossless-claude/config.json\` is created with the correct \`llm\` block
- [ ] Confirm \`anthropic\` option exits with error when \`ANTHROPIC_API_KEY\` is not set
- [ ] Confirm \`anthropic\` option succeeds and writes \`\${ANTHROPIC_API_KEY}\` placeholder when env var is set
- [ ] Confirm \`openai\` option proceeds without key for custom baseURL (local server path)
- [ ] Confirm \`openai\` option exits with error when public \`https://api.openai.com/v1\` is used without key
- [ ] Confirm \`openai\` option prompts for model ID and baseURL with sensible defaults
- [ ] Pipe \`echo 1 | bash installer/setup.sh\` and confirm non-TTY path skips interactive prompts
- [ ] Run \`XGH_DRY_RUN=1 bash installer/setup.sh\` and confirm dry-run prints preview and exits 0 without writing config
- [ ] Confirm \`lcm install\` and \`lcm doctor\` are called at the end of a normal interactive run
- [ ] Confirm that existing non-\`llm\` keys in \`config.json\` are preserved after re-running setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)