### PR TITLE
fix: make duplicate-hook hint actionable with event name and file path

### DIFF
--- a/src/diagnose.ts
+++ b/src/diagnose.ts
@@ -534,6 +534,26 @@ export function formatDiagnoseResult(
     lines.push("");
     lines.push(`  Most common: ${result.mostCommon.type} (${result.mostCommon.count}x)`);
   }
-  lines.push("  Suggestion: Run `lcm doctor` to check current health");
+
+  // Collect unique duplicate-hook events across all sessions for a specific hint
+  const duplicateHookEvents = Array.from(
+    new Set(
+      result.sessions.flatMap((s) =>
+        s.errors
+          .filter((e) => e.type === "duplicate-hook" && e.hookEvent)
+          .map((e) => e.hookEvent as string)
+      )
+    )
+  );
+
+  lines.push("");
+  if (duplicateHookEvents.length > 0) {
+    const settingsPath = `~/.claude/settings.json`;
+    const eventList = duplicateHookEvents.map((e) => `\`${e}\``).join(", ");
+    lines.push(`  Fix: Remove the duplicate ${eventList} hook ${duplicateHookEvents.length === 1 ? "entry" : "entries"} from \`${settingsPath}\``);
+    lines.push(`       (hooks are owned by the plugin — run \`lcm install\` to clean up automatically)`);
+  } else {
+    lines.push("  Suggestion: Run `lcm doctor` to check current health");
+  }
   return lines.join("\n") + "\n";
 }

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -214,7 +214,7 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>): Promise<CheckR
         name: "hooks",
         category: "Settings",
         status: "warn",
-        message: `Duplicate hooks in settings.json: ${duplicateHooks.join(", ")} — run: lcm install`,
+        message: `Duplicate ${duplicateHooks.join(", ")} hook ${duplicateHooks.length === 1 ? "entry" : "entries"} in ${settingsPath} — remove the \`hooks.${duplicateHooks[0]}\` block(s) from that file, then run: lcm install`,
       });
     }
   } else {


### PR DESCRIPTION
## Summary

- `lcm diagnose`: when duplicate hooks are detected, replaces the generic `"Run lcm doctor"` suggestion with a specific fix message naming the exact hook event(s) (e.g. `PreToolUse`) and pointing to `~/.claude/settings.json`, with `lcm install` as the one-command auto-fix.
- `lcm doctor`: when auto-fix fails, the fallback warning now includes the full settings file path and the specific `hooks.<Event>` block(s) to remove, rather than just listing event names.

## Test plan

- [ ] Run `lcm diagnose` in a project with a session that has duplicate `PreToolUse` or `UserPromptSubmit` hook fires — confirm output shows e.g. `Fix: Remove the duplicate \`PreToolUse\` hook entry from \`~/.claude/settings.json\``
- [ ] Manually introduce duplicate hooks in `~/.claude/settings.json` (both `plugin.json` and `settings.json` entries), then run `lcm doctor` with write permissions blocked — confirm the warning names the file and block to remove
- [ ] All existing tests pass: `npm test -- test/diagnose.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)