### PR TITLE
ci: enable Copilot auto-review on all PRs

### DIFF
--- a/.github/workflows/copilot-review.yml
+++ b/.github/workflows/copilot-review.yml
@@ -1,0 +1,21 @@
+name: Request Copilot Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review]
+
+jobs:
+  request-review:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add Copilot as reviewer
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" \
+            --add-reviewer "copilot-pull-request-reviewer" \
+            --repo "${{ github.repository }}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/copilot-review.yml` to automatically request Copilot review on every non-draft PR
- Mirrors the workflow already in place on `extreme-go-horse/xgh`
- Implements ipedro/claudinho#65 (enable Copilot auto-review on all org repos)

## What the workflow does

Triggers on `pull_request` events (`opened`, `ready_for_review`), skips drafts, and adds `copilot-pull-request-reviewer` as a reviewer via `gh pr edit`.

## Test plan
- [ ] Open a new non-draft PR → Copilot should be auto-added as reviewer
- [ ] Open a draft PR → Copilot should NOT be added until marked ready