### PR TITLE
fix(cli): repair Commander.js subcommand routing and compact batch mode detection

### DIFF
--- a/.claude-plugin/commands/lcm-curate.md
+++ b/.claude-plugin/commands/lcm-curate.md
@@ -20,23 +20,23 @@ Replace `lcm` with the command above in all instructions below.
 
 ## Instructions
 
-Run the following commands sequentially via Bash:
+Run the following commands sequentially via Bash. Always use `--verbose` on `import` and `promote` by default:
 
 ```bash
-lcm import && lcm compact && lcm promote
+lcm import --verbose && lcm compact && lcm promote --verbose
 ```
 
 ### Options
 
 Pass user-specified flags through to the commands that support them:
 - `--all` — Process all projects (default: current project only); applies to all three commands
-- `--verbose` — Show per-step details; applies to `import` and `promote` only (compact does not support `--verbose`)
+- `--no-verbose` — Suppress verbose output (verbose is on by default)
 - `--dry-run` — Preview without writing; applies to all three commands
 
 For example:
-- `/lcm-curate --all` → `lcm import --all && lcm compact --all && lcm promote --all`
-- `/lcm-curate --all --verbose` → `lcm import --all --verbose && lcm compact --all && lcm promote --all --verbose`
-- `/lcm-curate --dry-run` → `lcm import --dry-run && lcm compact --dry-run && lcm promote --dry-run`
+- `/lcm-curate --all` → `lcm import --all --verbose && lcm compact --all && lcm promote --all --verbose`
+- `/lcm-curate --dry-run` → `lcm import --dry-run --verbose && lcm compact --dry-run && lcm promote --dry-run --verbose`
+- `/lcm-curate --no-verbose` → `lcm import && lcm compact && lcm promote`
 
 The pipeline stops on the first failure and reports the result.
 

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -36,13 +36,8 @@ async function main() {
       writeErr: (str) => process.stderr.write(str),
     });
 
-  // Override default --help to use custom help
+  // Disable Commander's built-in help entirely — we handle it manually below
   program.helpOption(false);
-  program.option("-h, --help", "Show help").hook("preAction", async () => {
-    const { printHelp } = await import("../src/cli-help.js");
-    printHelp();
-    exit(0);
-  });
 
   // ─── help command ──────────────────────────────────────────────────────────
   program
@@ -114,9 +109,13 @@ async function main() {
         printHelp("compact"); exit(0);
       }
       const all: boolean = opts.all ?? false;
-      // Interactive batch compact: --all (all projects) or TTY stdin (current project only).
-      // If stdin is piped (hook invocation), fall through to hook dispatch.
-      if (all || process.stdin.isTTY) {
+      const dryRun: boolean = opts.dryRun ?? false;
+      const verbose: boolean = opts.verbose ?? false;
+      const replay: boolean = opts.replay ?? false;
+      // Batch mode: --all, TTY stdin, or any explicit flag (--dry-run/--verbose/--replay
+      // don't apply to hook dispatch, so their presence means the caller wants batch mode).
+      const batchMode = all || process.stdin.isTTY || dryRun || verbose || replay;
+      if (batchMode) {
         const { batchCompact } = await import("../src/batch-compact.js");
         const { loadDaemonConfig } = await import("../src/daemon/config.js");
         const { join } = await import("node:path");
@@ -130,10 +129,7 @@ async function main() {
           console.error("Could not connect to daemon. Start it with: lcm daemon start --detach");
           exit(1);
         }
-        const dryRun: boolean = opts.dryRun ?? false;
-        const replay: boolean = opts.replay ?? false;
         const noPromote: boolean = !opts.promote;
-        const verbose: boolean = opts.verbose ?? false;
         const minTokens = config.compaction.autoCompactMinTokens;
         const cwd = all ? undefined : process.cwd();
 
@@ -850,22 +846,16 @@ async function main() {
     exit(1);
   });
 
-  // Override program-level --help to show custom help
-  program.on("option:help", async () => {
-    const { printHelp } = await import("../src/cli-help.js");
-    printHelp();
-    exit(0);
-  });
-
-  // Parse with allowUnknownOption to avoid Commander erroring before our handler
-  await program.parseAsync(argv);
-
-  // If no command was given, show help
-  if (argv.length <= 2) {
+  // Handle root-level help and no-args before Commander parses — this prevents
+  // Commander from seeing --help at the root level and intercepting it before
+  // dispatching to subcommands (lcm import --help would otherwise show root help).
+  if (argv.length <= 2 || (argv.length === 3 && (argv[2] === "-h" || argv[2] === "--help"))) {
     const { printHelp } = await import("../src/cli-help.js");
     printHelp();
     exit(0);
   }
+
+  await program.parseAsync(argv);
 }
 
 main().catch((err) => { console.error(err); exit(1); });


### PR DESCRIPTION
## Summary

- **Subcommand routing broken**: The root program had a `preAction` hook that fired unconditionally before every subcommand action, causing every `lcm <subcommand>` to show root help and exit. Fixed by removing the hook and handling `-h/--help` pre-parse instead.
- **`lcm import --help` intercepted at root**: Commander was parsing `--help` against the root program option before dispatching to the subcommand. Fixed by not registering `-h/--help` at the root level.
- **`lcm compact` silent in non-TTY**: The batch mode guard `if (all || process.stdin.isTTY)` caused `lcm compact --verbose` to silently fall through to hook dispatch when run from scripts. Fixed by also entering batch mode when explicit flags (`--verbose`, `--dry-run`, `--replay`) are passed.
- **`lcm-curate` skill defaults to `--verbose`**: Curate pipeline now shows per-session details without requiring the user to pass `--verbose` explicitly.

## Test plan
- [ ] `lcm import --help` shows import-specific help (not root help)
- [ ] `lcm compact --help` shows compact-specific help
- [ ] `lcm --help` still shows root help
- [ ] `lcm compact --verbose` enters batch mode from a non-TTY script
- [ ] `/lcm-curate` outputs verbose details by default