### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality-gates.yml
+++ b/.github/workflows/quality-gates.yml
@@ -5,6 +5,8 @@ on:
 
 jobs:
   quality-gates:
+    permissions:
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Check quality gate labels


### PR DESCRIPTION
Potential fix for [https://github.com/lossless-claude/lcm/security/code-scanning/11](https://github.com/lossless-claude/lcm/security/code-scanning/11)

In general, the fix is to set an explicit `permissions` block for the workflow or the individual job, restricting `GITHUB_TOKEN` to the minimal rights required. This workflow only needs to read pull request metadata (labels), which is covered by `pull-requests: read`. It does not need to write to PRs, issues, or repo contents.

The single best fix, without changing functionality, is to add a `permissions` block to the `quality-gates` job (or at the root). To keep the change clearly tied to the flagged line, we’ll add it under `jobs: quality-gates:` before `runs-on`. For this job, we can safely limit permissions to:

```yaml
permissions:
  pull-requests: read
```

This allows reading pull request details (including labels) via the context but does not permit writes to PRs or repository contents. No new methods, imports, or other definitions are needed; it is purely a YAML configuration change inside `.github/workflows/quality-gates.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
