### PR TITLE
fix: bump plugin.json version to 0.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lcm",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Lossless context management — DAG-based summarization that preserves every message",
   "author": {
     "name": "Pedro Almeida",


### PR DESCRIPTION
Missed in the v0.9.0 release — plugin.json still said 0.8.1. Causes cache dir mismatch (system creates 0.7.0 dir instead of 0.9.0).