### PR TITLE
feat(llm): copilot-process provider + normalized token cost reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @lossless-claude/lcm
 
+## Unreleased
+
+### Added
+- `copilot-process` summarizer provider, backed by the GitHub Copilot CLI. `auto` resolves to it once a client identifies itself as `copilot`; today select it with `LCM_SUMMARY_PROVIDER=copilot-process`.
+- Normalized token cost reporting across all three process providers. `llm_usage_stats` now stores input, cached, and output tokens alongside the total, and `lcm import --replay` prints the breakdown.
+
+### Changed
+- `codex-process` reads its usage from `codex exec --json` instead of the stderr banner, gaining an exact input/cached/output split (the stderr total remains a fallback for older Codex builds).
+- `claude-process` reads `--output-format json`, so it now reports token usage and cost.
+
 ## [0.8.1] - 2026-03-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ All environment variables are optional. The default summarizer mode is `auto`.
 
 | Variable | Default | Description |
 |---|---|---|
-| `LCM_SUMMARY_PROVIDER` | `auto` | `auto`, `claude-process`, `codex-process`, `anthropic`, `openai`, or `disabled` |
+| `LCM_SUMMARY_PROVIDER` | `auto` | `auto`, `claude-process`, `codex-process`, `copilot-process`, `anthropic`, `openai`, or `disabled` |
 | `LCM_SUMMARY_MODEL` | unset | Optional model override for the selected summarizer provider |
 | `LCM_CONTEXT_THRESHOLD` | `0.75` | Context fill ratio that triggers compaction |
 | `LCM_FRESH_TAIL_COUNT` | `32` | Most recent raw messages protected from compaction |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -151,6 +151,7 @@ LCM defaults to `LCM_SUMMARY_PROVIDER=auto`.
 
 - In Claude sessions, `auto` resolves to `claude-process`
 - In Codex sessions, `auto` resolves to `codex-process`
+- In Copilot sessions, `auto` resolves to `copilot-process` — no client identifies itself as `copilot` yet, so today you select it with `LCM_SUMMARY_PROVIDER=copilot-process`
 - If you explicitly set `LCM_SUMMARY_PROVIDER`, that override applies to both CLIs
 
 You can pin a specific summarizer provider and model:
@@ -166,9 +167,33 @@ Valid provider values are:
 - `auto`
 - `claude-process`
 - `codex-process`
+- `copilot-process`
 - `anthropic`
 - `openai`
 - `disabled`
+
+### Token cost reporting
+
+Every process-backed provider reports its usage in a normalized shape, stored in
+`llm_usage_stats` and shown by `lcm import --replay`:
+
+| Provider | Input | Cached | Output | Extra |
+|---|---|---|---|---|
+| `claude-process` | yes | yes | yes | list-price cost in USD |
+| `codex-process` | yes | yes | yes | — |
+| `copilot-process` | no | no | yes | premium requests |
+
+`inputTokens` always counts the full prompt, with `cachedInputTokens` as a subset
+of it, so totals are comparable across providers. The Copilot CLI only exposes
+prompt-token counts in its text output mode, which hard-wraps the summary and is
+therefore unusable here — it reports output tokens and GitHub premium requests
+instead.
+
+Copilot bills per request, not per token: every call costs about 0.33 premium
+requests regardless of size, so a compaction over N chunks costs roughly
+N × 0.33. LCM runs it with no tools, no MCP servers and no repo instructions,
+which keeps the prompt around 6k tokens instead of the ~26k a default session
+spends on tool schemas alone.
 
 Using a cheaper or faster model for summarization can reduce costs, but quality matters because poor summaries compound as they are condensed into higher-level nodes.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -24,6 +24,7 @@ The exception is the summarizer, which you configure explicitly:
 | `disabled` (default) | Nothing |
 | `claude-process` | Messages sent to Anthropic via the `claude` CLI (your Claude subscription) |
 | `codex-process` | Messages sent to OpenAI via the `codex` CLI (your OpenAI subscription) |
+| `copilot-process` | Messages sent to GitHub via the `copilot` CLI (your Copilot subscription) |
 | `anthropic` | Messages sent to Anthropic API (your API key) |
 | `openai` | Messages sent to OpenAI API (your API key) |
 

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -42,7 +42,7 @@ export type DaemonConfig = {
     stalePenalty: number;
     allowStaleOnStrongMatch: boolean;
   };
-  llm: { provider: "auto" | "claude-process" | "codex-process" | "anthropic" | "openai" | "disabled"; model: string; apiKey?: string; baseURL: string };
+  llm: { provider: "auto" | "claude-process" | "codex-process" | "copilot-process" | "anthropic" | "openai" | "disabled"; model: string; apiKey?: string; baseURL: string };
   summarizer: { mock: boolean };
   security: SecurityConfig;
   hooks: { snapshotIntervalSec: number; disableAutoCompact: boolean };
