### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through a stack trace

### DIFF
--- a/src/daemon/routes/promote-events.ts
+++ b/src/daemon/routes/promote-events.ts
@@ -82,7 +82,9 @@ export function createPromoteEventsHandler(config: DaemonConfig): RouteHandler {
     try {
       cwd = validateCwd(input.cwd);
     } catch (err) {
-      sendJson(res, 400, { error: String(err) });
+      // Log the detailed error server-side and return a generic message to the client
+      safeLogError(err, "validateCwd failed in promote-events");
+      sendJson(res, 400, { error: "cwd is invalid" });
       return;
     }
 
@@ -192,7 +194,9 @@ export function createPromoteEventsHandler(config: DaemonConfig): RouteHandler {
         edb.close();
       }
     } catch (error) {
-      sendJson(res, 500, { error: String(error) });
+      // Log detailed failure but avoid exposing internal error/stack info to the client
+      safeLogError(error, "PromoteEventsHandler failed");
+      sendJson(res, 500, { error: "failed to promote events" });
       return;
     }
 

--- a/src/hooks/events-db.ts
+++ b/src/hooks/events-db.ts
@@ -4,6 +4,7 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import type { ExtractedEvent } from "./extractors.js";
 import { getLcmConnection, closeLcmConnection, isLcmConnectionOpen } from "../db/connection.js";
+import { sanitizeError } from "../daemon/safe-error.js";
 
 /**
  * Tracks which db paths have already had migrations applied in this process.
@@ -83,7 +84,8 @@ export class EventsDb {
         // Migration failed — release the pooled connection so the ref-count
         // doesn't leak. The constructor will re-throw, so callers see the error.
         closeLcmConnection(dbPath);
-        throw e;
+        const message = sanitizeError(e instanceof Error ? e.message : String(e));
+        throw new Error(message);
       }
       _migratedPaths.add(dbPath);
     }
@@ -139,7 +141,8 @@ export class EventsDb {
         this.db.exec("COMMIT");
       } catch (e) {
         try { this.db.exec("ROLLBACK"); } catch { /* ignore */ }
-        throw e;
+        const message = sanitizeError(e instanceof Error ? e.message : String(e));
+        throw new Error(message);
       }
     }
   }


### PR DESCRIPTION
Potential fix for [https://github.com/lossless-claude/lcm/security/code-scanning/2](https://github.com/lossless-claude/lcm/security/code-scanning/2)

To fix the issue, we should stop exposing raw exception messages to clients and instead send generic messages while logging the original errors on the server. We already have `sanitizeError` and `safeLogError` utilities; we can leverage them so behavior stays consistent and debuggability is preserved.

Concretely:

1. In `src/daemon/routes/promote-events.ts`:
   - In the `catch (err)` around `validateCwd`, replace `sendJson(res, 400, { error: String(err) });` with:
     - a server-side log using `safeLogError(err, ...)`, and
     - a generic client error string like `"cwd is invalid"` (or similar), containing no stack/details.
   - In the outer `catch (error)` around database work, replace `sendJson(res, 500, { error: String(error) });` with:
     - a `safeLogError(error, ...)` call, and
     - a generic `"internal server error"`-style message (e.g. `"failed to promote events"`).

2. In `src/hooks/events-db.ts`:
   - In the constructor’s `catch (e)` around `this.migrate()`, we should not change semantics (the constructor is supposed to rethrow). However, to avoid eventual exposure of stack trace text through callers, we can ensure that any error string that escapes is pre-sanitized:
     - Use `throw sanitizeError(e instanceof Error ? e.message : String(e));` or, if we must throw an `Error`, wrap sanitized text in a new `Error`.
     - Since we are allowed to introduce imports of well-known utilities from within this file, but not change existing imports, the cleanest is to import `sanitizeError` from `../daemon/safe-error.js` and use it to sanitize before rethrow. Callers that stringify this error will then only see sanitized content.
   - In the `migrate` method’s `catch (e)` around the migration transaction, likewise sanitize before rethrowing.

This keeps overall behavior (exceptions still propagate) but ensures any message content is stripped of stack-trace-like or path data, and the HTTP handlers no longer echo raw exception messages.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
