### PR TITLE
feat: auto-promote after compact

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -94,9 +94,52 @@ async function main() {
         }
         const dryRun = argv.includes("--dry-run");
         const replay = argv.includes("--replay");
+        const noPromote = argv.includes("--no-promote");
         const minTokens = config.compaction.autoCompactMinTokens;
         const cwd = all ? undefined : process.cwd();
-        await batchCompact({ minTokens, dryRun, port, cwd, replay });
+        const { compacted } = await batchCompact({ minTokens, dryRun, port, cwd, replay });
+
+        // Auto-promote after a successful compact: new summaries are prime promotion candidates.
+        if (compacted > 0 && !noPromote) {
+          const { readdirSync, existsSync, readFileSync } = await import("node:fs");
+          const promoteCwds: string[] = [];
+          if (cwd) {
+            promoteCwds.push(cwd);
+          } else {
+            const projectsDir = join(homedir(), ".lossless-claude", "projects");
+            if (existsSync(projectsDir)) {
+              for (const entry of readdirSync(projectsDir, { withFileTypes: true })) {
+                if (!entry.isDirectory()) continue;
+                const metaPath = join(projectsDir, entry.name, "meta.json");
+                if (!existsSync(metaPath)) continue;
+                try {
+                  const meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+                  if (meta.cwd) promoteCwds.push(meta.cwd);
+                } catch { /* skip unreadable */ }
+              }
+            }
+          }
+
+          let totalPromoted = 0;
+          for (const promoteCwd of promoteCwds) {
+            try {
+              const res = await fetch(`http://127.0.0.1:${port}/promote`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ cwd: promoteCwd, dry_run: dryRun }),
+              });
+              if (res.ok) {
+                const result = await res.json() as { processed: number; promoted: number };
+                totalPromoted += result.promoted;
+              }
+            } catch { /* non-fatal: promote is best-effort */ }
+          }
+
+          if (totalPromoted > 0) {
+            console.log(`  → ${totalPromoted} insight${totalPromoted !== 1 ? "s" : ""} promoted`);
+          }
+        }
+
         break;
       }
     }
@@ -494,7 +537,11 @@ async function main() {
         }
       }
 
-      console.log(`  ${totalPromoted} insight${totalPromoted !== 1 ? "s" : ""} promoted to long-term memory`);
+      if (totalPromoted === 0) {
+        console.log("  Nothing to promote — no new insights found.");
+      } else {
+        console.log(`  ${totalPromoted} insight${totalPromoted !== 1 ? "s" : ""} promoted to long-term memory`);
+      }
       if (verbose) console.log(`  (${totalProcessed} summaries scanned across ${cwds.length} project${cwds.length !== 1 ? "s" : ""})`);
       if (dryRun) console.log("  [dry-run] No changes written.");
       console.log();

--- a/src/batch-compact.ts
+++ b/src/batch-compact.ts
@@ -86,16 +86,18 @@ export async function batchCompact(opts: {
   port: number;
   cwd?: string;
   replay?: boolean;
-}): Promise<void> {
+}): Promise<{ compacted: number }> {
   const conversations = findUncompacted(opts.minTokens, opts.dryRun, opts.cwd, opts.replay);
 
   if (conversations.length === 0) {
-    console.log("No uncompacted conversations above threshold.");
-    return;
+    console.log("Nothing to compact — all sessions are up to date.");
+    return { compacted: 0 };
   }
 
   const totalTokens = conversations.reduce((s, c) => s + c.tokens, 0);
   console.log(`Found ${conversations.length} uncompacted conversation${conversations.length > 1 ? "s" : ""} (${(totalTokens / 1000).toFixed(1)}k tokens)\n`);
+
+  let compacted = 0;
 
   for (const conv of conversations) {
     const label = `${conv.cwd} conv #${conv.conversationId} (${conv.messages} msgs, ${(conv.tokens / 1000).toFixed(1)}k tokens)`;
@@ -127,6 +129,7 @@ export async function batchCompact(opts: {
           console.log(" skipped (already in progress)");
         } else {
           console.log(" done");
+          compacted++;
         }
       }
     } catch (err) {
@@ -137,4 +140,6 @@ export async function batchCompact(opts: {
   if (!opts.dryRun) {
     console.log("\nBatch compact complete.");
   }
+
+  return { compacted };
 }

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -78,19 +78,21 @@ const HELP: Record<string, CommandHelp> = {
 
   compact: {
     summary: "Compact conversation context into DAG summary nodes.",
-    usage: "lcm compact [--all] [--dry-run] [--replay]",
+    usage: "lcm compact [--all] [--dry-run] [--replay] [--no-promote]",
     options: [
       ["--all", "Compact all tracked projects (default: current project only)"],
       ["--dry-run", "Show what would be compacted without writing anything"],
       ["--replay", "Compact sequentially, threading each summary through the prior context"],
+      ["--no-promote", "Skip the automatic promote step that runs after compaction"],
     ],
     examples: [
       ["lcm compact", "Compact current project"],
       ["lcm compact --all", "Compact all tracked projects"],
       ["lcm compact --dry-run", "Preview compaction for current project"],
       ["lcm compact --all --replay", "Rebuild all projects with threaded context (slow)"],
+      ["lcm compact --no-promote", "Compact without auto-promoting new insights"],
     ],
-    notes: "When invoked via the PreCompact hook (piped stdin), runs automatically during Claude Code context compaction.",
+    notes: "When invoked via the PreCompact hook (piped stdin), runs automatically during Claude Code context compaction. After a successful compact, promote runs automatically to surface new insights to long-term memory.",
   },
 
   import: {
@@ -256,7 +258,7 @@ const GROUPS = [
   {
     label: "Memory",
     commands: [
-      { name: "compact [--all] [--dry-run] [--replay]", summary: "Compact conversations into DAG summaries" },
+      { name: "compact [--all] [--dry-run] [--replay] [--no-promote]", summary: "Compact conversations into DAG summaries (auto-promotes after)" },
       { name: "import [--all] [--verbose] [--dry-run] [--replay]", summary: "Import Claude Code session transcripts" },
       { name: "promote [--all] [--verbose] [--dry-run]", summary: "Promote insights to long-term memory" },
       { name: "stats [-v]", summary: "Memory inventory and compression ratios" },


### PR DESCRIPTION
## Summary

- After `lcm compact` successfully compacts at least one conversation, automatically runs `promote` against the same scope so freshly created summaries are immediately surfaced to long-term memory
- `batchCompact` now returns `{ compacted: number }` so the caller knows whether real work was done (not dry-run, not skipped)
- Auto-promote is gated: only fires if `compacted > 0`; skippable with `--no-promote`
- Output is minimal — prints `  → N insights promoted` only when N > 0; silent otherwise

## Changes

- `src/batch-compact.ts`: return `{ compacted: number }` instead of `void`; increment counter on each successful (non-skipped) compaction
- `bin/lcm.ts`: parse `--no-promote` flag; run auto-promote loop after `batchCompact` when appropriate; reuse existing `port`, `join`, `homedir` from same scope
- `src/cli-help.ts`: document `--no-promote` in compact command help and main command listing

## Test plan

- [ ] `lcm compact` with compactable sessions: verify `  → N insights promoted` appears after "Batch compact complete."
- [ ] `lcm compact` with nothing to compact: verify no promote output
- [ ] `lcm compact --no-promote`: verify promote step is skipped entirely
- [ ] `lcm compact --dry-run`: verify no real changes and no promote output (compacted stays 0)
- [ ] `lcm compact --all`: verify promote runs for each project cwd
- [ ] `lcm compact --help`: verify `--no-promote` appears in options

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)