### PR TITLE
feat: support importing Codex CLI session transcripts

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -449,6 +449,24 @@ async function main() {
       const { printImportSummary } = await import("../src/import-summary.js");
       const { join } = await import("node:path");
       const { homedir } = await import("node:os");
+      const importModule = await import("../src/import.js");
+
+      // --codex is a shorthand for --provider codex
+      let provider: import("../src/import.js").ImportProvider = "claude";
+      if (argv.includes("--codex")) {
+        provider = "codex";
+      } else {
+        const provIdx = argv.indexOf("--provider");
+        if (provIdx !== -1) {
+          const provVal = argv[provIdx + 1];
+          if (provVal === "claude" || provVal === "codex" || provVal === "all") {
+            provider = provVal;
+          } else {
+            console.error(`  Unknown provider "${provVal ?? ""}". Use: claude, codex, all`);
+            exit(1);
+          }
+        }
+      }
 
       const config = loadDaemonConfig(join(homedir(), ".lossless-claude", "config.json"));
       const port = config.daemon?.port ?? 3737;
@@ -457,9 +475,13 @@ async function main() {
       if (!connected) { console.error("  Daemon not available"); exit(1); }
 
       const client = new DaemonClient(`http://127.0.0.1:${port}`);
-      console.log(`\n  Importing Claude Code sessions${all ? " (all projects)" : ""}...\n`);
+      const providerLabel =
+        provider === "codex" ? "Codex CLI" :
+        provider === "all"   ? "Claude Code + Codex CLI" :
+                               "Claude Code";
+      console.log(`\n  Importing ${providerLabel} sessions${all ? " (all projects)" : ""}...\n`);
 
-      const result = await importSessions(client, { all, verbose, dryRun, replay });
+      const result = await importModule.importSessions(client, { all, verbose, dryRun, replay, provider });
 
       if (dryRun) console.log("  [dry-run] No changes written.\n");
       printImportSummary(result, { replay });

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -96,21 +96,25 @@ const HELP: Record<string, CommandHelp> = {
   },
 
   import: {
-    summary: "Import Claude Code session transcripts into lossless memory.",
-    usage: "lcm import [--all] [--verbose] [--dry-run] [--replay]",
+    summary: "Import session transcripts (Claude Code or Codex CLI) into lossless memory.",
+    usage: "lcm import [--provider claude|codex|all] [--all] [--verbose] [--dry-run] [--replay]",
     options: [
+      ["--provider <name>", "Source: claude (default), codex, or all"],
+      ["--codex", "Shorthand for --provider codex"],
       ["--all", "Import all projects (default: current project only)"],
       ["--verbose", "Show per-session import detail"],
       ["--dry-run", "Preview without importing"],
       ["--replay", "Replay compaction for each imported session"],
     ],
     examples: [
-      ["lcm import", "Import current project sessions"],
-      ["lcm import --all", "Import all tracked projects"],
+      ["lcm import", "Import current Claude Code project sessions"],
+      ["lcm import --codex", "Import Codex CLI sessions from ~/.codex/"],
+      ["lcm import --provider all", "Import both Claude Code and Codex sessions"],
+      ["lcm import --all", "Import all tracked Claude Code projects"],
       ["lcm import --all --replay", "Import and compact with threaded context"],
       ["lcm import --dry-run", "Preview what would be imported"],
     ],
-    notes: "Reads transcripts from ~/.claude/projects/. Already-imported sessions are skipped.",
+    notes: "Claude sessions are read from ~/.claude/projects/. Codex sessions from ~/.codex/. Already-imported sessions are skipped.",
   },
 
   promote: {
@@ -259,7 +263,7 @@ const GROUPS = [
     label: "Memory",
     commands: [
       { name: "compact [--all] [--dry-run] [--replay] [--no-promote]", summary: "Compact conversations into DAG summaries (auto-promotes after)" },
-      { name: "import [--all] [--verbose] [--dry-run] [--replay]", summary: "Import Claude Code session transcripts" },
+      { name: "import [--provider claude|codex|all] [--all] [--verbose] [--dry-run] [--replay]", summary: "Import session transcripts (Claude Code or Codex CLI)" },
       { name: "promote [--all] [--verbose] [--dry-run]", summary: "Promote insights to long-term memory" },
       { name: "stats [-v]", summary: "Memory inventory and compression ratios" },
       { name: "diagnose [--all] [--days N] [--verbose] [--json]", summary: "Scan sessions for hook failures and issues" },

--- a/src/codex-transcript.ts
+++ b/src/codex-transcript.ts
@@ -1,0 +1,244 @@
+/**
+ * Parser for Codex CLI session transcript files.
+ *
+ * Codex stores sessions in ~/.codex/sessions/<session-id>/<session-id>.jsonl
+ * and archives them in ~/.codex/archived_sessions/<name>.jsonl.
+ *
+ * Each JSONL line is an event object with a top-level `type` and `payload`:
+ *
+ *   { type: "session_meta", payload: { id, cwd, ... } }
+ *   { type: "response_item", payload: { type: "message", role: "user"|"assistant"|..., content: [...] } }
+ *   { type: "event_msg", payload: { ... } }
+ *   ...
+ *
+ * Content blocks for user messages use `type: "input_text"` and for assistant
+ * messages use `type: "output_text"` (both carry a `text` string field).
+ */
+
+import { readdirSync, readFileSync, existsSync, statSync } from "node:fs";
+import { join, basename } from "node:path";
+import { homedir } from "node:os";
+import { estimateTokens } from "./transcript.js";
+import type { ParsedMessage } from "./transcript.js";
+
+// ---------------------------------------------------------------------------
+// Types matching the Codex JSONL event format
+// ---------------------------------------------------------------------------
+
+interface CodexContentBlock {
+  type?: string;
+  text?: string;
+}
+
+interface CodexResponseItemPayload {
+  type?: string;
+  role?: string;
+  content?: string | CodexContentBlock[];
+}
+
+interface CodexSessionMetaPayload {
+  id?: string;
+  cwd?: string;
+}
+
+interface CodexLine {
+  type?: string;
+  timestamp?: string;
+  payload?: CodexResponseItemPayload | CodexSessionMetaPayload | Record<string, unknown>;
+}
+
+// ---------------------------------------------------------------------------
+// Text extraction
+// ---------------------------------------------------------------------------
+
+function extractCodexText(content: string | CodexContentBlock[] | undefined): string {
+  if (typeof content === "string") return content.trim();
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((b) => {
+      // Codex uses input_text (user) and output_text (assistant)
+      if ((b.type === "input_text" || b.type === "output_text") && typeof b.text === "string") {
+        return b.text;
+      }
+      // Plain text fallback
+      if (b.type === "text" && typeof b.text === "string") {
+        return b.text;
+      }
+      return "";
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
+// ---------------------------------------------------------------------------
+// Exported parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Codex JSONL transcript file into the standard ParsedMessage format.
+ * Returns an empty array on any read or parse error.
+ */
+export function parseCodexTranscript(transcriptPath: string): ParsedMessage[] {
+  let raw: string;
+  try {
+    raw = readFileSync(transcriptPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const messages: ParsedMessage[] = [];
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let obj: CodexLine;
+    try {
+      obj = JSON.parse(trimmed) as CodexLine;
+    } catch {
+      continue;
+    }
+
+    // Only response_item lines carry user/assistant messages
+    if (obj.type !== "response_item") continue;
+
+    const payload = obj.payload as CodexResponseItemPayload | undefined;
+    if (!payload || payload.type !== "message") continue;
+
+    const role = payload.role;
+    if (!role || !["user", "assistant"].includes(role)) continue;
+
+    const content = extractCodexText(payload.content);
+    if (!content.trim()) continue;
+
+    messages.push({ role, content, tokenCount: estimateTokens(content) });
+  }
+
+  return messages;
+}
+
+/**
+ * Extract the working directory from a Codex session JSONL file.
+ * Returns undefined if the session_meta line cannot be found/parsed.
+ */
+export function extractCodexSessionCwd(transcriptPath: string): string | undefined {
+  let raw: string;
+  try {
+    raw = readFileSync(transcriptPath, "utf-8");
+  } catch {
+    return undefined;
+  }
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const obj = JSON.parse(trimmed) as CodexLine;
+      if (obj.type === "session_meta") {
+        const meta = obj.payload as CodexSessionMetaPayload | undefined;
+        if (typeof meta?.cwd === "string" && meta.cwd) return meta.cwd;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Session discovery
+// ---------------------------------------------------------------------------
+
+export interface CodexSessionFile {
+  path: string;
+  sessionId: string;
+  mtime: number;
+}
+
+/**
+ * Discover Codex transcript files under a root directory.
+ *
+ * Supported layouts:
+ *   - Flat:  <root>/<name>.jsonl         (archived_sessions/)
+ *   - Nested: <root>/<id>/<id>.jsonl     (sessions/ layout)
+ */
+export function findCodexSessionFiles(rootDir: string): CodexSessionFile[] {
+  const files: CodexSessionFile[] = [];
+  if (!existsSync(rootDir)) return files;
+
+  for (const entry of readdirSync(rootDir, { withFileTypes: true })) {
+    // Flat layout: rootDir/<name>.jsonl
+    if (entry.isFile() && entry.name.endsWith(".jsonl")) {
+      try {
+        const full = join(rootDir, entry.name);
+        files.push({
+          path: full,
+          sessionId: basename(entry.name, ".jsonl"),
+          mtime: statSync(full).mtimeMs,
+        });
+      } catch {
+        // skip unreadable entries
+      }
+      continue;
+    }
+
+    // Nested layout: rootDir/<id>/<id>.jsonl
+    if (entry.isDirectory()) {
+      const nested = join(rootDir, entry.name, `${entry.name}.jsonl`);
+      if (existsSync(nested)) {
+        try {
+          const st = statSync(nested);
+          if (st.isFile()) {
+            files.push({
+              path: nested,
+              sessionId: entry.name,
+              mtime: st.mtimeMs,
+            });
+          }
+        } catch {
+          // skip
+        }
+      }
+    }
+  }
+
+  return files.sort((a, b) => {
+    const d = a.mtime - b.mtime;
+    if (d !== 0) return d;
+    return a.sessionId.localeCompare(b.sessionId);
+  });
+}
+
+/**
+ * Collect all Codex transcript files from a Codex home directory.
+ *
+ * Searches:
+ *   - <codexDir>/archived_sessions/*.jsonl  (flat layout)
+ *   - <codexDir>/sessions/<id>/<id>.jsonl   (nested layout)
+ *
+ * Defaults to ~/.codex when codexDir is omitted.
+ */
+export function findAllCodexTranscripts(codexDir?: string): CodexSessionFile[] {
+  const root = codexDir ?? join(homedir(), ".codex");
+  const results: CodexSessionFile[] = [];
+
+  // Archived sessions (flat)
+  results.push(...findCodexSessionFiles(join(root, "archived_sessions")));
+
+  // Active sessions (nested)
+  results.push(...findCodexSessionFiles(join(root, "sessions")));
+
+  // De-duplicate by sessionId (flat archive wins over sessions/)
+  const seen = new Map<string, CodexSessionFile>();
+  for (const f of results) {
+    if (!seen.has(f.sessionId)) seen.set(f.sessionId, f);
+  }
+
+  return [...seen.values()].sort((a, b) => {
+    const d = a.mtime - b.mtime;
+    if (d !== 0) return d;
+    return a.sessionId.localeCompare(b.sessionId);
+  });
+}

--- a/src/import.ts
+++ b/src/import.ts
@@ -3,6 +3,9 @@ import { join, basename } from "node:path";
 import { homedir } from "node:os";
 import type { DaemonClient } from "./daemon/client.js";
 import { formatNumber, formatRatio } from "./stats.js";
+import { findAllCodexTranscripts, extractCodexSessionCwd } from "./codex-transcript.js";
+
+export type ImportProvider = "claude" | "codex" | "all";
 
 interface ImportOptions {
   all?: boolean;
@@ -10,10 +13,14 @@ interface ImportOptions {
   dryRun?: boolean;
   cwd?: string;
   replay?: boolean;
+  /** Which transcript provider to import from (default: "claude") */
+  provider?: ImportProvider;
   /** Override ~/.claude/projects path — used in tests only */
   _claudeProjectsDir?: string;
   /** Override ~/.lossless-claude path — used in tests only */
   _lcmDir?: string;
+  /** Override ~/.codex path — used in tests only */
+  _codexDir?: string;
 }
 
 export interface ImportResult {
@@ -132,121 +139,168 @@ export function findSessionFiles(projectDir: string): { path: string; sessionId:
   });
 }
 
+// ---------------------------------------------------------------------------
+// Shared inner loop — ingests a flat list of { path, sessionId, cwd } entries
+// ---------------------------------------------------------------------------
+
+interface SessionEntry {
+  path: string;
+  sessionId: string;
+  cwd: string;
+}
+
+async function ingestSessionList(
+  client: DaemonClient,
+  sessions: SessionEntry[],
+  options: ImportOptions,
+  result: ImportResult,
+): Promise<void> {
+  let previousSummary: string | undefined;
+
+  for (const { path, sessionId, cwd } of sessions) {
+    if (options.dryRun) {
+      if (options.verbose) {
+        const replayNote = options.replay ? " (would compact)" : "";
+        console.log(`  [dry-run] ${sessionId}${replayNote}`);
+      }
+      result.imported++;
+      continue;
+    }
+
+    try {
+      const res = await client.post<{ ingested: number; totalTokens: number }>('/ingest', {
+        session_id: sessionId,
+        cwd,
+        transcript_path: path,
+      });
+      if (res.ingested === 0 && res.totalTokens === 0) {
+        result.skippedEmpty++;
+        if (options.verbose) console.log(`  \u23ed\ufe0f ${sessionId}: empty or already ingested`);
+      } else {
+        result.imported++;
+        result.totalMessages += res.ingested;
+        // In replay mode, totalTokens is sourced from compact's tokensBefore to avoid
+        // double-counting (compact covers already-ingested sessions too).
+        if (!options.replay) {
+          result.totalTokens += res.totalTokens;
+        }
+        if (options.verbose) console.log(`  \u2705 ${sessionId}: ${res.ingested} messages (${formatNumber(res.totalTokens)} tokens)`);
+      }
+
+      // Replay: compact immediately after every session (even already-ingested ones)
+      // so that re-runs are idempotent and the temporal chain stays intact.
+      if (options.replay) {
+        try {
+          const compactRes = await client.post<{
+            summary?: string;
+            latestSummaryContent?: string;
+            skipped?: boolean;
+            tokensBefore?: number;
+            tokensAfter?: number;
+          }>('/compact', {
+            session_id: sessionId,
+            cwd,
+            skip_ingest: true,
+            client: 'claude',
+            ...(previousSummary !== undefined ? { previous_summary: previousSummary } : {}),
+          });
+          const hadPrevious = previousSummary !== undefined;
+          if (compactRes.latestSummaryContent !== undefined) {
+            previousSummary = compactRes.latestSummaryContent;
+          }
+          // Use compact's tokensBefore as the authoritative token count for this session.
+          // This avoids under-reporting when /ingest returns totalTokens=0 (already-ingested).
+          if (typeof compactRes.tokensBefore === 'number') {
+            result.totalTokens += compactRes.tokensBefore;
+          }
+          if (typeof compactRes.tokensAfter === 'number') {
+            result.tokensAfter += compactRes.tokensAfter;
+          }
+          if (options.verbose) {
+            const ctx = hadPrevious ? ' (with prior context)' : '';
+            if (typeof compactRes.tokensBefore === 'number' && typeof compactRes.tokensAfter === 'number' && compactRes.tokensAfter < compactRes.tokensBefore) {
+              const ratio = formatRatio(compactRes.tokensBefore, compactRes.tokensAfter);
+              console.log(`  \ud83e\udde0 ${sessionId}: ${formatNumber(compactRes.tokensBefore)} \u2192 ${formatNumber(compactRes.tokensAfter)}  (${ratio}\u00d7)${ctx}`);
+            } else {
+              console.log(`  \ud83e\udde0 ${sessionId}: compacted${ctx}`);
+            }
+          }
+        } catch (err) {
+          // Non-fatal: import succeeded; compact failure breaks the chain at this link.
+          previousSummary = undefined;
+          // Always warn on chain breakage so users know the DAG is incomplete,
+          // regardless of whether --verbose was passed.
+          console.error(`  \u26a0\ufe0f [replay] compact failed for session ${sessionId}: ${err instanceof Error ? err.message : 'unknown error'}`);
+          // Fall back to ingest's totalTokens so they aren't silently lost.
+          result.totalTokens += res.totalTokens;
+        }
+      }
+    } catch (err) {
+      result.failed++;
+      if (options.replay) previousSummary = undefined; // chain broken by ingest failure
+      if (options.verbose) console.log(`  \u274c ${sessionId}: ${err instanceof Error ? err.message : "failed"}`);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
 export async function importSessions(
   client: DaemonClient,
   options: ImportOptions = {}
 ): Promise<ImportResult> {
-  const claudeProjectsDir = options._claudeProjectsDir ?? join(homedir(), '.claude', 'projects');
+  const provider: ImportProvider = options.provider ?? "claude";
   const result: ImportResult = { imported: 0, skippedEmpty: 0, failed: 0, totalMessages: 0, totalTokens: 0, tokensAfter: 0 };
 
-  const projectDirs: { dir: string; cwd: string }[] = [];
+  // --- Claude Code sessions ---
+  if (provider === "claude" || provider === "all") {
+    const claudeProjectsDir = options._claudeProjectsDir ?? join(homedir(), '.claude', 'projects');
 
-  if (options.all) {
-    if (!existsSync(claudeProjectsDir)) return result;
-    const projectMap = buildProjectMap(options._lcmDir);
-    for (const entry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
-      if (!entry.isDirectory()) continue;
-      const cwd = projectMap.get(entry.name);
-      if (!cwd) continue;
-      projectDirs.push({ dir: join(claudeProjectsDir, entry.name), cwd });
+    const projectDirs: { dir: string; cwd: string }[] = [];
+
+    if (options.all) {
+      if (existsSync(claudeProjectsDir)) {
+        const projectMap = buildProjectMap(options._lcmDir);
+        for (const entry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
+          if (!entry.isDirectory()) continue;
+          const cwd = projectMap.get(entry.name);
+          if (!cwd) continue;
+          projectDirs.push({ dir: join(claudeProjectsDir, entry.name), cwd });
+        }
+      }
+    } else {
+      const cwd = options.cwd ?? process.cwd();
+      const hash = cwdToProjectHash(cwd);
+      const dir = join(claudeProjectsDir, hash);
+      if (existsSync(dir)) {
+        projectDirs.push({ dir, cwd });
+      }
     }
-  } else {
-    const cwd = options.cwd ?? process.cwd();
-    const hash = cwdToProjectHash(cwd);
-    const dir = join(claudeProjectsDir, hash);
-    if (existsSync(dir)) {
-      projectDirs.push({ dir, cwd });
+
+    for (const { dir, cwd } of projectDirs) {
+      const sessionFiles = findSessionFiles(dir);
+      await ingestSessionList(
+        client,
+        sessionFiles.map(f => ({ ...f, cwd })),
+        options,
+        result,
+      );
     }
   }
 
-  for (const { dir, cwd } of projectDirs) {
-    const sessionFiles = findSessionFiles(dir);
-    let previousSummary: string | undefined;  // resets per project
+  // --- Codex CLI sessions ---
+  if (provider === "codex" || provider === "all") {
+    const codexTranscripts = findAllCodexTranscripts(options._codexDir);
+    const codexSessions: SessionEntry[] = codexTranscripts.map(f => ({
+      path: f.path,
+      sessionId: f.sessionId,
+      // Prefer the cwd embedded in the transcript; fall back to process.cwd()
+      cwd: extractCodexSessionCwd(f.path) ?? process.cwd(),
+    }));
 
-    for (const { path, sessionId } of sessionFiles) {
-      if (options.dryRun) {
-        if (options.verbose) {
-          const replayNote = options.replay ? " (would compact)" : "";
-          console.log(`  [dry-run] ${sessionId}${replayNote}`);
-        }
-        result.imported++;
-        continue;
-      }
-
-      try {
-        const res = await client.post<{ ingested: number; totalTokens: number }>('/ingest', {
-          session_id: sessionId,
-          cwd,
-          transcript_path: path,
-        });
-        if (res.ingested === 0 && res.totalTokens === 0) {
-          result.skippedEmpty++;
-          if (options.verbose) console.log(`  \u23ed\ufe0f ${sessionId}: empty or already ingested`);
-        } else {
-          result.imported++;
-          result.totalMessages += res.ingested;
-          // In replay mode, totalTokens is sourced from compact's tokensBefore to avoid
-          // double-counting (compact covers already-ingested sessions too).
-          if (!options.replay) {
-            result.totalTokens += res.totalTokens;
-          }
-          if (options.verbose) console.log(`  \u2705 ${sessionId}: ${res.ingested} messages (${formatNumber(res.totalTokens)} tokens)`);
-        }
-
-        // Replay: compact immediately after every session (even already-ingested ones)
-        // so that re-runs are idempotent and the temporal chain stays intact.
-        if (options.replay) {
-          try {
-            const compactRes = await client.post<{
-              summary?: string;
-              latestSummaryContent?: string;
-              skipped?: boolean;
-              tokensBefore?: number;
-              tokensAfter?: number;
-            }>('/compact', {
-              session_id: sessionId,
-              cwd,
-              skip_ingest: true,
-              client: 'claude',
-              ...(previousSummary !== undefined ? { previous_summary: previousSummary } : {}),
-            });
-            const hadPrevious = previousSummary !== undefined;
-            if (compactRes.latestSummaryContent !== undefined) {
-              previousSummary = compactRes.latestSummaryContent;
-            }
-            // Use compact's tokensBefore as the authoritative token count for this session.
-            // This avoids under-reporting when /ingest returns totalTokens=0 (already-ingested).
-            if (typeof compactRes.tokensBefore === 'number') {
-              result.totalTokens += compactRes.tokensBefore;
-            }
-            if (typeof compactRes.tokensAfter === 'number') {
-              result.tokensAfter += compactRes.tokensAfter;
-            }
-            if (options.verbose) {
-              const ctx = hadPrevious ? ' (with prior context)' : '';
-              if (typeof compactRes.tokensBefore === 'number' && typeof compactRes.tokensAfter === 'number' && compactRes.tokensAfter < compactRes.tokensBefore) {
-                const ratio = formatRatio(compactRes.tokensBefore, compactRes.tokensAfter);
-                console.log(`  \ud83e\udde0 ${sessionId}: ${formatNumber(compactRes.tokensBefore)} \u2192 ${formatNumber(compactRes.tokensAfter)}  (${ratio}\u00d7)${ctx}`);
-              } else {
-                console.log(`  \ud83e\udde0 ${sessionId}: compacted${ctx}`);
-              }
-            }
-          } catch (err) {
-            // Non-fatal: import succeeded; compact failure breaks the chain at this link.
-            previousSummary = undefined;
-            // Always warn on chain breakage so users know the DAG is incomplete,
-            // regardless of whether --verbose was passed.
-            console.error(`  \u26a0\ufe0f [replay] compact failed for session ${sessionId}: ${err instanceof Error ? err.message : 'unknown error'}`);
-            // Fall back to ingest's totalTokens so they aren't silently lost.
-            result.totalTokens += res.totalTokens;
-          }
-        }
-      } catch (err) {
-        result.failed++;
-        if (options.replay) previousSummary = undefined; // chain broken by ingest failure
-        if (options.verbose) console.log(`  \u274c ${sessionId}: ${err instanceof Error ? err.message : "failed"}`);
-      }
-    }
+    await ingestSessionList(client, codexSessions, options, result);
   }
 
   return result;

--- a/test/codex-transcript.test.ts
+++ b/test/codex-transcript.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, utimesSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import {
+  parseCodexTranscript,
+  extractCodexSessionCwd,
+  findCodexSessionFiles,
+  findAllCodexTranscripts,
+} from "../src/codex-transcript.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const d of dirs) rmSync(d, { recursive: true, force: true });
+  dirs.length = 0;
+});
+
+function makeTmpDir(): string {
+  const d = mkdtempSync(join(tmpdir(), "lcm-codex-test-"));
+  dirs.push(d);
+  return d;
+}
+
+function makeSessionLine(role: "user" | "assistant", text: string): string {
+  const contentType = role === "user" ? "input_text" : "output_text";
+  return JSON.stringify({
+    timestamp: "2026-01-01T00:00:00.000Z",
+    type: "response_item",
+    payload: {
+      type: "message",
+      role,
+      content: [{ type: contentType, text }],
+    },
+  });
+}
+
+function makeSessionMeta(id: string, cwd: string): string {
+  return JSON.stringify({
+    timestamp: "2026-01-01T00:00:00.000Z",
+    type: "session_meta",
+    payload: { id, cwd, cli_version: "0.100.0", model_provider: "openai" },
+  });
+}
+
+function makeEventLine(eventType: string): string {
+  return JSON.stringify({
+    timestamp: "2026-01-01T00:00:00.000Z",
+    type: "event_msg",
+    payload: { type: eventType },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// parseCodexTranscript
+// ---------------------------------------------------------------------------
+
+describe("parseCodexTranscript", () => {
+  it("returns empty array for nonexistent file", () => {
+    expect(parseCodexTranscript("/nonexistent/path/session.jsonl")).toEqual([]);
+  });
+
+  it("parses user message with input_text block", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    writeFileSync(file, makeSessionLine("user", "What is the capital of France?") + "\n");
+
+    const msgs = parseCodexTranscript(file);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].role).toBe("user");
+    expect(msgs[0].content).toBe("What is the capital of France?");
+    expect(msgs[0].tokenCount).toBeGreaterThan(0);
+  });
+
+  it("parses assistant message with output_text block", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    writeFileSync(file, makeSessionLine("assistant", "Paris is the capital of France.") + "\n");
+
+    const msgs = parseCodexTranscript(file);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].role).toBe("assistant");
+    expect(msgs[0].content).toBe("Paris is the capital of France.");
+  });
+
+  it("skips session_meta and event_msg lines", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    const content = [
+      makeSessionMeta("abc-123", "/some/path"),
+      makeEventLine("task_started"),
+      makeSessionLine("user", "Hello"),
+      makeEventLine("task_completed"),
+    ].join("\n");
+    writeFileSync(file, content + "\n");
+
+    const msgs = parseCodexTranscript(file);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].role).toBe("user");
+  });
+
+  it("skips response_item lines with non-user/assistant roles (developer, system)", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    const devLine = JSON.stringify({
+      timestamp: "2026-01-01T00:00:00.000Z",
+      type: "response_item",
+      payload: {
+        type: "message",
+        role: "developer",
+        content: [{ type: "input_text", text: "Some system instruction" }],
+      },
+    });
+    writeFileSync(file, devLine + "\n" + makeSessionLine("user", "Hello") + "\n");
+
+    const msgs = parseCodexTranscript(file);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].role).toBe("user");
+  });
+
+  it("skips lines with empty content after extraction", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    const emptyLine = JSON.stringify({
+      timestamp: "2026-01-01T00:00:00.000Z",
+      type: "response_item",
+      payload: { type: "message", role: "user", content: [] },
+    });
+    writeFileSync(file, emptyLine + "\n");
+
+    expect(parseCodexTranscript(file)).toHaveLength(0);
+  });
+
+  it("skips malformed JSON lines without throwing", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    writeFileSync(file, "not-json\n" + makeSessionLine("user", "Valid") + "\n");
+
+    const msgs = parseCodexTranscript(file);
+    expect(msgs).toHaveLength(1);
+  });
+
+  it("handles string content (non-array) in response_item payload", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    const line = JSON.stringify({
+      type: "response_item",
+      payload: { type: "message", role: "user", content: "Plain string content" },
+    });
+    writeFileSync(file, line + "\n");
+
+    const msgs = parseCodexTranscript(file);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0].content).toBe("Plain string content");
+  });
+
+  it("parses a full conversation (multiple turns)", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    const content = [
+      makeSessionMeta("sess-1", "/workspace"),
+      makeSessionLine("user", "Fix the bug"),
+      makeSessionLine("assistant", "I found the issue on line 42."),
+      makeEventLine("tool_call"),
+      makeSessionLine("user", "Great, thanks!"),
+      makeSessionLine("assistant", "You're welcome."),
+    ].join("\n");
+    writeFileSync(file, content + "\n");
+
+    const msgs = parseCodexTranscript(file);
+    expect(msgs).toHaveLength(4);
+    expect(msgs.map(m => m.role)).toEqual(["user", "assistant", "user", "assistant"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractCodexSessionCwd
+// ---------------------------------------------------------------------------
+
+describe("extractCodexSessionCwd", () => {
+  it("returns undefined for nonexistent file", () => {
+    expect(extractCodexSessionCwd("/nonexistent/path.jsonl")).toBeUndefined();
+  });
+
+  it("extracts cwd from session_meta line", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    writeFileSync(
+      file,
+      makeSessionMeta("abc-123", "/Users/pedro/Developer/myproject") + "\n",
+    );
+
+    expect(extractCodexSessionCwd(file)).toBe("/Users/pedro/Developer/myproject");
+  });
+
+  it("returns undefined when no session_meta line is present", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    writeFileSync(file, makeSessionLine("user", "Hello") + "\n");
+
+    expect(extractCodexSessionCwd(file)).toBeUndefined();
+  });
+
+  it("returns first session_meta cwd when multiple are present", () => {
+    const dir = makeTmpDir();
+    const file = join(dir, "session.jsonl");
+    writeFileSync(
+      file,
+      [
+        makeSessionMeta("sess-1", "/first/path"),
+        makeSessionMeta("sess-2", "/second/path"),
+      ].join("\n") + "\n",
+    );
+
+    expect(extractCodexSessionCwd(file)).toBe("/first/path");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findCodexSessionFiles
+// ---------------------------------------------------------------------------
+
+describe("findCodexSessionFiles", () => {
+  it("returns empty array for nonexistent directory", () => {
+    expect(findCodexSessionFiles("/nonexistent")).toEqual([]);
+  });
+
+  it("discovers flat .jsonl files", () => {
+    const dir = makeTmpDir();
+    writeFileSync(join(dir, "session-abc.jsonl"), "");
+    writeFileSync(join(dir, "session-def.jsonl"), "");
+    writeFileSync(join(dir, "readme.txt"), "");
+
+    const files = findCodexSessionFiles(dir);
+    const ids = files.map(f => f.sessionId).sort();
+    expect(ids).toEqual(["session-abc", "session-def"]);
+  });
+
+  it("discovers nested layout: <dir>/<id>/<id>.jsonl", () => {
+    const dir = makeTmpDir();
+    const sessionDir = join(dir, "session-xyz");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, "session-xyz.jsonl"), "");
+
+    const files = findCodexSessionFiles(dir);
+    expect(files).toHaveLength(1);
+    expect(files[0].sessionId).toBe("session-xyz");
+    expect(files[0].path).toBe(join(sessionDir, "session-xyz.jsonl"));
+  });
+
+  it("returns files sorted by mtime ascending", async () => {
+    const dir = makeTmpDir();
+    const older = join(dir, "old-session.jsonl");
+    const newer = join(dir, "new-session.jsonl");
+    writeFileSync(newer, "");
+    writeFileSync(older, "");
+    const oldTime = new Date(Date.now() - 10_000);
+    utimesSync(older, oldTime, oldTime);
+
+    const files = findCodexSessionFiles(dir);
+    expect(files.map(f => f.sessionId)).toEqual(["old-session", "new-session"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// findAllCodexTranscripts
+// ---------------------------------------------------------------------------
+
+describe("findAllCodexTranscripts", () => {
+  it("returns empty array when codexDir has no sessions", () => {
+    const dir = makeTmpDir();
+    expect(findAllCodexTranscripts(dir)).toEqual([]);
+  });
+
+  it("collects from archived_sessions/ (flat) and sessions/ (nested)", () => {
+    const codexDir = makeTmpDir();
+
+    // archived_sessions flat layout
+    const archived = join(codexDir, "archived_sessions");
+    mkdirSync(archived, { recursive: true });
+    writeFileSync(join(archived, "rollout-session-1.jsonl"), "");
+
+    // sessions nested layout
+    const sessions = join(codexDir, "sessions");
+    const sessionDir = join(sessions, "session-2");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, "session-2.jsonl"), "");
+
+    const files = findAllCodexTranscripts(codexDir);
+    const ids = files.map(f => f.sessionId).sort();
+    expect(ids).toEqual(["rollout-session-1", "session-2"]);
+  });
+
+  it("deduplicates sessions present in both archived_sessions and sessions/", () => {
+    const codexDir = makeTmpDir();
+
+    const archived = join(codexDir, "archived_sessions");
+    mkdirSync(archived, { recursive: true });
+    writeFileSync(join(archived, "dup-session.jsonl"), "archived");
+
+    const sessions = join(codexDir, "sessions");
+    const sessionDir = join(sessions, "dup-session");
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, "dup-session.jsonl"), "active");
+
+    const files = findAllCodexTranscripts(codexDir);
+    const matches = files.filter(f => f.sessionId === "dup-session");
+    expect(matches).toHaveLength(1);
+    // archived_sessions is added first, so it wins
+    expect(matches[0].path).toBe(join(archived, "dup-session.jsonl"));
+  });
+});

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -525,3 +525,165 @@ describe("importSessions", () => {
     expect(result.failed).toBe(1);
   });
 });
+
+// --- importSessions with provider: "codex" ---
+
+function makeCodexResponseItemLine(role: "user" | "assistant", text: string): string {
+  const contentType = role === "user" ? "input_text" : "output_text";
+  return JSON.stringify({
+    timestamp: "2026-01-01T00:00:00.000Z",
+    type: "response_item",
+    payload: { type: "message", role, content: [{ type: contentType, text }] },
+  });
+}
+
+function makeCodexSessionMetaLine(id: string, cwd: string): string {
+  return JSON.stringify({
+    timestamp: "2026-01-01T00:00:00.000Z",
+    type: "session_meta",
+    payload: { id, cwd, cli_version: "0.100.0", model_provider: "openai" },
+  });
+}
+
+describe("importSessions — provider: codex", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    dirs.length = 0;
+    vi.restoreAllMocks();
+  });
+
+  function makeTmpDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "lcm-import-codex-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  it("imports Codex sessions from _codexDir/archived_sessions/", async () => {
+    const codexDir = makeTmpDir();
+    const archivedDir = join(codexDir, "archived_sessions");
+    mkdirSync(archivedDir, { recursive: true });
+
+    const cwd = "/workspace/myproject";
+    const sessionId = "rollout-2026-01-01-session-abc";
+    const content = [
+      makeCodexSessionMetaLine(sessionId, cwd),
+      makeCodexResponseItemLine("user", "Hello Codex"),
+      makeCodexResponseItemLine("assistant", "Hello! How can I help?"),
+    ].join("\n");
+    writeFileSync(join(archivedDir, `${sessionId}.jsonl`), content);
+
+    const calls: { path: string; body: unknown }[] = [];
+    const client = makeMockClient(async (path, body) => {
+      calls.push({ path, body });
+      return { ingested: 2, totalTokens: 200 };
+    });
+
+    const result = await importSessions(client, {
+      provider: "codex",
+      _codexDir: codexDir,
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].path).toBe("/ingest");
+    expect((calls[0].body as { session_id: string }).session_id).toBe(sessionId);
+    expect((calls[0].body as { cwd: string }).cwd).toBe(cwd);
+    expect((calls[0].body as { transcript_path: string }).transcript_path).toContain(`${sessionId}.jsonl`);
+    expect(result.imported).toBe(1);
+    expect(result.totalMessages).toBe(2);
+    expect(result.totalTokens).toBe(200);
+    expect(result.failed).toBe(0);
+  });
+
+  it("falls back to process.cwd() when session_meta has no cwd", async () => {
+    const codexDir = makeTmpDir();
+    const archivedDir = join(codexDir, "archived_sessions");
+    mkdirSync(archivedDir, { recursive: true });
+
+    // A transcript without a session_meta line
+    writeFileSync(
+      join(archivedDir, "no-meta-session.jsonl"),
+      makeCodexResponseItemLine("user", "Hi") + "\n",
+    );
+
+    const calls: { path: string; body: unknown }[] = [];
+    const client = makeMockClient(async (path, body) => {
+      calls.push({ path, body });
+      return { ingested: 1, totalTokens: 50 };
+    });
+
+    await importSessions(client, {
+      provider: "codex",
+      _codexDir: codexDir,
+    });
+
+    expect(calls).toHaveLength(1);
+    // Falls back to process.cwd()
+    expect((calls[0].body as { cwd: string }).cwd).toBe(process.cwd());
+  });
+
+  it("imports nothing when _codexDir does not exist", async () => {
+    const client = makeMockClient(async () => ({ ingested: 1, totalTokens: 100 }));
+
+    const result = await importSessions(client, {
+      provider: "codex",
+      _codexDir: "/nonexistent/codex/dir",
+    });
+
+    expect(client.post).not.toHaveBeenCalled();
+    expect(result.imported).toBe(0);
+  });
+
+  it("dry-run does not call /ingest for codex sessions", async () => {
+    const codexDir = makeTmpDir();
+    const archivedDir = join(codexDir, "archived_sessions");
+    mkdirSync(archivedDir, { recursive: true });
+    writeFileSync(join(archivedDir, "session-x.jsonl"), makeCodexSessionMetaLine("session-x", "/ws"));
+
+    const client = makeMockClient(async () => ({ ingested: 1, totalTokens: 100 }));
+
+    const result = await importSessions(client, {
+      provider: "codex",
+      dryRun: true,
+      _codexDir: codexDir,
+    });
+
+    expect(client.post).not.toHaveBeenCalled();
+    expect(result.imported).toBe(1);
+  });
+
+  it("provider all imports from both Claude and Codex", async () => {
+    // Claude project dir
+    const claudeProjectsDir = makeTmpDir();
+    const cwd = "/home/user/claudeproject";
+    const hash = cwdToProjectHash(cwd);
+    const claudeProjDir = join(claudeProjectsDir, hash);
+    mkdirSync(claudeProjDir, { recursive: true });
+    writeFileSync(join(claudeProjDir, "claude-session.jsonl"), "");
+
+    // Codex dir
+    const codexDir = makeTmpDir();
+    const archivedDir = join(codexDir, "archived_sessions");
+    mkdirSync(archivedDir, { recursive: true });
+    writeFileSync(join(archivedDir, "codex-session.jsonl"), makeCodexSessionMetaLine("codex-session", "/workspace"));
+
+    const sessionIds: string[] = [];
+    const client = makeMockClient(async (path, body) => {
+      sessionIds.push((body as { session_id: string }).session_id);
+      return { ingested: 1, totalTokens: 100 };
+    });
+
+    const result = await importSessions(client, {
+      provider: "all",
+      cwd,
+      _claudeProjectsDir: claudeProjectsDir,
+      _codexDir: codexDir,
+    });
+
+    expect(sessionIds.sort()).toEqual(["claude-session", "codex-session"]);
+    expect(result.imported).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--provider claude|codex|all` flag (and `--codex` shorthand) to `lcm import` so Codex CLI sessions stored in `~/.codex/` can be imported into lossless memory
- New `src/codex-transcript.ts` parser handles Codex JSONL format (`response_item` events with `input_text`/`output_text` content blocks), CWD extraction from `session_meta`, and session discovery across `archived_sessions/` and `sessions/` layouts
- Refactored `importSessions` in `src/import.ts` to share a single ingestion loop between Claude and Codex providers; `provider: "all"` runs both sequentially

## How it works

Codex transcripts differ from Claude Code transcripts:

| Field | Claude Code | Codex CLI |
|---|---|---|
| Message wrapper | `{ type: "human"\|"assistant", message: { role, content } }` | `{ type: "response_item", payload: { type: "message", role, content } }` |
| Text block type | `text` | `input_text` (user) / `output_text` (assistant) |
| CWD source | directory name (project hash) | `session_meta` event in the JSONL |
| Discovery | `~/.claude/projects/<hash>/` | `~/.codex/archived_sessions/` + `~/.codex/sessions/<id>/` |

## Test plan

- [x] 20 new unit tests in `test/codex-transcript.test.ts` covering parse, CWD extraction, and discovery
- [x] 5 new integration tests in `test/import.test.ts` covering `provider: "codex"`, `provider: "all"`, dry-run, missing dir, and missing cwd fallback
- [x] Full suite: 521 tests passing across 68 test files

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)