### PR TITLE
chore: add missing forbidden paths to autoimprove.yaml

### DIFF
--- a/autoimprove.yaml
+++ b/autoimprove.yaml
@@ -45,6 +45,13 @@ constraints:
     - autoimprove.yaml
     - test/
     - src/connectors/templates/
+    - src/scrub.ts                        # scrubbing engine — hands off
+    - src/daemon/routes/ingest.ts         # ingest pipeline + scrubbing entry point — hands off
+    - src/daemon/config.ts                # daemon config schema — hands off
+    - scripts/**
+    - package.json
+    - package-lock.json
+    - tsconfig.json
     - .changeset/
   test_modification: additive_only
   trust_ratchet:


### PR DESCRIPTION
## Summary

- Adds `src/scrub.ts` (scrubbing engine), `src/daemon/routes/ingest.ts` (ingest/scrubbing entry), and `src/daemon/config.ts` (daemon config schema) to forbidden paths — these are the most sensitive files in the repo
- Adds `scripts/**`, `package.json`, `package-lock.json`, `tsconfig.json` to prevent accidental build-metadata mutations
- Existing `test/`, `src/connectors/templates/`, `.changeset/` guards preserved

Closes #182

## Related

- #181 — pre-existing failing test in `restore.test.ts` (blocks the `npm test` gate until fixed; unrelated to this PR)

## Test plan

- [ ] `autoimprove.yaml` diff reviewed — additive only, no logic changes
- [ ] Forbidden path paths verified against actual file structure (`src/scrub.ts` ✓, `src/daemon/routes/ingest.ts` ✓, `src/daemon/config.ts` ✓, `scripts/` ✓)

[SKIP_AR: single config file, purely additive — 7 new lines in forbidden_paths list]
[DEVIATION: autoimprove.yaml already existed in main; PR improves it instead of creating from scratch]

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>