### PR TITLE
docs: keep cross-session threading; correct the ledger plan

### DIFF
--- a/.xgh/plans/2026-09-07-replay-ledger-redesign.md
+++ b/.xgh/plans/2026-09-07-replay-ledger-redesign.md
@@ -12,28 +12,30 @@ Steps 1–4 are the redesign. Steps 5–7 are ordinary bugs Codex found that are
 
 ---
 
-## 1. Shrink the ledger schema
+## 0. Decisions that shape the steps
+
+**Threading stays** (Pedro, 2026-09-07). `previous_summary` continues to cross sessions, so steps 6–7 are in scope rather than dissolving.
+
+**The anchor rule, formalised.** With threading kept, resume must re-establish the chain in a fresh process. Rather than re-deriving it by query, `replay_ledger` **keeps `summary_id` as a nullable anchor-only column**. Its *purpose* changes: it is no longer what `--restart` deletes (that is now conversation-scoped), only where the chain picks up.
+
+That change alone dissolves `import.ts:440`: a `no_work` row with `summary_id = NULL` is now a complete, valid row — the anchor search simply walks further back to the most recent non-null one.
+
+The anchor's definition matches today's de-facto behaviour, which should be written down rather than reinvented: `getSummariesByConversation` orders `BY created_at`, and `compact.ts:367` takes the last element. So **the anchor is the most recently created summary of that conversation**, regardless of depth.
+
+**Migrations stay additive.** `.github/skills/code-review/SKILL.md` §7 (merged in #310) forbids destructive DDL, so nothing below drops a table or a column.
+
+## 1. Adjust the ledger schema (additive only)
 
 **`src/db/migration.ts`**
 
-- Drop the `replay_ledger_summaries` table added in round 1 (`CREATE TABLE IF NOT EXISTS` — remove the block and its index).
-- `replay_ledger` becomes:
+- Add the outcome column, guarded for idempotency (check `PRAGMA table_info(replay_ledger)` the way `ensureSummaryDepthColumn` does):
   ```sql
-  CREATE TABLE IF NOT EXISTS replay_ledger (
-    run_id              TEXT NOT NULL,
-    session_id          TEXT NOT NULL,
-    position            INTEGER NOT NULL,
-    content_fingerprint TEXT NOT NULL,
-    outcome             TEXT NOT NULL,   -- 'compacted' | 'no_work'
-    completed_at        TEXT NOT NULL DEFAULT (datetime('now')),
-    PRIMARY KEY (run_id, session_id)
-  );
+  ALTER TABLE replay_ledger ADD COLUMN outcome TEXT NOT NULL DEFAULT 'compacted';
   ```
-  Removed: `summary_id`, `prev_session_id`, `model`.
+- Remove the `CREATE TABLE IF NOT EXISTS replay_ledger_summaries` block and its index so new databases never get it. **Do not `DROP` it** — dev databases that ran round 1 keep a harmless orphan table.
+- `prev_session_id` and `model` stay in the schema as nullable columns but stop being written. `summary_id` stays and keeps being written, now as the threading anchor only (see §0).
 
-**Migration note:** the branch is unreleased, so existing `replay_ledger` rows only exist on dev machines that ran the branch. Prefer dropping and recreating the table over an `ALTER` chain — but confirm that assumption before writing it.
-
-`model` moves to (or stays on) `replay_manifest`, which is where the run-level "last run's model" line is read from anyway. Verify `loadLatestRun` still resolves it.
+Resulting row: `(run_id, session_id, position, content_fingerprint, summary_id?, outcome, completed_at)`.
 
 ## 2. Add the wipe-and-rebuild helper
 
@@ -43,20 +45,37 @@ Steps 1–4 are the redesign. Steps 5–7 are ordinary bugs Codex found that are
 async resetConversationContext(conversationId: number): Promise<number>
 ```
 
+Pair it with a read-only `countSummaries(conversationId)` so `--restart` can report the total **before** wiping anything (the spec requires the warning to precede the deletion, and the reset method can only return a count after the fact).
+
 In one transaction:
-1. Collect `summary_id`s for the conversation; return the count (the caller reports it).
+1. Collect `summary_id`s for the conversation.
 2. `DELETE FROM summary_messages WHERE summary_id IN (...)`
 3. `DELETE FROM summary_parents WHERE summary_id IN (...) OR parent_summary_id IN (...)`
 4. `DELETE FROM context_items WHERE conversation_id = ?`
 5. `DELETE FROM summaries WHERE conversation_id = ?`
-6. Rebuild:
+6. Delete the now-stale compaction-event messages — they describe summaries that no longer exist:
+   ```sql
+   DELETE FROM messages WHERE conversation_id = ? AND EXISTS (
+     SELECT 1 FROM message_parts p
+     WHERE p.message_id = messages.message_id AND p.part_type = 'compaction'
+   )
+   ```
+7. Rebuild — **excluding compaction events**:
    ```sql
    INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
-   SELECT ?, ROW_NUMBER() OVER (ORDER BY seq) - 1, 'message', message_id
-   FROM messages WHERE conversation_id = ? ORDER BY seq
+   SELECT ?, ROW_NUMBER() OVER (ORDER BY m.seq) - 1, 'message', m.message_id
+   FROM messages m
+   WHERE m.conversation_id = ?
+     AND NOT EXISTS (
+       SELECT 1 FROM message_parts p
+       WHERE p.message_id = m.message_id AND p.part_type = 'compaction'
+     )
+   ORDER BY m.seq
    ```
 
-Check the FTS5 mirror: `deleteMessageFromFullText` exists for messages — confirm whether summaries have an equivalent index that also needs clearing.
+**Why the exclusion is mandatory:** `CompactionEngine.writeEvent` (`src/compaction.ts:1331`) calls `createMessage` + `createMessageParts` but **never** `appendContextMessage` — verified, `appendContextMessage` has no callers outside its own definition. So event rows live in `messages` and have never been in `context_items`. A naive `INSERT … SELECT FROM messages` would surface `"LCM compaction leaf pass (normal): 5000 -> 200"` into the model's context, which is a regression the current code does not have. Step 6 makes step 7's predicate redundant, but keep both — step 7 must be correct on its own if step 6 is ever reordered or dropped.
+
+Check the FTS5 mirror: `deleteMessageFromFullText` exists for messages — confirm whether summaries have an equivalent index that also needs clearing, and call it for both the summaries and the deleted event messages.
 
 ## 3. Rewrite `clearReplayState`
 
@@ -70,19 +89,19 @@ Delete outright:
 
 Replace with: resolve the conversations for the run's manifest sessions → `resetConversationContext` on each → delete the run's `replay_ledger` rows. Keep the `missing` / `error` / `ready` distinction from round 1 — it was right, and it is what makes `clearReplayState` return `false` on an unusable database.
 
-Sum the returned counts and surface them: `--restart` prints how many summaries it is discarding **before** doing it (spec requirement).
+Run `countSummaries` over the affected conversations first and print the total, then wipe.
 
-## 4. Record `outcome` instead of summary ids
+## 4. Record `outcome`; keep `summary_id` as the anchor
 
 **`src/import.ts`, `src/batch-compact.ts`**
 
-`recordReplayProgress` loses `summaryId`, `summaryIds`, `prevSessionId`; gains `outcome: "compacted" | "no_work"`. The `replayOutcome` gating from round 1 stays — it is the fix for "disabled compactions recorded as done" and is independent of this rework.
+`recordReplayProgress` loses `summaryIds` and `prevSessionId`; gains `outcome: "compacted" | "no_work"`; **keeps** `summaryId` (nullable) per §0. The `replayOutcome` gating from round 1 stays — it is the fix for "disabled compactions recorded as done" and is independent of this rework.
 
-This dissolves `import.ts:440` (a `no_work` session no longer needs a `summary_id` to be a valid resume point).
+**Resume anchor lookup** in `planProject`: from the last done row before the first gap, walk backwards to the most recent row with a non-null `summary_id` and load its content. A run of `no_work` rows is skipped rather than treated as a broken chain — that is what dissolves `import.ts:440`.
 
-**`src/daemon/routes/compact.ts`** — `latestSummaryIds` can go from the response; `latestSummaryContent` stays (threading still needs it). Keep `replayOutcome`.
+**`src/daemon/routes/compact.ts`** — `latestSummaryIds` goes from the response; `latestSummaryContent` and `latestSummaryId` stay (threading needs the content, the ledger needs the id). Keep `replayOutcome`. The `else if (allSummaries.length > 0)` fallback stays and is now the *documented* anchor rule (§0) rather than an accident.
 
-**`src/compaction.ts`** — `createdSummaryIds` on `CompactionResult` is now unused by replay. It is still written into the compaction-event `metadata`; decide whether to keep it there (harmless, and useful for debugging) or drop it.
+**`src/compaction.ts`** — `createdSummaryIds` on `CompactionResult` is no longer read by replay. Keep it in the compaction-event `metadata` (harmless, useful for debugging); drop it from the route response only.
 
 ## 5. Fix the fingerprint predicate (2 findings)
 
@@ -130,6 +149,10 @@ Closes `batch-compact.ts:274` and `batch-compact.ts:72` together. Add a test tha
 ## Verification
 
 `npm run typecheck` and `npm test`. Note two pre-existing unrelated failures observed on this branch: `test/daemon/routes/restore.test.ts` and `test/daemon/routes/stats.test.ts` (the latter a 60s `/stats` timeout).
+
+## Known gap, not addressed here
+
+`--restart` runs in the CLI process and wipes summaries while the daemon may be compacting the same conversation. The daemon's `compactingNow` guard is per-request and in-process, so it does not serialise against an external wipe. This is pre-existing to #302 and not introduced by the redesign, but it is the kind of thing Codex raises — either refuse `--restart` while a daemon lock is held, or state explicitly that `--restart` assumes no concurrent compaction. Decide before the review round rather than during it.
 
 ## Docs to update in the same PR
 

--- a/.xgh/specs/2026-09-07-replay-ledger-redesign-design.md
+++ b/.xgh/specs/2026-09-07-replay-ledger-redesign-design.md
@@ -85,17 +85,23 @@ CREATE TABLE replay_ledger (
   session_id         TEXT NOT NULL,
   position           INTEGER NOT NULL,
   content_fingerprint TEXT NOT NULL,
+  summary_id         TEXT,             -- nullable; threading anchor ONLY (see below)
   outcome            TEXT NOT NULL,   -- 'compacted' | 'no_work'
   completed_at       TEXT NOT NULL,
   PRIMARY KEY (run_id, session_id)
 );
 ```
 
-Gone: `summary_id`, `prev_session_id`, and the whole `replay_ledger_summaries` table added in round 1.
+Gone: `prev_session_id`, and the whole `replay_ledger_summaries` table added in round 1. `summary_id` survives but stops being the thing `--restart` deletes — see "Cross-session threading" below.
+
+Note the migration is **additive**: `.github/skills/code-review/SKILL.md` §7 forbids destructive DDL, so the unused columns stay in the schema and simply stop being written, and `replay_ledger_summaries` is removed from the create path rather than dropped.
 
 - **Resume** = skip rows whose fingerprint matches *and* that precede the first gap (the `seenGap` rule from round 1 is right and survives).
 - **Restart** = for each session in the run's manifest: wipe that conversation's summaries, rebuild `context_items`, delete its ledger rows.
-- **Threading** needs no stored column. "The latest summary content for the last done session's conversation" is a query against `summaries` at plan time, not state carried in the ledger.
+
+### The rebuild must exclude compaction events
+
+`CompactionEngine.writeEvent` (`src/compaction.ts:1331`) writes its `"LCM compaction leaf pass (normal): 5000 -> 200"` row into `messages` + `message_parts` but **never** into `context_items` — `appendContextMessage` has no callers outside its own definition. So a naive `INSERT … SELECT FROM messages` would surface compaction noise into the model's context, a regression the current code does not have. The rebuild filters on the same `part_type = 'compaction'` predicate used for the fingerprint below, and the wipe deletes those now-stale event rows outright.
 
 ### The fingerprint has an exact discriminator
 
@@ -119,7 +125,7 @@ WHERE NOT EXISTS (
 | Finding | Under the rebuild model |
 |---|---|
 | `db/migration.ts:650` — only final `latestSummaryId` retained | **Dissolves.** No summary ids in the ledger at all. |
-| `import.ts:440` — `no_work` records `summary_id = NULL`, kills the anchor | **Dissolves.** No anchor concept; `outcome` is a first-class column. |
+| `import.ts:440` — `no_work` records `summary_id = NULL`, kills the anchor | **Dissolves.** `outcome` is a first-class column, so a NULL-anchor row is complete and valid; the anchor search walks further back. |
 | `replay-resume.ts:642` — sources hidden beneath surviving summaries | **Dissolves.** No expansion; rebuild from `messages`. |
 | `batch-compact.ts:274` — unstable batch fingerprint | **Collapses** into the `part_type = 'compaction'` predicate. |
 | `batch-compact.ts:72` — `role = 'system'` over-excludes | **Same predicate.** One fix, both findings. |
@@ -131,11 +137,15 @@ WHERE NOT EXISTS (
 
 Three P1s vanish. Two collapse into one predicate. Three are plain bugs. Two are unrelated hygiene. That is what convergence looks like.
 
-## Open question
+## Cross-session threading — kept
 
-**Cross-session threading.** Is `previous_summary` threading *across sessions* worth keeping at all? It is the source of the per-project chain bugs, the "broken chain" warnings, and the `prev_session_id` column. If each session compacts independently, several findings stop existing. If it materially improves summary quality it stays — but then it must be a plan-time lookup against `summaries`, never ledger state.
+**Decision (Pedro, 2026-09-07): `previous_summary` continues to cross sessions.** It is worth the per-project chain bookkeeping.
 
-Undecided; does not block the ledger rework, since the chosen row shape carries no threading state either way.
+That has one consequence for the row shape above: resume must re-establish the chain in a fresh process, so **`summary_id` stays as a nullable anchor-only column**. Its purpose changes rather than disappearing — it is no longer what `--restart` deletes (that is conversation-scoped now), only where the chain picks up. `prev_session_id` still goes.
+
+This is also what dissolves `import.ts:440` cleanly: a `no_work` row with `summary_id = NULL` is a complete, valid row, and the anchor search walks further back to the most recent non-null one instead of treating it as a broken chain.
+
+**The anchor rule, written down.** Today it is implicit: `getSummariesByConversation` orders `BY created_at` and `compact.ts:367` takes the last element. Formalised: *the anchor is the most recently created summary of that conversation, regardless of depth.*
 
 ## Not covered here
 


### PR DESCRIPTION
## Summary

Follows #317. Records the cross-session threading decision and corrects three things in the plan that would have failed review. Docs only.

## Decision: threading stays

`previous_summary` keeps crossing sessions. That has a consequence the earlier plan got wrong.

**`summary_id` survives** in `replay_ledger` as a nullable **anchor-only** column — resume must re-establish the chain in a fresh process, and re-deriving it by query is more moving parts than keeping the column. Its *purpose* changes rather than disappearing: it is no longer what `--restart` deletes (that is conversation-scoped now).

That is also the clean dissolution of `import.ts:440` — a `no_work` row with a NULL anchor is a complete, valid row, and the anchor search walks further back to the most recent non-null one instead of treating it as a broken chain.

**The anchor rule is now written down** rather than reinvented: `getSummariesByConversation` orders `BY created_at` and `compact.ts:367` takes the last element, so the anchor is *the most recently created summary of that conversation, regardless of depth*.

## Corrections

**1. Migrations go additive.** The earlier plan dropped `replay_ledger_summaries` and rewrote `replay_ledger`. That violates this repo's own review rule — `.github/skills/code-review/SKILL.md` §7, merged in #310: *"Schema migrations must be additive only… Flag `DROP TABLE`."* Now: `ALTER TABLE … ADD COLUMN outcome`, remove `replay_ledger_summaries` from the create path without dropping it, leave unused columns in place and stop writing them.

**2. The context rebuild must exclude compaction events.** `CompactionEngine.writeEvent` (`src/compaction.ts:1331`) writes its event row to `messages` + `message_parts` but **never** calls `appendContextMessage` — verified, that method has no callers outside its own definition. So event rows have never been in `context_items`, and the plan's `INSERT … SELECT FROM messages` would have surfaced `"LCM compaction leaf pass (normal): 5000 -> 200"` into the model's context — a regression the current code does not have. The wipe now deletes those stale event rows, and the rebuild filters on the same `part_type = 'compaction'` predicate used for the fingerprint fix.

**3. `--restart` needs a separate count.** The spec requires reporting how many summaries will be discarded *before* wiping, but `resetConversationContext` can only return a count after deleting. Adds a read-only `countSummaries` pass.

## Known gap recorded

`--restart` runs in the CLI process and wipes summaries while the daemon may be compacting the same conversation; `compactingNow` is per-request and in-process, so it does not serialise against an external wipe. Pre-existing to #302, not introduced here — but worth settling before the review round rather than during it.

## Type of change

- [x] Documentation

## Testing done

None required — no code paths touched. Each claim was read from source first: the `appendContextMessage` caller check, the `created_at` ordering behind the anchor rule, and §7 of the code-review skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJ71TAxF8W69PuzX6etVHc
