### PR TITLE
feat: emit signal:memory_used instruction in UserPromptSubmit hook

### DIFF
--- a/src/hooks/user-prompt.ts
+++ b/src/hooks/user-prompt.ts
@@ -20,6 +20,9 @@ When you recognize a durable insight, call lcm_store immediately:
 - workflow: multi-step process that works
 
 Usage: lcm_store(text: "concise insight with why", tags: ["category:decision"])
+
+When you act on a surfaced memory (use it to inform a decision, avoid a known pitfall, or reference it in your work), emit:
+lcm_store(text: "Acted on memory <id> — <one-line how>", tags: ["signal:memory_used", "memory_id:<id>"])
 </learning-instruction>`;
 
 export async function handleUserPromptSubmit(

--- a/test/hooks/user-prompt.test.ts
+++ b/test/hooks/user-prompt.test.ts
@@ -132,6 +132,20 @@ describe("handleUserPromptSubmit", () => {
     expect(result.stdout).toContain("</learning-instruction>");
   });
 
+  it("includes signal:memory_used recall instruction", async () => {
+    mockEnsureDaemon.mockResolvedValue({ connected: true, port: 3737, spawned: false });
+    const mockClient = {
+      health: vi.fn(),
+      post: vi.fn().mockResolvedValue({ hints: ["some hint"], ids: ["uuid-1"] }),
+    };
+    const result = await handleUserPromptSubmit(
+      JSON.stringify({ prompt: "test", cwd: "/tmp/test", session_id: "s1" }),
+      mockClient as any,
+    );
+    expect(result.stdout).toContain("signal:memory_used");
+    expect(result.stdout).toContain("memory_id:<id>");
+  });
+
   it("includes learning-instruction even when no memory-context hints", async () => {
     mockEnsureDaemon.mockResolvedValue({ connected: true, port: 3737, spawned: false });
     const mockClient = {


### PR DESCRIPTION
## Summary

- Adds recall signal instruction to `LEARNING_INSTRUCTION` template in UserPromptSubmit hook
- Agents are now instructed to emit `signal:memory_used` when they act on a surfaced memory
- Closes the feedback loop for Layer A recall effectiveness measurement

Closes #209

## Comprehension

- **System-level impact:** Every UserPromptSubmit now includes an instruction for agents to emit `signal:memory_used` back to LCM when a surfaced memory influences their work. This creates the data pipeline needed for Layer A to compute recall precision (memories surfaced AND used / memories surfaced).
- **Implicit decisions:** Chose instruction-based approach (Option A) over hook-based detection (Option B) because it's simpler, immediately testable, and sufficient for initial data collection. The signal depends on agent compliance — but since all our agents process learning-instruction blocks, this is reliable enough for v1.

## Test plan

- [x] Existing 10 tests pass
- [x] New test: signal:memory_used and memory_id present in hook output
- [x] Type-check clean
- [ ] After 1 week: lcm_search(tags: signal:memory_used) returns 20+ entries

## AR

AR ran — 4 findings (2 medium, 2 low), all relate to pre-existing test patterns, none to the new code. Verdict: SHIP.

Generated with Claude Code

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>