### PR TITLE
fix: discover flat and nested transcript layouts in lcm import

### DIFF
--- a/src/import.ts
+++ b/src/import.ts
@@ -54,20 +54,45 @@ export function findSessionFiles(projectDir: string): { path: string; sessionId:
   const files: { path: string; sessionId: string; mtime: number }[] = [];
   if (!existsSync(projectDir)) return files;
 
+  // Track which session IDs have a flat (project-root) transcript so we can
+  // deduplicate when the same session also has a nested copy.
+  const flatSessionIds = new Set<string>();
+
   for (const entry of readdirSync(projectDir, { withFileTypes: true })) {
+    // Layout B (flat): <projectDir>/<session-id>.jsonl
     if (entry.isFile() && entry.name.endsWith('.jsonl')) {
       try {
+        const sessionId = basename(entry.name, '.jsonl');
         files.push({
           path: join(projectDir, entry.name),
-          sessionId: basename(entry.name, '.jsonl'),
+          sessionId,
           mtime: statSync(join(projectDir, entry.name)).mtimeMs,
         });
+        flatSessionIds.add(sessionId);
       } catch {
         // Skip entries that can't be stat'd (file deleted or permissions issue)
         continue;
       }
     }
     if (entry.isDirectory()) {
+      // Layout A (nested): <projectDir>/<session-id>/<session-id>.jsonl
+      const nestedTranscript = join(projectDir, entry.name, `${entry.name}.jsonl`);
+      if (existsSync(nestedTranscript)) {
+        try {
+          const nestedStat = statSync(nestedTranscript);
+          if (nestedStat.isFile()) {
+            files.push({
+              path: nestedTranscript,
+              sessionId: entry.name,
+              mtime: nestedStat.mtimeMs,
+            });
+          }
+        } catch {
+          // Skip entries that can't be stat'd
+        }
+      }
+
+      // Subagent transcripts: <projectDir>/<session-id>/subagents/<agent-id>.jsonl
       const subagentsDir = join(projectDir, entry.name, 'subagents');
       if (existsSync(subagentsDir)) {
         for (const sub of readdirSync(subagentsDir, { withFileTypes: true })) {
@@ -87,7 +112,18 @@ export function findSessionFiles(projectDir: string): { path: string; sessionId:
       }
     }
   }
-  return files.sort((a, b) => {
+
+  // Deduplicate: when a session has both a flat and nested transcript,
+  // keep only the flat file (the canonical source in newer Claude Code versions).
+  // Subagent files (inside subagents/) are kept unconditionally because their
+  // paths never match the nested transcript pattern below.
+  const nestedSuffix = (sid: string) => join(sid, `${sid}.jsonl`);
+  const deduped = files.filter(f => {
+    const isNested = f.path.endsWith(nestedSuffix(f.sessionId));
+    return !isNested || !flatSessionIds.has(f.sessionId);
+  });
+
+  return deduped.sort((a, b) => {
     const mtimeDiff = a.mtime - b.mtime;
     if (mtimeDiff !== 0) return mtimeDiff;
     const sessionIdDiff = a.sessionId.localeCompare(b.sessionId);

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -86,14 +86,67 @@ describe("findSessionFiles", () => {
     expect(sessionIds).toEqual(["child-session", "main-session"]);
   });
 
-  it("ignores directories without a subagents subfolder", () => {
+  it("ignores directories without a subagents subfolder or matching nested transcript", () => {
     const dir = makeTmpDir();
     const subDir = join(dir, "some-dir");
     mkdirSync(subDir, { recursive: true });
-    writeFileSync(join(subDir, "file.jsonl"), ""); // not in subagents/
+    writeFileSync(join(subDir, "file.jsonl"), ""); // not in subagents/ and name doesn't match dir
 
     const result = findSessionFiles(dir);
     expect(result).toEqual([]);
+  });
+
+  it("discovers nested session transcripts (Layout A: <session-id>/<session-id>.jsonl)", () => {
+    const dir = makeTmpDir();
+    const sessionDir = join(dir, "session-abc");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, "session-abc.jsonl"), "");
+
+    const result = findSessionFiles(dir);
+    expect(result).toHaveLength(1);
+    expect(result[0].sessionId).toBe("session-abc");
+    expect(result[0].path).toBe(join(sessionDir, "session-abc.jsonl"));
+  });
+
+  it("ignores nested transcript paths that are not regular files", () => {
+    const dir = makeTmpDir();
+    const sessionDir = join(dir, "session-abc");
+    const nestedPath = join(sessionDir, "session-abc.jsonl");
+    mkdirSync(nestedPath, { recursive: true });
+
+    const result = findSessionFiles(dir);
+    expect(result).toEqual([]);
+  });
+
+  it("discovers nested transcripts alongside subagent files", () => {
+    const dir = makeTmpDir();
+    // Layout A: nested main transcript + subagent
+    const sessionDir = join(dir, "session-parent");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, "session-parent.jsonl"), "");
+    const subagentsDir = join(sessionDir, "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-1.jsonl"), "");
+
+    const result = findSessionFiles(dir);
+    const sessionIds = result.map((f) => f.sessionId).sort();
+    expect(sessionIds).toEqual(["agent-1", "session-parent"]);
+  });
+
+  it("deduplicates when both flat and nested transcripts exist for the same session", () => {
+    const dir = makeTmpDir();
+    // Flat transcript at project root
+    writeFileSync(join(dir, "session-abc.jsonl"), "flat");
+    // Nested transcript inside session directory
+    const sessionDir = join(dir, "session-abc");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, "session-abc.jsonl"), "nested");
+
+    const result = findSessionFiles(dir);
+    // Should only return one entry, the flat file (preferred)
+    const matches = result.filter((f) => f.sessionId === "session-abc");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].path).toBe(join(dir, "session-abc.jsonl"));
   });
 
   it("returns files sorted by mtime ascending", () => {


### PR DESCRIPTION
## Summary

- Adds support for **Layout A (nested)** transcript discovery: `<session-id>/<session-id>.jsonl` inside the session subdirectory — the layout used by standard Claude Code installs
- Layout B (flat) `<session-id>.jsonl` at the project root was already discovered; this PR completes dual-layout support
- Deduplicates when both layouts coexist for the same session — flat file preferred as the canonical source in newer Claude Code versions

Fixes #56.

## Changes

- `src/import.ts` — `findSessionFiles` now tracks `flatSessionIds`, checks `<session-id>/<session-id>.jsonl` for Layout A, and filters out nested duplicates when a flat copy exists
- `test/import.test.ts` — 4 new cases: Layout A discovery, non-file nested path guard, nested + subagent together, flat/nested deduplication

## Test plan

- [x] All 495 existing tests pass
- [x] New test: discovers `<session-id>/<session-id>.jsonl` (Layout A)
- [x] New test: ignores nested path when it is a directory, not a file
- [x] New test: discovers nested transcript alongside subagent files
- [x] New test: deduplicates — returns only the flat file when both exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)