### PR TITLE
fix(extractors): normalize <channel> XML in prompts before decision detection

### DIFF
--- a/src/hooks/extractors.ts
+++ b/src/hooks/extractors.ts
@@ -5,6 +5,7 @@ export interface ExtractedEvent {
   category: string;
   data: string;
   priority: number;
+  tags?: string[];
 }
 
 interface PostToolInput {
@@ -177,9 +178,21 @@ export function extractPostToolEvents(input: PostToolInput): ExtractedEvent[] {
   return [];
 }
 
+// Extract text content from <channel> XML tags, or return prompt as-is
+export function normalizePromptWithChannels(prompt: string): { text: string; fromChannel: boolean } {
+  const normalized = prompt.replace(/<channel[^>]*>([\s\S]*?)<\/channel>/g, (_, content) => content.trim());
+  return { text: normalized, fromChannel: normalized !== prompt };
+}
+
 export function extractUserPromptEvents(prompt: string): ExtractedEvent[] {
   const events: ExtractedEvent[] = [];
-  const lower = prompt.toLowerCase();
+
+  // Strip <channel> XML tags before running extractors
+  const { text: normalizedPrompt, fromChannel } = normalizePromptWithChannels(prompt);
+
+  const lower = normalizedPrompt.toLowerCase();
+
+  const channelTags = fromChannel ? ["source:telegram"] : undefined;
 
   // Decision extraction with negative-match guards
   const hasNegative = NEGATIVE_PATTERNS.some(np => lower.includes(np));
@@ -188,13 +201,15 @@ export function extractUserPromptEvents(prompt: string): ExtractedEvent[] {
       /\b(don'?t|never|always|prefer|use .+ instead)\b/i,
     ];
     for (const pattern of decisionPatterns) {
-      if (pattern.test(prompt)) {
-        events.push({
+      if (pattern.test(normalizedPrompt)) {
+        const event: ExtractedEvent = {
           type: "user_decision",
           category: "decision",
-          data: truncate(prompt),
+          data: truncate(normalizedPrompt),
           priority: 1,
-        });
+        };
+        if (channelTags) event.tags = channelTags;
+        events.push(event);
         break;
       }
     }
@@ -206,13 +221,15 @@ export function extractUserPromptEvents(prompt: string): ExtractedEvent[] {
     /\b(senior|junior|staff|lead|principal)\s+(engineer|developer|scientist|designer)\b/i,
   ];
   for (const pattern of rolePatterns) {
-    if (pattern.test(prompt)) {
-      events.push({
+    if (pattern.test(normalizedPrompt)) {
+      const event: ExtractedEvent = {
         type: "user_role",
         category: "role",
-        data: truncate(prompt),
+        data: truncate(normalizedPrompt),
         priority: 2,
-      });
+      };
+      if (channelTags) event.tags = channelTags;
+      events.push(event);
       break;
     }
   }
@@ -225,13 +242,15 @@ export function extractUserPromptEvents(prompt: string): ExtractedEvent[] {
     [/\b(refactor|clean|simplify|optimize)\b/i, "refactor"],
   ];
   for (const [pattern, intent] of intentMap) {
-    if (pattern.test(prompt)) {
-      events.push({
+    if (pattern.test(normalizedPrompt)) {
+      const event: ExtractedEvent = {
         type: `intent_${intent}`,
         category: "intent",
         data: intent,
         priority: 3,
-      });
+      };
+      if (channelTags) event.tags = channelTags;
+      events.push(event);
       break;
     }
   }

--- a/test/hooks/extractors.test.ts
+++ b/test/hooks/extractors.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   extractPostToolEvents,
   extractUserPromptEvents,
+  normalizePromptWithChannels,
   type ExtractedEvent,
 } from "../../src/hooks/extractors.js";
 
@@ -213,5 +214,68 @@ describe("extractUserPromptEvents", () => {
     const events = extractUserPromptEvents("fix the bug in main.ts");
     // "fix" matches intent, so we expect 1 intent event
     expect(events.filter(e => e.category === "decision")).toHaveLength(0);
+  });
+});
+
+describe("normalizePromptWithChannels", () => {
+  it("strips channel XML and returns clean text", () => {
+    const raw = '<channel source="telegram" chat_id="123" message_id="456" user="pedro" ts="1234">always use TypeScript</channel>';
+    const { text, fromChannel } = normalizePromptWithChannels(raw);
+    expect(text).toBe("always use TypeScript");
+    expect(fromChannel).toBe(true);
+  });
+
+  it("returns original text unchanged when no channel tag present", () => {
+    const raw = "always use TypeScript";
+    const { text, fromChannel } = normalizePromptWithChannels(raw);
+    expect(text).toBe("always use TypeScript");
+    expect(fromChannel).toBe(false);
+  });
+
+  it("handles multi-line channel content", () => {
+    const raw = '<channel source="telegram" chat_id="1">\nalways use TypeScript\nfor new files\n</channel>';
+    const { text, fromChannel } = normalizePromptWithChannels(raw);
+    expect(text).toBe("always use TypeScript\nfor new files");
+    expect(fromChannel).toBe(true);
+  });
+});
+
+describe("extractUserPromptEvents — Telegram channel wrapping", () => {
+  it("extracts decision from channel-wrapped prompt", () => {
+    const raw = '<channel source="telegram" chat_id="123" message_id="456" user="pedro" ts="1234">always use TypeScript for new files</channel>';
+    const events = extractUserPromptEvents(raw);
+    const decisions = events.filter(e => e.category === "decision");
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({
+      type: "user_decision",
+      category: "decision",
+      priority: 1,
+    });
+  });
+
+  it("strips XML from stored data in decision events from Telegram", () => {
+    const raw = '<channel source="telegram" chat_id="123" message_id="1" user="pedro" ts="1234">always use TypeScript for new files</channel>';
+    const events = extractUserPromptEvents(raw);
+    const decision = events.find(e => e.category === "decision");
+    expect(decision).toBeDefined();
+    expect(decision!.data).not.toContain("<channel");
+    expect(decision!.data).toContain("always use TypeScript");
+  });
+
+  it("adds source:telegram tag to events extracted from channel messages", () => {
+    const raw = '<channel source="telegram" chat_id="123" message_id="1" user="pedro" ts="1234">always use TypeScript</channel>';
+    const events = extractUserPromptEvents(raw);
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(event.tags).toContain("source:telegram");
+    }
+  });
+
+  it("does NOT add source:telegram tag for non-channel prompts", () => {
+    const events = extractUserPromptEvents("always use TypeScript");
+    expect(events.length).toBeGreaterThan(0);
+    for (const event of events) {
+      expect(event.tags).toBeUndefined();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Telegram messages arrive wrapped in `<channel source="telegram" ...>text</channel>` XML
- The extractor was running decision regex on the raw XML string, causing misses and polluted stored data
- Added `normalizePromptWithChannels()` helper that strips channel XML before any regex runs
- Events extracted from channel-wrapped prompts receive a `source:telegram` tag for traceability
- Added `tags?: string[]` field to `ExtractedEvent` interface

## Test plan

- [x] `normalizePromptWithChannels` unit tests: strips XML, returns `fromChannel: true`, handles multiline
- [x] Channel-wrapped prompt containing decision keyword → decision extracted correctly
- [x] Stored `data` field contains clean text (no `<channel` tags)
- [x] `source:telegram` tag present on all events from channel messages
- [x] Non-channel prompts have no `tags` field set
- [x] All 736 existing tests pass (1 pre-existing unrelated failure in `restore.test.ts`)

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)