### PR TITLE
fix(hooks): restore redacted phrase in session-end auth doc comment

### DIFF
--- a/.changeset/fix-session-end-auth-doc.md
+++ b/.changeset/fix-session-end-auth-doc.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Correct the `authHeaders` doc comment in the session-end hook, which had its key phrase replaced by a redaction placeholder, and assert the mocked token directly in the session-end tests instead of deriving it by calling `readAuthToken`.

--- a/src/hooks/session-end.ts
+++ b/src/hooks/session-end.ts
@@ -11,9 +11,10 @@ import { Buffer } from "node:buffer";
  * Build the Authorization header for daemon requests, if a token is available.
  *
  * Auth has been mandatory on the daemon since #109, so every fire-and-forget
- * request must carry the ****** or it fails with HTTP 401 — silently,
- * because a 401 is a normal response, not a socket "error" event. Returns an
- * empty object when no token file exists so callers can spread it unconditionally.
+ * request must carry an `Authorization: Bearer <token>` header or it fails with
+ * HTTP 401 — silently, because a 401 is a normal response, not a socket "error"
+ * event. Returns an empty object when no token file exists so callers can spread
+ * it unconditionally.
  */
 function authHeaders(): Record<string, string> {
   const token = readAuthToken(join(homedir(), ".lossless-claude", "daemon.token"));

--- a/test/hooks/session-end.test.ts
+++ b/test/hooks/session-end.test.ts
@@ -217,7 +217,7 @@ describe("handleSessionEnd", () => {
     for (const path of paths) {
       const calls = httpReqMock.mock.calls.filter((args: any[]) => args[0]?.path === path);
       expect(calls.length, `expected a request to ${path}`).toBeGreaterThan(0);
-      const expected = "Bearer " + readAuthToken("/nonexistent");
+      const expected = "Bearer test-token-abc";
       for (const call of calls) {
         expect(call[0]?.headers?.Authorization).toBe(expected);
       }


### PR DESCRIPTION
Applies the two review comments left on #292. That PR merged at 00:48:06 and the review was submitted at 00:49:59, so neither was addressed before the merge and both are still on `main`.

## 1. Redaction placeholder in a doc comment

`src/hooks/session-end.ts` currently reads:

```
 * request must carry the ****** or it fails with HTTP 401 — silently,
```

A secret-scrubbing pass replaced the phrase with a placeholder. The sentence explains exactly why a missing header fails without a visible error, and it is unreadable at that point. Restored to `an `Authorization: Bearer <token>` header`, with the paragraph reflowed.

## 2. Test derives its expected value from the function under test

`test/hooks/session-end.test.ts:220`:

```ts
const expected = "Bearer " + readAuthToken("/nonexistent");
```

This calls the mocked `readAuthToken` to compute what the assertion should be, which couples the test to the mock argument handling and adds an extra call to the mock that later assertions may count. Replaced with the known mocked value:

```ts
const expected = "Bearer test-token-abc";
```

## Verification

- `npx vitest run test/hooks/session-end.test.ts` — 14 passed
- `npx tsc --noEmit` — clean

No behaviour change; documentation and test hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFLCfp7vPKDyCoSQwGH5eW