### PR TITLE
fix: include response body in batch-compact HTTP error messages

### DIFF
--- a/src/batch-compact.ts
+++ b/src/batch-compact.ts
@@ -119,7 +119,8 @@ export async function batchCompact(opts: {
       });
 
       if (!res.ok) {
-        console.log(` FAILED (HTTP ${res.status})`);
+        const body = await res.text().catch(() => "");
+        console.log(` FAILED (HTTP ${res.status}${body ? `: ${body}` : ""})`);
       } else {
         const data = await res.json() as { summary?: string; skipped?: boolean };
         if (data.skipped) {


### PR DESCRIPTION
## Summary

- When batch compaction hits an HTTP error, the error message previously only showed the status code (e.g. `FAILED (HTTP 500)`)
- Now reads the response body and includes it: `FAILED (HTTP 500: <body text>)`
- Body read is wrapped in `.catch(() => "")` so a secondary failure reading the body doesn't mask the original error

## Test plan

- [ ] Trigger a batch compact against a daemon returning a 500 error and verify the response body appears in the output
- [ ] Verify normal success path (`done` / `skipped`) is unaffected
- [ ] Verify that if `res.text()` itself throws, the error still reports cleanly with just the status code

## File changed

`src/batch-compact.ts` — lines 121-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)