### PR TITLE
fix(release): v0.8.0 blockers — atomic meta.json + redaction_stats migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # @lossless-claude/lcm
 
+## [0.8.0] - 2026-03-28
+
+### Added
+- Connection pooling for sidecar EventsDb (issue #131)
+- Portable knowledge export/import commands — `lcm export`, `lcm import-knowledge` (issue #132)
+- Pool stats observable — `lcm stats --pool` + `GET /stats/pool` daemon endpoint
+- AR coverage gate CI workflow
+- Copilot auto-review on all PRs
+
+### Fixed
+- `post-tool` command not registered in CLI dispatcher (#162)
+- Security: upgraded hono, rollup, picomatch (3 high CVEs)
+- Security: CodeQL hostname regex escaping + sanitizeError in daemon
+- Atomic meta.json write in `importKnowledge` — prevents corruption on crash mid-write
+- `redaction_stats` CHECK constraint migration for v0.7.0 → v0.8.0 upgrades (adds `'gitleaks'` category)
+
 ## 0.1.0
 
 Initial release under `@lossless-claude/lcm`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lossless-claude/lcm",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Never lose context again. lossless-claude compresses Claude Code sessions into searchable memory — every message preserved, every insight remembered.",
   "type": "module",
   "main": "dist/src/memory/index.js",

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -496,15 +496,28 @@ export function runLcmMigrations(
   backfillSummaryDepths(db);
   backfillSummaryMetadata(db);
 
-  // Redaction stats (counts of secrets scrubbed per project per category)
-  db.exec(`
-    CREATE TABLE IF NOT EXISTS redaction_stats (
-      project_id TEXT NOT NULL,
-      category TEXT NOT NULL CHECK(category IN ('gitleaks', 'built_in', 'global', 'project')),
-      count INTEGER NOT NULL DEFAULT 0,
-      PRIMARY KEY (project_id, category)
-    );
-  `);
+  // Redaction stats (counts of secrets scrubbed per project per category).
+  // v0.7.0 created this table with CHECK(category IN ('built_in', 'global', 'project')).
+  // v0.8.0 adds 'gitleaks' to the enum. CREATE TABLE IF NOT EXISTS silently skips creation
+  // on existing DBs, so we must detect the stale constraint and recreate.
+  // redaction_stats is a pure counter table (no user data) — DROP/RECREATE is safe.
+  const redactionStatsRow = db
+    .prepare("SELECT sql FROM sqlite_master WHERE type='table' AND name='redaction_stats'")
+    .get() as { sql?: string } | undefined;
+  const needsRedactionStatsMigration =
+    !redactionStatsRow ||
+    (redactionStatsRow.sql !== undefined && !redactionStatsRow.sql.includes("'gitleaks'"));
+  if (needsRedactionStatsMigration) {
+    db.exec(`
+      DROP TABLE IF EXISTS redaction_stats;
+      CREATE TABLE redaction_stats (
+        project_id TEXT NOT NULL,
+        category TEXT NOT NULL CHECK(category IN ('built_in', 'global', 'project', 'gitleaks')),
+        count INTEGER NOT NULL DEFAULT 0,
+        PRIMARY KEY (project_id, category)
+      );
+    `);
+  }
 
   // Session instructions (CLAUDE.md captured on startup)
   db.exec(`

--- a/src/portable-knowledge.ts
+++ b/src/portable-knowledge.ts
@@ -13,7 +13,7 @@
  * Deduplication is performed on import via deduplicateAndInsert().
  */
 
-import { existsSync, writeFileSync, mkdirSync } from "node:fs";
+import { existsSync, writeFileSync, mkdirSync, renameSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { createHash } from "node:crypto";
@@ -245,9 +245,12 @@ export async function importKnowledge(
 
   // Write meta.json if it doesn't already exist so this project is visible
   // to `lcm export --all` (which enumerates projects by scanning for meta.json).
+  // Use a tmp-file + rename for atomicity — a crash mid-write would corrupt the file.
   const metaPath = join(projDir, "meta.json");
   if (!existsSync(metaPath)) {
-    writeFileSync(metaPath, JSON.stringify({ cwd }, null, 2), "utf-8");
+    const tmpPath = metaPath + ".tmp";
+    writeFileSync(tmpPath, JSON.stringify({ cwd }, null, 2), "utf-8");
+    renameSync(tmpPath, metaPath);
   }
 
   return {


### PR DESCRIPTION
## Summary

- **B-1 (atomic meta.json write):** `importKnowledge()` in `src/portable-knowledge.ts` previously wrote `meta.json` directly to its final path. A crash mid-write would corrupt the file. Fixed by writing to `metaPath + '.tmp'` then using `renameSync(tmpPath, metaPath)` — atomic on POSIX, effectively atomic on Windows (best-effort). Added `renameSync` to the `node:fs` import.

- **B-2 (redaction_stats constraint migration):** v0.7.0 created `redaction_stats` with `CHECK(category IN ('built_in', 'global', 'project'))`. v0.8.0 added `'gitleaks'` but used `CREATE TABLE IF NOT EXISTS`, which silently skips creation on existing DBs. Fixed by inspecting `sqlite_master` for the stale constraint and issuing `DROP TABLE IF EXISTS` + `CREATE TABLE` with the updated enum when detected. `redaction_stats` is a pure stats counter — no user data is lost.

- **B-3 (version bump):** `package.json` bumped from `0.7.0` → `0.8.0`.

- **CHANGELOG:** Added `[0.8.0] - 2026-03-28` entry with all shipped features and fixes.

## Note on pre-existing test failure

`test/daemon/routes/restore.test.ts > POST /restore > returns empty context for source=compact with no session_instructions` fails on `main` before this PR (confirmed by stashing these changes and running the suite). It is unrelated to B-1/B-2.

## Test plan

- [x] `npm test` passes all tests that were passing on `main` before this PR
- [x] `portable-knowledge.test.ts` (12 tests) passes — covers import/export including meta.json write
- [x] `migration.test.ts` (8 tests) passes — covers migration upgrade paths
- [x] Pre-existing failure in `restore.test.ts` confirmed pre-dates this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)