### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lossless-claude/lcm",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Never lose context again. lossless-claude compresses Claude Code sessions into searchable memory — every message preserved, every insight remembered.",
   "type": "module",
   "main": "dist/src/memory/index.js",


### PR DESCRIPTION
Version bump to v0.9.0 — Memory Recall Effectiveness (Layer A).

All 956 tests passing. Tag `v0.9.0` already pushed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)