### PR TITLE
chore(release): v0.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lcm",
-  "version": "0.7.0",
+  "version": "0.8.1",
   "description": "Lossless context management — DAG-based summarization that preserves every message",
   "author": {
     "name": "Pedro Almeida",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @lossless-claude/lcm
 
+## [0.8.1] - 2026-03-30
+
+### Added
+- User notification when sensitive data is filtered from LCM history (closes #178)
+
+### Fixed
+- Compact-restore test isolation — eliminate tmpdir() contamination (#184)
+
+### Changed
+- Quality-gates CI: label-based merge requirements (#185)
+- autoimprove.yaml: add missing forbidden paths (closes #182) (#183)
+
 ## [0.8.0] - 2026-03-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lossless-claude/lcm",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Never lose context again. lossless-claude compresses Claude Code sessions into searchable memory — every message preserved, every insight remembered.",
   "type": "module",
   "main": "dist/src/memory/index.js",


### PR DESCRIPTION
## v0.8.1 Release

Version bump + CHANGELOG for patch release.

### Changes included
- feat(hooks): notify user when sensitive data is filtered from LCM history (closes #178)
- fix(restore): compact-restore test isolation — eliminate tmpdir() contamination (#184)
- chore: quality-gates CI label-based merge requirements (#185)
- chore: autoimprove.yaml add missing forbidden paths (closes #182) (#183)

### Files changed
- `CHANGELOG.md` — added [0.8.1] entry
- `.claude-plugin/plugin.json` — 0.7.0 → 0.8.1
- `package.json` — 0.8.0 → 0.8.1

### Quality gates
`gates-exempt` — pure version bump, no logic changes. Tests: 773 passed / 2 skipped / 0 failed.