@@ -145,7 +145,7 @@ export function loadDaemonConfig(configPath: string, overrides?: any, env?: Reco
   if (merged.llm.apiKey) merged.llm.apiKey = merged.llm.apiKey.replace(/\$\{(\w+)\}/g, (_: string, k: string) => e[k] ?? "");
 
   // Env var override: LCM_SUMMARY_PROVIDER takes precedence over config
-  const VALID_PROVIDERS = new Set(["auto", "claude-process", "codex-process", "anthropic", "openai", "disabled"]);
+  const VALID_PROVIDERS = new Set(["auto", "claude-process", "codex-process", "copilot-process", "anthropic", "openai", "disabled"]);
   if (e.LCM_SUMMARY_PROVIDER) {
     if (!VALID_PROVIDERS.has(e.LCM_SUMMARY_PROVIDER)) {
       throw new Error(

--- a/src/daemon/routes/compact.ts
+++ b/src/daemon/routes/compact.ts
@@ -251,6 +251,7 @@ export function createCompactHandler(config: DaemonConfig): RouteHandler {
             return { summary: "No messages to compact.", providerId: effectiveProvider, providerLabel };
           }
 
+          let sawReportedUsageModel = false;
           const summarizeWithUsage: LcmSummarizeFn = async (text, aggressive, ctx = {}) => {
             const callTokensSpent = { tokens: 0, input: 0, cached: 0, output: 0 };
             let sawUsage = false;
@@ -265,6 +266,11 @@ export function createCompactHandler(config: DaemonConfig): RouteHandler {
                   callTokensSpent.input += usage.inputTokens ?? 0;
                   callTokensSpent.cached += usage.cachedInputTokens ?? 0;
                   callTokensSpent.output += usage.outputTokens ?? 0;
+                  const reportedModel = usage.model?.trim();
+                  if (!sawReportedUsageModel && reportedModel) {
+                    llmUsage.model = reportedModel;
+                    sawReportedUsageModel = true;
+                  }
                   ctx.onUsage?.(usage);
                 },
               });

--- a/src/daemon/routes/compact.ts
+++ b/src/daemon/routes/compact.ts
@@ -77,30 +77,51 @@ export const JUST_COMPACTED_TTL_MS = 30_000;
 // Guard against concurrent compactions for the same session
 const compactingNow = new Set<string>();
 
-type CompactLlmUsage = {
+export type CompactLlmUsage = {
   provider: string;
   model: string;
   calls: number;
   okCalls: number;
   failedCalls: number;
   tokensSpent: number;
+  tokensInput: number;
+  tokensCached: number;
+  tokensOutput: number;
 };
 
 function createCompactLlmUsage(provider: string, model: string): CompactLlmUsage {
-  return { provider, model, calls: 0, okCalls: 0, failedCalls: 0, tokensSpent: 0 };
+  return {
+    provider, model,
+    calls: 0, okCalls: 0, failedCalls: 0,
+    tokensSpent: 0, tokensInput: 0, tokensCached: 0, tokensOutput: 0,
+  };
 }
 
-function recordCompactLlmUsage(db: DatabaseSync, usage: CompactLlmUsage): void {
+function addTokens(
+  usage: CompactLlmUsage,
+  call: { tokens: number; input: number; cached: number; output: number },
+): void {
+  usage.tokensSpent += call.tokens;
+  usage.tokensInput += call.input;
+  usage.tokensCached += call.cached;
+  usage.tokensOutput += call.output;
+}
+
+export function recordCompactLlmUsage(db: DatabaseSync, usage: CompactLlmUsage): void {
   if (usage.calls === 0) return;
   db.prepare(`
     INSERT INTO llm_usage_stats (
-      provider, model, calls_total, calls_ok, calls_failed, tokens_spent_total, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+      provider, model, calls_total, calls_ok, calls_failed,
+      tokens_spent_total, tokens_input_total, tokens_cached_total, tokens_output_total, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
     ON CONFLICT(provider, model) DO UPDATE SET
       calls_total = calls_total + excluded.calls_total,
       calls_ok = calls_ok + excluded.calls_ok,
       calls_failed = calls_failed + excluded.calls_failed,
       tokens_spent_total = tokens_spent_total + excluded.tokens_spent_total,
+      tokens_input_total = tokens_input_total + excluded.tokens_input_total,
+      tokens_cached_total = tokens_cached_total + excluded.tokens_cached_total,
+      tokens_output_total = tokens_output_total + excluded.tokens_output_total,
       updated_at = datetime('now')
   `).run(
     usage.provider,
@@ -109,6 +130,9 @@ function recordCompactLlmUsage(db: DatabaseSync, usage: CompactLlmUsage): void {
     usage.okCalls,
     usage.failedCalls,
     usage.tokensSpent,
+    usage.tokensInput,
+    usage.tokensCached,
+    usage.tokensOutput,
   );
 }
 
@@ -158,6 +182,7 @@ export function createCompactHandler(config: DaemonConfig): RouteHandler {
     const providerLabels: Record<EffectiveProvider, string> = {
       "claude-process": "Claude (process)",
       "codex-process": "Codex (process)",
+      "copilot-process": "Copilot (process)",
       "anthropic": "Anthropic API",
       "openai": "OpenAI API",
       "disabled": "Disabled",
@@ -227,30 +252,33 @@ export function createCompactHandler(config: DaemonConfig): RouteHandler {
           }
 
           const summarizeWithUsage: LcmSummarizeFn = async (text, aggressive, ctx = {}) => {
-            let callTokensSpent = 0;
+            const callTokensSpent = { tokens: 0, input: 0, cached: 0, output: 0 };
             let sawUsage = false;
             try {
               const summary = await summarize(text, aggressive, {
                 ...ctx,
                 onUsage: (usage) => {
-                  if (usage.provider === "codex-process") {
-                    sawUsage = true;
-                    callTokensSpent += usage.tokensUsed;
-                  }
+                  // Every process-backed provider reports normalized usage;
+                  // only providers that report call onUsage at all.
+                  sawUsage = true;
+                  callTokensSpent.tokens += usage.tokensUsed;
+                  callTokensSpent.input += usage.inputTokens ?? 0;
+                  callTokensSpent.cached += usage.cachedInputTokens ?? 0;
+                  callTokensSpent.output += usage.outputTokens ?? 0;
                   ctx.onUsage?.(usage);
                 },
               });
               if (sawUsage) {
                 llmUsage.calls += 1;
                 llmUsage.okCalls += 1;
-                llmUsage.tokensSpent += callTokensSpent;
+                addTokens(llmUsage, callTokensSpent);
               }
               return summary;
             } catch (error) {
               if (sawUsage) {
                 llmUsage.calls += 1;
                 llmUsage.failedCalls += 1;
-                llmUsage.tokensSpent += callTokensSpent;
+                addTokens(llmUsage, callTokensSpent);
               }
               throw error;
             }

--- a/src/daemon/summarizer.ts
+++ b/src/daemon/summarizer.ts
@@ -1,15 +1,18 @@
 import type { DaemonConfig } from "./config.js";
 import { createClaudeProcessSummarizer } from "../llm/claude-process.js";
 import { createCodexProcessSummarizer } from "../llm/codex-process.js";
+import { createCopilotProcessSummarizer } from "../llm/copilot-process.js";
 import { createMockSummarizer } from "../llm/mock-summarizer.js";
 import type { LcmSummarizeFn } from "../llm/types.js";
 
-export type CompactClient = "claude" | "codex";
+export type CompactClient = "claude" | "codex" | "copilot";
 export type EffectiveProvider = Exclude<DaemonConfig["llm"]["provider"], "auto">;
 
 export function resolveEffectiveProvider(config: DaemonConfig, client?: CompactClient): EffectiveProvider {
   if (config.llm.provider === "auto") {
-    return client === "codex" ? "codex-process" : "claude-process";
+    if (client === "codex") return "codex-process";
+    if (client === "copilot") return "copilot-process";
+    return "claude-process";
   }
   return config.llm.provider;
 }
@@ -21,9 +24,14 @@ export async function createSummarizer(
   // Mock summarizer for E2E testing — deterministic, no LLM calls
   if (config.summarizer?.mock) return createMockSummarizer();
   if (provider === "disabled") return null;
+  // No model passed on purpose: config.llm.model is shared across providers, so
+  // a model pinned for codex/openai must not leak into the claude CLI.
   if (provider === "claude-process") return createClaudeProcessSummarizer();
   if (provider === "codex-process") {
     return createCodexProcessSummarizer({ model: config.llm.model });
+  }
+  if (provider === "copilot-process") {
+    return createCopilotProcessSummarizer({ model: config.llm.model });
   }
   if (provider === "openai") {
     const { createOpenAISummarizer } = await import("../llm/openai.js");

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -26,6 +26,19 @@ type SummaryParentEdgeRow = {
   parent_summary_id: string;
 };
 
+/**
+ * Adds the normalized token breakdown to databases created before providers
+ * reported input/cached/output separately. Existing rows keep their totals.
+ */
+function ensureLlmUsageBreakdownColumns(db: DatabaseSync): void {
+  const columns = db.prepare(`PRAGMA table_info(llm_usage_stats)`).all() as SummaryColumnInfo[];
+  for (const name of ["tokens_input_total", "tokens_cached_total", "tokens_output_total"]) {
+    if (!columns.some((col) => col.name === name)) {
+      db.exec(`ALTER TABLE llm_usage_stats ADD COLUMN ${name} INTEGER NOT NULL DEFAULT 0`);
+    }
+  }
+}
+
 function ensureSummaryDepthColumn(db: DatabaseSync): void {
   const summaryColumns = db.prepare(`PRAGMA table_info(summaries)`).all() as SummaryColumnInfo[];
   const hasDepth = summaryColumns.some((col) => col.name === "depth");
@@ -570,10 +583,15 @@ export function runLcmMigrations(
       calls_ok INTEGER NOT NULL DEFAULT 0,
       calls_failed INTEGER NOT NULL DEFAULT 0,
       tokens_spent_total INTEGER NOT NULL DEFAULT 0,
+      tokens_input_total INTEGER NOT NULL DEFAULT 0,
+      tokens_cached_total INTEGER NOT NULL DEFAULT 0,
+      tokens_output_total INTEGER NOT NULL DEFAULT 0,
       updated_at TEXT NOT NULL DEFAULT (datetime('now')),
       PRIMARY KEY (provider, model)
     );
   `);
+
+  ensureLlmUsageBreakdownColumns(db);
 
   // Recall surfacing log — tracks when promoted memories are shown in user-prompt context
   db.exec(`

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -76,6 +76,15 @@ function addCodexProcessChecks(results: CheckResult[], deps: DoctorDeps): void {
 }
 
 
+function addCopilotProcessChecks(results: CheckResult[], deps: DoctorDeps): void {
+  if (checkBinary(deps, "copilot")) {
+    results.push({ name: "copilot-process", category: "Summarizer", status: "pass", message: "copilot CLI found" });
+  } else {
+    results.push({ name: "copilot-process", category: "Summarizer", status: "fail", message: "copilot CLI not found\n     Fix: npm install -g @github/copilot" });
+  }
+}
+
+
 function testMcpHandshake(): Promise<CheckResult> {
   return new Promise((resolve) => {
     const initMsg = JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: { protocolVersion: "2024-11-05", capabilities: {}, clientInfo: { name: "doctor", version: "0.1" } } });
@@ -189,7 +198,7 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>, verbose = false
     category: "Stack",
     status: "pass",
     message: config.summarizer === "auto"
-      ? "Summarizer: auto (Claude->claude-process, Codex->codex-process)"
+      ? "Summarizer: auto (Claude->claude-process, Codex->codex-process, Copilot->copilot-process)"
       : `Summarizer: ${config.summarizer}`,
   });
 
@@ -407,10 +416,13 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>, verbose = false
   if (config.summarizer === "auto") {
     addClaudeProcessChecks(results, deps);
     addCodexProcessChecks(results, deps);
+    addCopilotProcessChecks(results, deps);
   } else if (config.summarizer === "claude-process") {
     addClaudeProcessChecks(results, deps);
   } else if (config.summarizer === "codex-process") {
     addCodexProcessChecks(results, deps);
+  } else if (config.summarizer === "copilot-process") {
+    addCopilotProcessChecks(results, deps);
   } else if (config.summarizer === "anthropic") {
     if (process.env.ANTHROPIC_API_KEY) {
       results.push({ name: "anthropic-key", category: "Summarizer", status: "pass", message: "ANTHROPIC_API_KEY set" });

--- a/src/import-summary.ts
+++ b/src/import-summary.ts
@@ -55,6 +55,11 @@ export function printImportSummary(
         `${result.replayUsage.calls} (${result.replayUsage.okCalls} ok, ${result.replayUsage.failedCalls} failed)`,
       ],
       ["Tokens spent", formatNumber(result.replayUsage.tokensSpent)],
+      [
+        "  breakdown",
+        `${formatNumber(result.replayUsage.tokensInput)} in (${formatNumber(result.replayUsage.tokensCached)} cached), ` +
+        `${formatNumber(result.replayUsage.tokensOutput)} out`,
+      ],
       ["Avg per session", formatNumber(avgPerSession)],
     ];
     const labelWidth = Math.max(...rows.map(([l]) => l.length));

--- a/src/import.ts
+++ b/src/import.ts
@@ -190,9 +190,6 @@ function accumulateReplayUsage(result: ImportResult, usage: CompactLlmUsage | un
   if (!result.replayUsage) {
     result.replayUsage = {
       ...usage,
-      tokensInput: usage.tokensInput ?? 0,
-      tokensCached: usage.tokensCached ?? 0,
-      tokensOutput: usage.tokensOutput ?? 0,
     };
     return;
   }
@@ -206,9 +203,9 @@ function accumulateReplayUsage(result: ImportResult, usage: CompactLlmUsage | un
   result.replayUsage.okCalls += usage.okCalls;
   result.replayUsage.failedCalls += usage.failedCalls;
   result.replayUsage.tokensSpent += usage.tokensSpent;
-  result.replayUsage.tokensInput += usage.tokensInput ?? 0;
-  result.replayUsage.tokensCached += usage.tokensCached ?? 0;
-  result.replayUsage.tokensOutput += usage.tokensOutput ?? 0;
+  result.replayUsage.tokensInput += usage.tokensInput;
+  result.replayUsage.tokensCached += usage.tokensCached;
+  result.replayUsage.tokensOutput += usage.tokensOutput;
 }
 
 /**

--- a/src/import.ts
+++ b/src/import.ts
@@ -42,6 +42,9 @@ export interface ImportResult {
     okCalls: number;
     failedCalls: number;
     tokensSpent: number;
+    tokensInput: number;
+    tokensCached: number;
+    tokensOutput: number;
   };
 }
 
@@ -177,12 +180,20 @@ type CompactLlmUsage = {
   okCalls: number;
   failedCalls: number;
   tokensSpent: number;
+  tokensInput: number;
+  tokensCached: number;
+  tokensOutput: number;
 };
 
 function accumulateReplayUsage(result: ImportResult, usage: CompactLlmUsage | undefined): void {
   if (!usage || usage.calls <= 0) return;
   if (!result.replayUsage) {
-    result.replayUsage = { ...usage };
+    result.replayUsage = {
+      ...usage,
+      tokensInput: usage.tokensInput ?? 0,
+      tokensCached: usage.tokensCached ?? 0,
+      tokensOutput: usage.tokensOutput ?? 0,
+    };
     return;
   }
   if (result.replayUsage.provider !== usage.provider) {
@@ -195,6 +206,9 @@ function accumulateReplayUsage(result: ImportResult, usage: CompactLlmUsage | un
   result.replayUsage.okCalls += usage.okCalls;
   result.replayUsage.failedCalls += usage.failedCalls;
   result.replayUsage.tokensSpent += usage.tokensSpent;
+  result.replayUsage.tokensInput += usage.tokensInput ?? 0;
+  result.replayUsage.tokensCached += usage.tokensCached ?? 0;
+  result.replayUsage.tokensOutput += usage.tokensOutput ?? 0;
 }
 
 /**

--- a/src/llm/claude-process.ts
+++ b/src/llm/claude-process.ts
@@ -1,65 +1,192 @@
-import { spawn } from "node:child_process";
-import type { LcmSummarizeFn, SummarizeContext } from "./types.js";
-import {
-  LCM_SUMMARIZER_SYSTEM_PROMPT,
-  buildLeafSummaryPrompt,
-  buildCondensedSummaryPrompt,
-  resolveTargetTokens,
-} from "../summarize.js";
+import { spawn as defaultSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "./types.js";
+import { LCM_SUMMARIZER_SYSTEM_PROMPT } from "../summarize.js";
+import { buildSummaryPrompt } from "./prompt.js";
 
 const HAIKU_MODEL = "claude-haiku-4-5-20251001";
 const TIMEOUT_MS = 120_000;
+const STDERR_ERROR_MAX_CHARS = 2_000;
 
-export function createClaudeProcessSummarizer(): LcmSummarizeFn {
+type ClaudeModelUsage = {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadInputTokens?: number;
+  cacheCreationInputTokens?: number;
+  costUSD?: number;
+};
+
+type ClaudeResult = {
+  type?: string;
+  subtype?: string;
+  is_error?: boolean;
+  result?: string;
+  total_cost_usd?: number;
+  modelUsage?: Record<string, ClaudeModelUsage>;
+};
+
+export type ClaudeJsonOutcome = {
+  content: string;
+  isError: boolean;
+  usage?: SummarizerUsage;
+};
+
+/**
+ * Reads the single result object from `claude --print --output-format json`.
+ *
+ * Claude splits the prompt across three counters — `inputTokens` covers only
+ * the uncached part, with cache reads and cache writes reported separately —
+ * so they are summed into the normalized `inputTokens`, and the cache-read
+ * share is surfaced as `cachedInputTokens`.
+ */
+export function parseClaudeResult(stdout: string, fallbackModel: string): ClaudeJsonOutcome | undefined {
+  const trimmed = stdout.trim();
+  if (!trimmed.startsWith("{")) return undefined;
+
+  let result: ClaudeResult;
+  try {
+    result = JSON.parse(trimmed) as ClaudeResult;
+  } catch {
+    return undefined;
+  }
+
+  const entries = Object.entries(result.modelUsage ?? {});
+  let usage: SummarizerUsage | undefined;
+  if (entries.length > 0) {
+    let inputTokens = 0;
+    let cachedInputTokens = 0;
+    let outputTokens = 0;
+    let costUsd = 0;
+    for (const [, m] of entries) {
+      inputTokens += (m.inputTokens ?? 0) + (m.cacheReadInputTokens ?? 0) + (m.cacheCreationInputTokens ?? 0);
+      cachedInputTokens += m.cacheReadInputTokens ?? 0;
+      outputTokens += m.outputTokens ?? 0;
+      costUsd += m.costUSD ?? 0;
+    }
+    usage = {
+      provider: "claude-process",
+      model: entries[0][0] || fallbackModel,
+      inputTokens,
+      cachedInputTokens,
+      outputTokens,
+      tokensUsed: inputTokens + outputTokens,
+      costUsd: result.total_cost_usd ?? costUsd,
+    };
+  }
+
+  return {
+    content: typeof result.result === "string" ? result.result.trim() : "",
+    isError: result.is_error === true,
+    usage,
+  };
+}
+
+function buildClaudeExitError(code: number | null, stderr: string, stdout: string): Error {
+  const exitLabel = code ?? "unknown";
+  const detail = (stderr.trim() || stdout.trim()) || "no output";
+  const excerpt =
+    detail.length > STDERR_ERROR_MAX_CHARS
+      ? `[...] ${detail.slice(-STDERR_ERROR_MAX_CHARS)}`
+      : detail;
+  return new Error(`claude exited ${exitLabel}: ${excerpt}`);
+}
+
+function friendlyMissingClaudeError(): Error {
+  return new Error([
+    "Claude Code CLI is not installed or not on PATH.",
+    "Install it first, for example: npm install -g @anthropic-ai/claude-code",
+  ].join("\n"));
+}
+
+function normalizeSpawnError(error: unknown): Error {
+  if (error && typeof error === "object" && (error as { code?: unknown }).code === "ENOENT") {
+    return friendlyMissingClaudeError();
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export function buildClaudeArgs(model: string): string[] {
+  return [
+    "--print",
+    "--output-format", "json",
+    "--model", model,
+    "--no-session-persistence",
+    "--system-prompt", LCM_SUMMARIZER_SYSTEM_PROMPT,
+    "--tools", "",
+    "--disable-slash-commands",
+  ];
+}
+
+type ClaudeProcessDeps = {
+  model?: string;
+  spawn?: typeof defaultSpawn;
+  timeoutMs?: number;
+};
+
+export function createClaudeProcessSummarizer(opts: ClaudeProcessDeps = {}): LcmSummarizeFn {
+  const deps = {
+    model: opts.model?.trim() || HAIKU_MODEL,
+    spawn: opts.spawn ?? defaultSpawn,
+    timeoutMs: opts.timeoutMs ?? TIMEOUT_MS,
+  };
+
   return async function summarize(text: string, aggressive?: boolean, ctx: SummarizeContext = {}): Promise<string> {
-    const estimatedInputTokens = Math.ceil(text.length / 4);
-    const targetTokens = ctx.targetTokens ?? resolveTargetTokens({
-      inputTokens: estimatedInputTokens,
-      mode: aggressive ? "aggressive" : "normal",
-      isCondensed: ctx.isCondensed ?? false,
-      condensedTargetTokens: 2000,
-    });
-
-    const prompt = ctx.isCondensed
-      ? buildCondensedSummaryPrompt({ text, targetTokens, depth: ctx.depth ?? 1 })
-      : buildLeafSummaryPrompt({ text, mode: aggressive ? "aggressive" : "normal", targetTokens });
+    const prompt = buildSummaryPrompt(text, aggressive, ctx);
 
     return new Promise((resolve, reject) => {
-      const proc = spawn("claude", [
-        "--print",
-        "--model", HAIKU_MODEL,
-        "--no-session-persistence",
-        "--system-prompt", LCM_SUMMARIZER_SYSTEM_PROMPT,
-        "--tools", "",
-        "--disable-slash-commands",
-      ], {
-        stdio: ["pipe", "pipe", "pipe"],
-      });
+      let proc: ChildProcessWithoutNullStreams;
+      try {
+        proc = deps.spawn("claude", buildClaudeArgs(deps.model), { stdio: ["pipe", "pipe", "pipe"] });
+      } catch (error) {
+        reject(normalizeSpawnError(error));
+        return;
+      }
 
       let stdout = "";
       let stderr = "";
+      let finished = false;
 
       proc.stdout.on("data", (d: Buffer) => { stdout += d.toString(); });
       proc.stderr.on("data", (d: Buffer) => { stderr += d.toString(); });
 
       const timer = setTimeout(() => {
-        proc.kill();
-        reject(new Error(`claude process timed out after ${TIMEOUT_MS / 1000}s`));
-      }, TIMEOUT_MS);
-
-      proc.on("close", (code: number | null) => {
-        clearTimeout(timer);
-        const out = stdout.trim();
-        if (code === 0 && out) {
-          resolve(out);
-        } else {
-          reject(new Error(`claude exited ${code}: ${stderr.slice(0, 200) || "no output"}`));
+        if (finished) return;
+        finished = true;
+        try {
+          proc.kill();
+        } catch {
+          // ignore kill failures during timeout cleanup
         }
-      });
+        reject(new Error(`claude process timed out after ${Math.round(deps.timeoutMs / 1000)}s`));
+      }, deps.timeoutMs);
 
       proc.on("error", (err) => {
+        if (finished) return;
+        finished = true;
         clearTimeout(timer);
-        reject(err);
+        reject(normalizeSpawnError(err));
+      });
+
+      proc.on("close", (code: number | null) => {
+        if (finished) return;
+        finished = true;
+        clearTimeout(timer);
+
+        const outcome = parseClaudeResult(stdout, deps.model);
+        if (outcome?.usage) ctx.onUsage?.(outcome.usage);
+
+        if (code !== 0 || outcome?.isError) {
+          reject(buildClaudeExitError(code, stderr, stdout));
+          return;
+        }
+        if (!outcome) {
+          reject(new Error(`claude produced unparseable output: ${stdout.slice(0, 200) || "empty"}`));
+          return;
+        }
+        if (!outcome.content) {
+          reject(new Error("claude output was empty"));
+          return;
+        }
+        resolve(outcome.content);
       });
 
       proc.stdin.write(prompt);

--- a/src/llm/codex-process.ts
+++ b/src/llm/codex-process.ts
@@ -2,13 +2,8 @@ import { spawn as defaultSpawn, type ChildProcessWithoutNullStreams, type SpawnO
 import { mkdtempSync as defaultMkdtempSync, readFileSync as defaultReadFileSync, rmSync as defaultRmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import type { LcmSummarizeFn, SummarizeContext } from "./types.js";
-import {
-  LCM_SUMMARIZER_SYSTEM_PROMPT,
-  buildLeafSummaryPrompt,
-  buildCondensedSummaryPrompt,
-  resolveTargetTokens,
-} from "../summarize.js";
+import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "./types.js";
+import { buildSummaryPromptWithSystem } from "./prompt.js";
 
 const TIMEOUT_MS = 120_000;
 const STDERR_ERROR_MAX_CHARS = 2_000;
@@ -28,7 +23,48 @@ const STDERR_ERROR_MAX_CHARS = 2_000;
 // error message, which always comes after it.
 const BANNER_END_MARKER = "session id:";
 
-function parseTokensUsed(stderr: string): number | undefined {
+type CodexTurnUsage = {
+  input_tokens?: number;
+  cached_input_tokens?: number;
+  output_tokens?: number;
+};
+
+/**
+ * Reads the `turn.completed` event from `codex exec --json`.
+ *
+ * Codex counts `cached_input_tokens` as a SUBSET of `input_tokens`, so the
+ * total it prints as "tokens used" equals input + output. The summary itself
+ * arrives via --output-last-message, so stdout is free for the event stream.
+ */
+export function parseCodexUsage(stdout: string, model?: string): SummarizerUsage | undefined {
+  let usage: CodexTurnUsage | undefined;
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+    try {
+      const event = JSON.parse(trimmed) as { type?: string; usage?: CodexTurnUsage };
+      if (event.type === "turn.completed" && event.usage) usage = event.usage;
+    } catch {
+      continue; // partial or non-JSON line — ignore
+    }
+  }
+  if (!usage) return undefined;
+
+  const inputTokens = usage.input_tokens ?? 0;
+  const outputTokens = usage.output_tokens ?? 0;
+  return {
+    provider: "codex-process",
+    model,
+    inputTokens,
+    cachedInputTokens: usage.cached_input_tokens,
+    outputTokens,
+    tokensUsed: inputTokens + outputTokens,
+  };
+}
+
+/** Fallback for older Codex builds that only print a "tokens used" total on stderr. */
+export function parseLegacyCodexTokens(stderr: string): number | undefined {
   const normalized = stderr.replace(/\r\n/g, "\n");
   const match = normalized.match(/tokens used\s*\n\s*([0-9][0-9,]*)/i);
   if (!match) return undefined;
@@ -50,13 +86,41 @@ function skipCodexBanner(stderr: string): string {
   return stderr.trim();
 }
 
+/**
+ * With `--json`, the real failure is a JSONL event on stdout — stderr carries
+ * only unrelated transport noise — so stdout is the primary error source.
+ */
+export function extractCodexErrorEvents(stdout: string): string {
+  const messages: string[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{") || !/error|failed/i.test(trimmed)) continue;
+    try {
+      const event = JSON.parse(trimmed) as {
+        type?: string;
+        message?: unknown;
+        error?: { message?: unknown };
+      };
+      if (event.type === "turn.failed" && typeof event.error?.message === "string") {
+        messages.push(event.error.message);
+      } else if (event.type === "error" && typeof event.message === "string") {
+        messages.push(event.message);
+      }
+    } catch {
+      // ignore
+    }
+  }
+  // turn.failed repeats the error event verbatim; keep one copy.
+  return [...new Set(messages)].join("\n");
+}
+
 function isUsageLimitError(text: string): boolean {
   return /usage limit|rate limit|quota|too many requests|\b429\b/i.test(text);
 }
 
-function buildCodexExitError(code: number | null, stderr: string): Error {
+function buildCodexExitError(code: number | null, stderr: string, stdout: string): Error {
   const exitLabel = code ?? "unknown";
-  const detail = skipCodexBanner(stderr);
+  const detail = extractCodexErrorEvents(stdout) || skipCodexBanner(stderr);
   if (!detail) {
     return new Error(`codex exited ${exitLabel}: no output`);
   }
@@ -82,22 +146,6 @@ type CodexProcessDeps = {
   timeoutMs?: number;
 };
 
-function buildPrompt(text: string, aggressive: boolean | undefined, ctx: SummarizeContext): string {
-  const estimatedInputTokens = Math.ceil(text.length / 4);
-  const targetTokens = ctx.targetTokens ?? resolveTargetTokens({
-    inputTokens: estimatedInputTokens,
-    mode: aggressive ? "aggressive" : "normal",
-    isCondensed: ctx.isCondensed ?? false,
-    condensedTargetTokens: 2000,
-  });
-
-  const summaryPrompt = ctx.isCondensed
-    ? buildCondensedSummaryPrompt({ text, targetTokens, depth: ctx.depth ?? 1 })
-    : buildLeafSummaryPrompt({ text, mode: aggressive ? "aggressive" : "normal", targetTokens });
-
-  return [LCM_SUMMARIZER_SYSTEM_PROMPT, summaryPrompt].filter(Boolean).join("\n\n");
-}
-
 function friendlyMissingCodexError(): Error {
   return new Error([
     "Codex CLI is not installed or not on PATH.",
@@ -117,6 +165,7 @@ function buildArgs(outputPath: string, model?: string): string[] {
   const args = [
     "exec",
     "-",
+    "--json",
     "--skip-git-repo-check",
     "--sandbox",
     "read-only",
@@ -199,16 +248,11 @@ function runCodexSummarizer(
       clearTimeout(timer);
 
       try {
-        const tokensUsed = parseTokensUsed(stderr);
-        if (tokensUsed !== undefined) {
-          onUsage?.({
-            provider: "codex-process",
-            model: deps.model,
-            tokensUsed,
-          });
-        }
+        const usage = parseCodexUsage(stdout, deps.model)
+          ?? legacyUsage(parseLegacyCodexTokens(stderr), deps.model);
+        if (usage) onUsage?.(usage);
         if (code !== 0) {
-          throw buildCodexExitError(code, stderr);
+          throw buildCodexExitError(code, stderr, stdout);
         }
         const summary = deps.readFileSync(outputPath, "utf-8").trim();
         if (!summary) {
@@ -227,6 +271,10 @@ function runCodexSummarizer(
   });
 }
 
+function legacyUsage(tokensUsed: number | undefined, model?: string): SummarizerUsage | undefined {
+  return tokensUsed === undefined ? undefined : { provider: "codex-process", model, tokensUsed };
+}
+
 export function createCodexProcessSummarizer(opts: CodexProcessDeps = {}): LcmSummarizeFn {
   const deps = {
     model: opts.model,
@@ -239,7 +287,7 @@ export function createCodexProcessSummarizer(opts: CodexProcessDeps = {}): LcmSu
   };
 
   return async function summarize(text, aggressive, ctx = {}): Promise<string> {
-    const prompt = buildPrompt(text, aggressive, ctx);
+    const prompt = buildSummaryPromptWithSystem(text, aggressive, ctx);
     return runCodexSummarizer(prompt, deps, ctx.onUsage);
   };
 }

--- a/src/llm/copilot-process.ts
+++ b/src/llm/copilot-process.ts
@@ -1,0 +1,274 @@
+import { spawn as defaultSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "./types.js";
+import { buildSummaryPromptWithSystem } from "./prompt.js";
+
+const TIMEOUT_MS = 120_000;
+const STDERR_ERROR_MAX_CHARS = 2_000;
+
+// The Copilot CLI takes its prompt as an argv value: `-p -` is read as the
+// literal string "-", not as stdin. argv is capped by ARG_MAX (~1MB on macOS
+// and Linux), so refuse oversized prompts with a clear message instead of
+// letting the spawn fail with E2BIG.
+const MAX_PROMPT_BYTES = 200_000;
+
+type CopilotResultEvent = {
+  type: "result";
+  exitCode?: number;
+  usage?: {
+    premiumRequests?: number;
+  };
+};
+
+type CopilotMessageEvent = {
+  type: "assistant.message";
+  data?: {
+    content?: string;
+    outputTokens?: number;
+  };
+};
+
+export type CopilotJsonlOutcome = {
+  content: string;
+  outputTokens?: number;
+  premiumRequests?: number;
+};
+
+/**
+ * Reads Copilot's JSONL stream (`--output-format json`).
+ *
+ * Text mode is not usable here: it hard-wraps the answer at ~80 columns and
+ * prefixes it with a bullet, which reflows the summary. The trade-off is that
+ * JSON mode reports only output tokens and premium requests — the per-model
+ * "N in, N cached" breakdown exists in text mode's stderr only, and the two
+ * modes are mutually exclusive.
+ */
+export function parseCopilotJsonl(stdout: string): CopilotJsonlOutcome {
+  let content = "";
+  let outputTokens: number | undefined;
+  let premiumRequests: number | undefined;
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{")) continue;
+
+    let event: unknown;
+    try {
+      event = JSON.parse(trimmed);
+    } catch {
+      continue; // partial or non-JSON line — ignore
+    }
+    if (!event || typeof event !== "object") continue;
+
+    const type = (event as { type?: unknown }).type;
+    if (type === "assistant.message") {
+      const data = (event as CopilotMessageEvent).data;
+      if (typeof data?.content === "string" && data.content.trim()) {
+        content = data.content;
+      }
+      if (typeof data?.outputTokens === "number") {
+        outputTokens = (outputTokens ?? 0) + data.outputTokens;
+      }
+    } else if (type === "result") {
+      const premium = (event as CopilotResultEvent).usage?.premiumRequests;
+      if (typeof premium === "number") {
+        premiumRequests = (premiumRequests ?? 0) + premium;
+      }
+    }
+  }
+
+  return { content: content.trim(), outputTokens, premiumRequests };
+}
+
+function toUsage(outcome: CopilotJsonlOutcome, model?: string): SummarizerUsage | undefined {
+  if (outcome.outputTokens === undefined && outcome.premiumRequests === undefined) {
+    return undefined;
+  }
+  return {
+    provider: "copilot-process",
+    model,
+    // Copilot's JSONL stream carries no prompt-token counts, so inputTokens and
+    // cachedInputTokens stay undefined and tokensUsed covers output only.
+    outputTokens: outcome.outputTokens,
+    tokensUsed: outcome.outputTokens ?? 0,
+    premiumRequests: outcome.premiumRequests,
+  };
+}
+
+function isUsageLimitError(text: string): boolean {
+  return /usage limit|rate limit|quota|too many requests|premium request|\b429\b/i.test(text);
+}
+
+function buildCopilotExitError(code: number | null, stderr: string, stdout: string): Error {
+  const exitLabel = code ?? "unknown";
+  const detail = (stderr.trim() || extractCopilotErrorEvents(stdout)).trim();
+  if (!detail) {
+    return new Error(`copilot exited ${exitLabel}: no output`);
+  }
+  const excerpt =
+    detail.length > STDERR_ERROR_MAX_CHARS
+      ? `[...] ${detail.slice(-STDERR_ERROR_MAX_CHARS)}`
+      : detail;
+  if (isUsageLimitError(detail)) {
+    return new Error(
+      `copilot usage limit reached (exit ${exitLabel}) — wait for the quota to reset or switch models before retrying.\n${excerpt}`,
+    );
+  }
+  return new Error(`copilot exited ${exitLabel}: ${excerpt}`);
+}
+
+/** Copilot reports failures as JSONL events on stdout, leaving stderr empty. */
+function extractCopilotErrorEvents(stdout: string): string {
+  const messages: string[] = [];
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("{") || !/error/i.test(trimmed)) continue;
+    try {
+      const event = JSON.parse(trimmed) as { type?: string; data?: { message?: unknown }; error?: unknown };
+      if (typeof event.data?.message === "string") messages.push(event.data.message);
+      else if (typeof event.error === "string") messages.push(event.error);
+    } catch {
+      // ignore
+    }
+  }
+  return messages.join("\n");
+}
+
+function friendlyMissingCopilotError(): Error {
+  return new Error([
+    "Copilot CLI is not installed or not on PATH.",
+    "Install it first, for example: npm install -g @github/copilot",
+    "Then authenticate with: copilot login",
+  ].join("\n"));
+}
+
+function normalizeSpawnError(error: unknown): Error {
+  if (error && typeof error === "object" && (error as { code?: unknown }).code === "ENOENT") {
+    return friendlyMissingCopilotError();
+  }
+  return error instanceof Error ? error : new Error(String(error));
+}
+
+export function buildCopilotArgs(prompt: string, model?: string): string[] {
+  const args = [
+    "-p",
+    prompt,
+    "--output-format",
+    "json",
+    "--no-color",
+    // Keep the run hermetic: no repo AGENTS.md, no MCP servers, no tools, no
+    // interactive questions, no log files, no self-update mid-summarization.
+    "--no-custom-instructions",
+    "--disable-builtin-mcps",
+    // An EMPTY --available-tools= is silently ignored by the CLI, which leaves
+    // bash and file writes reachable from a summarization prompt. Naming a
+    // tool that does not exist is what actually yields a toolless model.
+    "--available-tools=__none__",
+    "--no-ask-user",
+    "--log-level",
+    "none",
+    "--no-auto-update",
+    "--stream",
+    "off",
+  ];
+
+  if (model && model.trim()) {
+    args.push("--model", model.trim());
+  }
+
+  return args;
+}
+
+type CopilotProcessDeps = {
+  model?: string;
+  spawn?: typeof defaultSpawn;
+  timeoutMs?: number;
+};
+
+function runCopilotSummarizer(
+  prompt: string,
+  deps: Required<Pick<CopilotProcessDeps, "spawn" | "timeoutMs">> & { model?: string },
+  onUsage?: SummarizeContext["onUsage"],
+): Promise<string> {
+  const promptBytes = Buffer.byteLength(prompt, "utf-8");
+  if (promptBytes > MAX_PROMPT_BYTES) {
+    return Promise.reject(new Error(
+      `copilot prompt is ${promptBytes} bytes, over the ${MAX_PROMPT_BYTES}-byte limit — ` +
+      "the Copilot CLI only accepts prompts as command-line arguments. Lower compaction.leafTokens.",
+    ));
+  }
+
+  return new Promise((resolve, reject) => {
+    let child: ChildProcessWithoutNullStreams;
+
+    try {
+      child = deps.spawn("copilot", buildCopilotArgs(prompt, deps.model), {
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (error) {
+      reject(normalizeSpawnError(error));
+      return;
+    }
+
+    let stdout = "";
+    let stderr = "";
+    let finished = false;
+
+    const timer = setTimeout(() => {
+      if (finished) return;
+      finished = true;
+      try {
+        child.kill();
+      } catch {
+        // ignore kill failures during timeout cleanup
+      }
+      reject(new Error(`copilot process timed out after ${Math.round(deps.timeoutMs / 1000)}s`));
+    }, deps.timeoutMs);
+
+    child.stdout.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+
+    child.on("error", (error) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+      reject(normalizeSpawnError(error));
+    });
+
+    child.on("close", (code: number | null) => {
+      if (finished) return;
+      finished = true;
+      clearTimeout(timer);
+
+      const outcome = parseCopilotJsonl(stdout);
+      const usage = toUsage(outcome, deps.model);
+      if (usage) onUsage?.(usage);
+
+      if (code !== 0) {
+        reject(buildCopilotExitError(code, stderr, stdout));
+        return;
+      }
+      if (!outcome.content) {
+        reject(new Error("copilot output was empty"));
+        return;
+      }
+      resolve(outcome.content);
+    });
+
+    // The prompt travels in argv; close stdin so copilot never waits on it.
+    child.stdin.end();
+  });
+}
+
+export function createCopilotProcessSummarizer(opts: CopilotProcessDeps = {}): LcmSummarizeFn {
+  const deps = {
+    model: opts.model,
+    spawn: opts.spawn ?? defaultSpawn,
+    timeoutMs: opts.timeoutMs ?? TIMEOUT_MS,
+  };
+
+  return async function summarize(text, aggressive, ctx = {}): Promise<string> {
+    // The Copilot CLI has no system-prompt flag, so the preamble is folded in.
+    const prompt = buildSummaryPromptWithSystem(text, aggressive, ctx);
+    return runCopilotSummarizer(prompt, deps, ctx.onUsage);
+  };
+}

--- a/src/llm/prompt.ts
+++ b/src/llm/prompt.ts
@@ -1,0 +1,37 @@
+import type { SummarizeContext } from "./types.js";
+import {
+  LCM_SUMMARIZER_SYSTEM_PROMPT,
+  buildLeafSummaryPrompt,
+  buildCondensedSummaryPrompt,
+  resolveTargetTokens,
+} from "../summarize.js";
+
+/** The summarization prompt, without the system preamble. */
+export function buildSummaryPrompt(
+  text: string,
+  aggressive: boolean | undefined,
+  ctx: SummarizeContext,
+): string {
+  const estimatedInputTokens = Math.ceil(text.length / 4);
+  const targetTokens = ctx.targetTokens ?? resolveTargetTokens({
+    inputTokens: estimatedInputTokens,
+    mode: aggressive ? "aggressive" : "normal",
+    isCondensed: ctx.isCondensed ?? false,
+    condensedTargetTokens: 2000,
+  });
+
+  return ctx.isCondensed
+    ? buildCondensedSummaryPrompt({ text, targetTokens, depth: ctx.depth ?? 1 })
+    : buildLeafSummaryPrompt({ text, mode: aggressive ? "aggressive" : "normal", targetTokens });
+}
+
+/** The same prompt with the system preamble prepended, for CLIs with no system-prompt flag. */
+export function buildSummaryPromptWithSystem(
+  text: string,
+  aggressive: boolean | undefined,
+  ctx: SummarizeContext,
+): string {
+  return [LCM_SUMMARIZER_SYSTEM_PROMPT, buildSummaryPrompt(text, aggressive, ctx)]
+    .filter(Boolean)
+    .join("\n\n");
+}

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,14 +1,35 @@
+export type SummarizerProvider = "claude-process" | "codex-process" | "copilot-process";
+
+/**
+ * Normalized token accounting, shared by every process-backed summarizer.
+ *
+ * Conventions (pinned so numbers stay comparable across providers):
+ * - `inputTokens` is the FULL prompt cost, cached portion included.
+ * - `cachedInputTokens` is a SUBSET of `inputTokens`, never additive.
+ * - `tokensUsed` is `inputTokens + outputTokens`, which preserves the value
+ *   the Codex CLI itself prints as "tokens used".
+ *
+ * Fields a provider cannot report are left undefined rather than zeroed, so
+ * callers can tell "no cache" apart from "cache not reported".
+ */
+export type SummarizerUsage = {
+  provider: SummarizerProvider;
+  model?: string;
+  inputTokens?: number;
+  cachedInputTokens?: number;
+  outputTokens?: number;
+  tokensUsed: number;
+  /** Claude CLI only — list-price cost of the call. */
+  costUsd?: number;
+  /** Copilot CLI only — GitHub's billing unit, not a token count. */
+  premiumRequests?: number;
+};
+
 export type SummarizeContext = {
   isCondensed?: boolean;
   targetTokens?: number;
   depth?: number;
   onUsage?: (usage: SummarizerUsage) => void;
-};
-
-export type SummarizerUsage = {
-  provider: "codex-process";
-  model?: string;
-  tokensUsed: number;
 };
 
 export type LcmSummarizeFn = (

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -33,6 +33,9 @@ export interface LlmUsageStats {
   okCalls: number;
   failedCalls: number;
   tokensSpent: number;
+  tokensInput: number;
+  tokensCached: number;
+  tokensOutput: number;
 }
 
 interface OverallStats {
@@ -91,10 +94,13 @@ function queryProjectStats(dbPath: string, projectId: string, staleCfg: { staleA
          COALESCE(SUM(calls_total), 0) as calls,
          COALESCE(SUM(calls_ok), 0) as okCalls,
          COALESCE(SUM(calls_failed), 0) as failedCalls,
-         COALESCE(SUM(tokens_spent_total), 0) as tokensSpent
+         COALESCE(SUM(tokens_spent_total), 0) as tokensSpent,
+         COALESCE(SUM(tokens_input_total), 0) as tokensInput,
+         COALESCE(SUM(tokens_cached_total), 0) as tokensCached,
+         COALESCE(SUM(tokens_output_total), 0) as tokensOutput
        FROM llm_usage_stats`,
     ).get() as
-      | { calls: number; okCalls: number; failedCalls: number; tokensSpent: number }
+      | { calls: number; okCalls: number; failedCalls: number; tokensSpent: number; tokensInput: number; tokensCached: number; tokensOutput: number }
       | undefined;
 
     const convRows = db.prepare(`
@@ -165,6 +171,9 @@ function queryProjectStats(dbPath: string, projectId: string, staleCfg: { staleA
         okCalls: llmUsageRow?.okCalls ?? 0,
         failedCalls: llmUsageRow?.failedCalls ?? 0,
         tokensSpent: llmUsageRow?.tokensSpent ?? 0,
+        tokensInput: llmUsageRow?.tokensInput ?? 0,
+        tokensCached: llmUsageRow?.tokensCached ?? 0,
+        tokensOutput: llmUsageRow?.tokensOutput ?? 0,
       },
     };
   } finally {
@@ -378,7 +387,7 @@ export function collectStats(): OverallStats {
       eventsCaptured: 0, eventsUnprocessed: 0, eventsErrors: 0,
       recallStats: emptyRecallStats,
       staleCount: 0,
-      llmUsage: { calls: 0, okCalls: 0, failedCalls: 0, tokensSpent: 0 },
+      llmUsage: { calls: 0, okCalls: 0, failedCalls: 0, tokensSpent: 0, tokensInput: 0, tokensCached: 0, tokensOutput: 0 },
     };
   }
 
@@ -397,7 +406,7 @@ export function collectStats(): OverallStats {
   let totalMemoriesSurfaced = 0;
   let totalMemoriesActedUpon = 0;
   const allTopRecalled: Array<{ id: string; content: string; actCount: number }> = [];
-  const totalLlmUsage: LlmUsageStats = { calls: 0, okCalls: 0, failedCalls: 0, tokensSpent: 0 };
+  const totalLlmUsage: LlmUsageStats = { calls: 0, okCalls: 0, failedCalls: 0, tokensSpent: 0, tokensInput: 0, tokensCached: 0, tokensOutput: 0 };
 
   // Load stale config once for all projects
   let staleCfg = { staleAfterDays: 90, staleSurfacingWithoutUseLimit: 5 };
@@ -440,6 +449,9 @@ export function collectStats(): OverallStats {
       totalLlmUsage.okCalls += projStats.llmUsage.okCalls;
       totalLlmUsage.failedCalls += projStats.llmUsage.failedCalls;
       totalLlmUsage.tokensSpent += projStats.llmUsage.tokensSpent;
+      totalLlmUsage.tokensInput += projStats.llmUsage.tokensInput;
+      totalLlmUsage.tokensCached += projStats.llmUsage.tokensCached;
+      totalLlmUsage.tokensOutput += projStats.llmUsage.tokensOutput;
     } catch {
       // skip corrupt databases
     }

--- a/test/daemon/config.test.ts
+++ b/test/daemon/config.test.ts
@@ -93,6 +93,13 @@ describe("loadDaemonConfig", () => {
     expect(c.llm.provider).toBe("auto");
   });
 
+  it("accepts copilot-process as a provider from file config", () => {
+    const c = loadDaemonConfig("/nonexistent/config.json", {
+      llm: { provider: "copilot-process" }
+    });
+    expect(c.llm.provider).toBe("copilot-process");
+  });
+
   it("accepts LCM_SUMMARY_PROVIDER=codex-process", () => {
     const c = loadDaemonConfig("/nonexistent", {}, { LCM_SUMMARY_PROVIDER: "codex-process" });
     expect(c.llm.provider).toBe("codex-process");

--- a/test/daemon/llm-usage-persistence.test.ts
+++ b/test/daemon/llm-usage-persistence.test.ts
@@ -1,0 +1,143 @@
+import { DatabaseSync } from "node:sqlite";
+import { describe, it, expect } from "vitest";
+import { runLcmMigrations } from "../../src/db/migration.js";
+import { recordCompactLlmUsage, type CompactLlmUsage } from "../../src/daemon/routes/compact.js";
+
+function migratedDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db);
+  return db;
+}
+
+function usage(overrides: Partial<CompactLlmUsage> = {}): CompactLlmUsage {
+  return {
+    provider: "codex-process",
+    model: "gpt-5.6",
+    calls: 1,
+    okCalls: 1,
+    failedCalls: 0,
+    tokensSpent: 30597,
+    tokensInput: 30592,
+    tokensCached: 7040,
+    tokensOutput: 5,
+    ...overrides,
+  };
+}
+
+function readRow(db: DatabaseSync) {
+  return db.prepare(`SELECT * FROM llm_usage_stats`).all() as Record<string, number | string>[];
+}
+
+describe("llm_usage_stats persistence", () => {
+  it("writes the full token breakdown for a call", () => {
+    const db = migratedDb();
+    try {
+      recordCompactLlmUsage(db, usage());
+      expect(readRow(db)).toHaveLength(1);
+      expect(readRow(db)[0]).toMatchObject({
+        provider: "codex-process",
+        model: "gpt-5.6",
+        calls_total: 1,
+        tokens_spent_total: 30597,
+        tokens_input_total: 30592,
+        tokens_cached_total: 7040,
+        tokens_output_total: 5,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("accumulates every counter on conflict instead of replacing the row", () => {
+    const db = migratedDb();
+    try {
+      recordCompactLlmUsage(db, usage());
+      recordCompactLlmUsage(db, usage({ failedCalls: 1, okCalls: 0 }));
+      const [row] = readRow(db);
+      expect(row).toMatchObject({
+        calls_total: 2,
+        calls_ok: 1,
+        calls_failed: 1,
+        tokens_spent_total: 61194,
+        tokens_input_total: 61184,
+        tokens_cached_total: 14080,
+        tokens_output_total: 10,
+      });
+    } finally {
+      db.close();
+    }
+  });
+
+  it("keeps a provider that reports output tokens only on its own row", () => {
+    const db = migratedDb();
+    try {
+      recordCompactLlmUsage(db, usage());
+      recordCompactLlmUsage(db, usage({
+        provider: "copilot-process",
+        model: "",
+        tokensSpent: 221,
+        tokensInput: 0,
+        tokensCached: 0,
+        tokensOutput: 221,
+      }));
+      expect(readRow(db)).toHaveLength(2);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("skips the write when no call reported usage", () => {
+    const db = migratedDb();
+    try {
+      recordCompactLlmUsage(db, usage({ calls: 0 }));
+      expect(readRow(db)).toHaveLength(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("adds the breakdown columns to a pre-existing table without losing totals", () => {
+    const db = new DatabaseSync(":memory:");
+    try {
+      // The schema as it shipped before the breakdown existed.
+      db.exec(`
+        CREATE TABLE llm_usage_stats (
+          provider TEXT NOT NULL,
+          model TEXT NOT NULL,
+          calls_total INTEGER NOT NULL DEFAULT 0,
+          calls_ok INTEGER NOT NULL DEFAULT 0,
+          calls_failed INTEGER NOT NULL DEFAULT 0,
+          tokens_spent_total INTEGER NOT NULL DEFAULT 0,
+          updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+          PRIMARY KEY (provider, model)
+        );
+        INSERT INTO llm_usage_stats (provider, model, calls_total, calls_ok, tokens_spent_total)
+        VALUES ('codex-process', 'gpt-5.6', 4, 4, 1000);
+      `);
+
+      runLcmMigrations(db);
+
+      const columns = (db.prepare(`PRAGMA table_info(llm_usage_stats)`).all() as { name: string }[])
+        .map((c) => c.name);
+      expect(columns).toEqual(expect.arrayContaining([
+        "tokens_input_total", "tokens_cached_total", "tokens_output_total",
+      ]));
+
+      const [row] = readRow(db);
+      expect(row).toMatchObject({
+        calls_total: 4,
+        tokens_spent_total: 1000,
+        // Historical rows have no breakdown; they backfill to zero, not to the total.
+        tokens_input_total: 0,
+        tokens_output_total: 0,
+      });
+
+      // The upgraded table still accepts the new write path.
+      recordCompactLlmUsage(db, usage({ tokensSpent: 1 }));
+      expect(readRow(db)).toHaveLength(1);
+      expect(readRow(db)[0].tokens_input_total).toBe(30592);
+    } finally {
+      db.close();
+    }
+  });
+});

--- a/test/daemon/routes/compact.test.ts
+++ b/test/daemon/routes/compact.test.ts
@@ -27,7 +27,12 @@ vi.mock("../../../src/llm/codex-process.js", () => ({
   createCodexProcessSummarizer: vi.fn().mockReturnValue(async () => "codex-process-summary"),
 }));
 
+vi.mock("../../../src/llm/copilot-process.js", () => ({
+  createCopilotProcessSummarizer: vi.fn().mockReturnValue(async () => "copilot-process-summary"),
+}));
+
 import { createClaudeProcessSummarizer } from "../../../src/llm/claude-process.js";
+import { createCopilotProcessSummarizer } from "../../../src/llm/copilot-process.js";
 import { createCodexProcessSummarizer } from "../../../src/llm/codex-process.js";
 import { createAnthropicSummarizer } from "../../../src/llm/anthropic.js";
 import { createOpenAISummarizer } from "../../../src/llm/openai.js";
@@ -226,6 +231,26 @@ describe("createCompactHandler — summarizer branching", () => {
     const { res } = mockRes();
     await handler({} as any, res, JSON.stringify({ session_id: "s1", cwd: testCwd, client: "codex" }));
     expect(createCodexProcessSummarizer).toHaveBeenCalled();
+    expect(createClaudeProcessSummarizer).not.toHaveBeenCalled();
+  });
+
+  it("uses createCopilotProcessSummarizer when provider is copilot-process", async () => {
+    vi.clearAllMocks();
+    const handler = createCompactHandler(makeConfig("copilot-process"));
+    const { res } = mockRes();
+    await handler({} as any, res, JSON.stringify({ session_id: "s1", cwd: testCwd }));
+
+    expect(createCopilotProcessSummarizer).toHaveBeenCalledWith(expect.objectContaining({ model: "test-model" }));
+    expect(createClaudeProcessSummarizer).not.toHaveBeenCalled();
+  });
+
+  it("auto + client=copilot resolves to copilot-process", async () => {
+    vi.clearAllMocks();
+    const handler = createCompactHandler(makeConfig("auto"));
+    const { res } = mockRes();
+    await handler({} as any, res, JSON.stringify({ session_id: "s1", cwd: testCwd, client: "copilot" }));
+
+    expect(createCopilotProcessSummarizer).toHaveBeenCalled();
     expect(createClaudeProcessSummarizer).not.toHaveBeenCalled();
   });
 

--- a/test/doctor/doctor.test.ts
+++ b/test/doctor/doctor.test.ts
@@ -189,6 +189,7 @@ describe("runDoctor summarizer modes", () => {
     expect(results.find((result) => result.name === "stack")?.message).toContain("Summarizer: auto");
     expect(results.some((result) => result.name === "claude-process")).toBe(true);
     expect(results.some((result) => result.name === "codex-process")).toBe(true);
+    expect(results.some((result) => result.name === "copilot-process")).toBe(true);
   });
 });
 

--- a/test/llm/codex-process.test.ts
+++ b/test/llm/codex-process.test.ts
@@ -68,6 +68,9 @@ describe("createCodexProcessSummarizer", () => {
     const [command, args] = spawn.mock.calls[0];
     expect(command).toBe("codex");
     expect(args).toContain("exec");
+    // --json puts the normalized usage breakdown on stdout; the summary still
+    // arrives through --output-last-message, so the two never collide.
+    expect(args).toContain("--json");
     expect(args).toContain("--skip-git-repo-check");
     expect(args).toContain("--sandbox");
     expect(args).toContain("read-only");

--- a/test/llm/copilot-process.test.ts
+++ b/test/llm/copilot-process.test.ts
@@ -1,0 +1,188 @@
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+import { describe, it, expect, vi } from "vitest";
+import {
+  createCopilotProcessSummarizer,
+  parseCopilotJsonl,
+  buildCopilotArgs,
+} from "../../src/llm/copilot-process.js";
+
+type FakeChild = EventEmitter & {
+  stdout: PassThrough;
+  stderr: PassThrough;
+  stdin: PassThrough;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+function makeChild(): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new PassThrough();
+  child.stderr = new PassThrough();
+  child.stdin = new PassThrough();
+  child.kill = vi.fn();
+  return child;
+}
+
+/** Feeds the streams, then closes, mirroring the ordering of a real process. */
+function finish(child: FakeChild, exitCode: number, stdout = "", stderr = ""): void {
+  setImmediate(() => {
+    if (stdout) child.stdout.write(stdout);
+    if (stderr) child.stderr.write(stderr);
+    setImmediate(() => child.emit("close", exitCode));
+  });
+}
+
+// Captured verbatim from `copilot -p ... --output-format json` (CLI 1.0.18).
+const REAL_JSONL = [
+  '{"type":"assistant.message_delta","data":{"messageId":"m1","deltaContent":"OK"},"ephemeral":true}',
+  '{"type":"assistant.message","data":{"messageId":"m1","content":"OK","toolRequests":[],"outputTokens":221}}',
+  '{"type":"result","sessionId":"s1","exitCode":0,"usage":{"premiumRequests":0.33,"totalApiDurationMs":3290}}',
+].join("\n");
+
+describe("parseCopilotJsonl", () => {
+  it("extracts the final message content and usage from real CLI output", () => {
+    expect(parseCopilotJsonl(REAL_JSONL)).toEqual({
+      content: "OK",
+      outputTokens: 221,
+      premiumRequests: 0.33,
+    });
+  });
+
+  it("ignores unparseable and non-JSON lines", () => {
+    const noisy = `not json\n{"broken":\n${REAL_JSONL}\n`;
+    expect(parseCopilotJsonl(noisy).content).toBe("OK");
+  });
+
+  it("keeps the last assistant message and sums output tokens across turns", () => {
+    const twoTurns = [
+      '{"type":"assistant.message","data":{"content":"first","outputTokens":10}}',
+      '{"type":"assistant.message","data":{"content":"second","outputTokens":5}}',
+    ].join("\n");
+    expect(parseCopilotJsonl(twoTurns)).toEqual({
+      content: "second",
+      outputTokens: 15,
+      premiumRequests: undefined,
+    });
+  });
+
+  it("returns empty content when the stream carries no message", () => {
+    expect(parseCopilotJsonl("").content).toBe("");
+  });
+});
+
+describe("buildCopilotArgs", () => {
+  it("passes the prompt as an argv value and keeps the run hermetic", () => {
+    const args = buildCopilotArgs("PROMPT");
+    expect(args[0]).toBe("-p");
+    expect(args[1]).toBe("PROMPT");
+    expect(args).toContain("--output-format");
+    expect(args).toContain("json");
+    expect(args).toContain("--no-custom-instructions");
+    expect(args).toContain("--disable-builtin-mcps");
+    // A bogus name, not an empty value: the CLI ignores --available-tools=
+    // and would still hand the model bash.
+    expect(args).toContain("--available-tools=__none__");
+    expect(args).not.toContain("--available-tools=");
+    expect(args).toContain("--no-ask-user");
+    expect(args).not.toContain("--model");
+  });
+
+  it("appends --model when one is configured", () => {
+    expect(buildCopilotArgs("PROMPT", " gpt-5.2 ")).toEqual(
+      expect.arrayContaining(["--model", "gpt-5.2"]),
+    );
+  });
+});
+
+describe("createCopilotProcessSummarizer", () => {
+  it("resolves with the message content and reports normalized usage", async () => {
+    const child = makeChild();
+    const spawn = vi.fn().mockReturnValue(child);
+    const onUsage = vi.fn();
+    const summarizer = createCopilotProcessSummarizer({ model: "gpt-5.2", spawn: spawn as any });
+
+    const promise = summarizer("Conversation text", false, { onUsage });
+    finish(child, 0, REAL_JSONL);
+
+    await expect(promise).resolves.toBe("OK");
+    expect(spawn.mock.calls[0][0]).toBe("copilot");
+    expect(onUsage).toHaveBeenCalledWith({
+      provider: "copilot-process",
+      model: "gpt-5.2",
+      // Copilot's JSONL stream carries no prompt-token counts.
+      outputTokens: 221,
+      tokensUsed: 221,
+      premiumRequests: 0.33,
+    });
+  });
+
+  it("still reports usage when the process exits non-zero", async () => {
+    const child = makeChild();
+    const onUsage = vi.fn();
+    const summarizer = createCopilotProcessSummarizer({ spawn: vi.fn().mockReturnValue(child) as any });
+
+    const promise = summarizer("text", false, { onUsage });
+    finish(child, 1, REAL_JSONL, "boom");
+
+    await expect(promise).rejects.toThrow(/copilot exited 1: boom/);
+    expect(onUsage).toHaveBeenCalledOnce();
+  });
+
+  it("recognizes quota exhaustion and says how to recover", async () => {
+    const child = makeChild();
+    const summarizer = createCopilotProcessSummarizer({ spawn: vi.fn().mockReturnValue(child) as any });
+
+    const promise = summarizer("text");
+    finish(child, 1, "", "You have exceeded your premium request quota");
+
+    await expect(promise).rejects.toThrow(/copilot usage limit reached/);
+  });
+
+  it("falls back to JSONL error events when stderr is empty", async () => {
+    const child = makeChild();
+    const summarizer = createCopilotProcessSummarizer({ spawn: vi.fn().mockReturnValue(child) as any });
+
+    const promise = summarizer("text");
+    finish(child, 1, '{"type":"error","data":{"message":"model unavailable"}}');
+
+    await expect(promise).rejects.toThrow(/copilot exited 1: model unavailable/);
+  });
+
+  it("rejects an empty answer on a successful exit", async () => {
+    const child = makeChild();
+    const summarizer = createCopilotProcessSummarizer({ spawn: vi.fn().mockReturnValue(child) as any });
+
+    const promise = summarizer("text");
+    finish(child, 0, '{"type":"result","exitCode":0,"usage":{"premiumRequests":0.33}}');
+
+    await expect(promise).rejects.toThrow(/copilot output was empty/);
+  });
+
+  it("rejects oversized prompts instead of overflowing argv", async () => {
+    const spawn = vi.fn();
+    const summarizer = createCopilotProcessSummarizer({ spawn: spawn as any });
+
+    await expect(summarizer("x".repeat(300_000))).rejects.toThrow(/over the 200000-byte limit/);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it("explains how to install the CLI when it is missing", async () => {
+    const spawn = vi.fn(() => {
+      throw Object.assign(new Error("spawn copilot ENOENT"), { code: "ENOENT" });
+    });
+    const summarizer = createCopilotProcessSummarizer({ spawn: spawn as any });
+
+    await expect(summarizer("text")).rejects.toThrow(/npm install -g @github\/copilot/);
+  });
+
+  it("kills the process and rejects on timeout", async () => {
+    const child = makeChild();
+    const summarizer = createCopilotProcessSummarizer({
+      spawn: vi.fn().mockReturnValue(child) as any,
+      timeoutMs: 5,
+    });
+
+    await expect(summarizer("text")).rejects.toThrow(/timed out after 0s/);
+    expect(child.kill).toHaveBeenCalled();
+  });
+});

--- a/test/llm/usage-normalization.test.ts
+++ b/test/llm/usage-normalization.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { parseCodexUsage, parseLegacyCodexTokens, extractCodexErrorEvents } from "../../src/llm/codex-process.js";
+import { parseClaudeResult } from "../../src/llm/claude-process.js";
+import { parseCopilotJsonl } from "../../src/llm/copilot-process.js";
+
+// All three fixtures were captured verbatim from the real CLIs. They pin the
+// convention that makes the numbers comparable: inputTokens is the full prompt
+// cost and cachedInputTokens is a subset of it, never additive.
+
+describe("codex usage normalization", () => {
+  // From `codex exec --json`; the same run printed "tokens used\n30,597" on stderr.
+  const TURN_COMPLETED =
+    '{"type":"turn.completed","usage":{"input_tokens":30592,"cached_input_tokens":7040,' +
+    '"cache_write_input_tokens":0,"output_tokens":5,"reasoning_output_tokens":0}}';
+
+  it("treats cached tokens as a subset, matching the CLI's own total", () => {
+    const usage = parseCodexUsage(TURN_COMPLETED, "gpt-5.6");
+    expect(usage).toEqual({
+      provider: "codex-process",
+      model: "gpt-5.6",
+      inputTokens: 30592,
+      cachedInputTokens: 7040,
+      outputTokens: 5,
+      tokensUsed: 30597,
+    });
+    // The discriminator: the CLI's own "tokens used" line agrees.
+    expect(usage!.tokensUsed).toBe(parseLegacyCodexTokens("tokens used\n30,597"));
+  });
+
+  it("returns undefined when no turn completed", () => {
+    expect(parseCodexUsage('{"type":"turn.started"}')).toBeUndefined();
+    expect(parseCodexUsage("")).toBeUndefined();
+  });
+
+  it("keeps the legacy stderr total for older Codex builds", () => {
+    expect(parseLegacyCodexTokens("tokens used\n30,597")).toBe(30597);
+    expect(parseLegacyCodexTokens("no usage here")).toBeUndefined();
+  });
+});
+
+describe("extractCodexErrorEvents", () => {
+  // With --json the real cause is a stdout event; stderr only had unrelated
+  // MCP transport noise in the run this was captured from.
+  const FAILED = [
+    '{"type":"item.completed","item":{"id":"item_4","type":"error","message":"Skill descriptions were shortened."}}',
+    '{"type":"error","message":"The \'bogus-model-xyz\' model is not supported."}',
+    '{"type":"turn.failed","error":{"message":"The \'bogus-model-xyz\' model is not supported."}}',
+  ].join("\n");
+
+  it("reads the failure from the event stream and does not repeat it", () => {
+    expect(extractCodexErrorEvents(FAILED)).toBe("The 'bogus-model-xyz' model is not supported.");
+  });
+
+  it("returns empty when the stream carries no failure", () => {
+    expect(extractCodexErrorEvents('{"type":"turn.completed","usage":{}}')).toBe("");
+  });
+});
+
+describe("claude usage normalization", () => {
+  // From `claude --print --output-format json`, trimmed to the fields read.
+  const RESULT = JSON.stringify({
+    type: "result",
+    subtype: "success",
+    is_error: false,
+    result: "  OK  ",
+    total_cost_usd: 0.0325202,
+    modelUsage: {
+      "claude-haiku-4-5-20251001": {
+        inputTokens: 10,
+        outputTokens: 49,
+        cacheReadInputTokens: 14112,
+        cacheCreationInputTokens: 15427,
+        costUSD: 0.0325202,
+      },
+    },
+  });
+
+  it("folds Claude's three prompt counters into one inputTokens total", () => {
+    const outcome = parseClaudeResult(RESULT, "fallback");
+    expect(outcome).toEqual({
+      content: "OK",
+      isError: false,
+      usage: {
+        provider: "claude-process",
+        model: "claude-haiku-4-5-20251001",
+        // 10 uncached + 14112 cache reads + 15427 cache writes
+        inputTokens: 29549,
+        cachedInputTokens: 14112,
+        outputTokens: 49,
+        tokensUsed: 29598,
+        costUsd: 0.0325202,
+      },
+    });
+  });
+
+  it("flags an error result without losing its usage", () => {
+    const errored = JSON.stringify({ is_error: true, result: "boom", modelUsage: {} });
+    expect(parseClaudeResult(errored, "m")).toEqual({ content: "boom", isError: true, usage: undefined });
+  });
+
+  it("returns undefined for non-JSON output", () => {
+    expect(parseClaudeResult("plain text answer", "m")).toBeUndefined();
+  });
+});
+
+describe("copilot usage normalization", () => {
+  it("reports output tokens only, leaving prompt counters unreported", () => {
+    const outcome = parseCopilotJsonl(
+      '{"type":"assistant.message","data":{"content":"OK","outputTokens":221}}\n' +
+      '{"type":"result","usage":{"premiumRequests":0.33}}',
+    );
+    // undefined, not zero: Copilot's JSON mode never exposes prompt tokens, and
+    // that must stay distinguishable from a genuinely empty prompt.
+    expect(outcome.outputTokens).toBe(221);
+    expect(outcome.premiumRequests).toBe(0.33);
+  });
+});


### PR DESCRIPTION
Adds a Copilot CLI summarizer alongside `claude-process` and `codex-process`, and normalizes what all three report so their numbers are comparable.

## Normalized usage

One convention, pinned by tests: `inputTokens` is the full prompt cost, `cachedInputTokens` is a **subset** of it (never additive), and `tokensUsed = input + output`. That identity is what Codex itself prints as "tokens used" (30592 + 5 = 30597), so the existing contract is preserved rather than redefined. Claude splits the prompt across three counters, which are summed into `inputTokens`.

| Provider | input | cached | output | extra |
|---|---|---|---|---|
| `claude-process` | ✅ | ✅ | ✅ | cost in USD |
| `codex-process` | ✅ | ✅ | ✅ | — |
| `copilot-process` | — | — | ✅ | premium requests |

Fields a provider cannot report stay `undefined` rather than `0`, so "no cache" stays distinguishable from "cache not reported".

## Reporting now actually flows

`compact.ts` dropped every usage event that was not `codex-process`, so nothing but Codex ever reached `llm_usage_stats`. The table gains input/cached/output columns (guarded `ALTER` for existing installs) and `lcm import --replay` prints the breakdown.

## Provider changes

- **codex-process** reads `codex exec --json` for an exact split; the stderr total stays as a fallback for older builds. Adding `--json` also moved failures to stdout JSONL events (stderr carries only unrelated MCP transport noise), so error extraction follows.
- **claude-process** reads `--output-format json`, gaining usage and cost.
- **copilot-process** uses JSON output. Its text mode is the only place with prompt-token counts, but it hard-wraps the summary at ~80 columns with a bullet prefix, and the two modes are mutually exclusive — so Copilot reports output tokens and premium requests, leaving prompt counters unreported.

## Copilot CLI gotcha

An **empty** `--available-tools=` is silently ignored by the CLI, which left `bash` reachable from a summarization prompt — verified by prompting it to run a shell command with the flag set. Naming a tool that does not exist is what actually yields a toolless model, and it drops the prompt from 26k to 6k tokens. Billing is unchanged either way: Copilot charges ~0.33 premium requests per call regardless of size.

`-p` also takes the prompt as argv only (`-p -` is read as the literal string `-`), so prompts are capped at 200KB with a clear error.

## Deliberately not included

- No client sends `client: "copilot"` yet, so `auto` never selects it — use `LCM_SUMMARY_PROVIDER=copilot-process`. Docs say so explicitly.
- Cost and premium requests stay in the `onUsage` payload rather than the schema, since they are not normalizable across providers.
- `claude-process` still ignores `config.llm.model`: that field is shared across providers, so a model pinned for codex must not leak into the claude CLI.

## Verification

- Full suite: **1058 passed, 0 failures**
- New tests cover each parser against verbatim CLI output, the DB write path, and the `ALTER` migration on a pre-existing table
- Smoke-tested end to end against all three real CLIs — each produced a summary and correct usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017g4HmVBhxqH8LPSfwmtyrg
