### PR TITLE
ci: give Copilot code review the codebase-memory graph

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,16 +2,16 @@
 
 This repo is a TypeScript SQLite daemon that persists Claude session memories across context resets. It uses Node.js `DatabaseSync` (synchronous SQLite API) and exposes an HTTP daemon with REST routes.
 
-## Use the codebase-memory MCP server
+## codebase-memory MCP
 
-A `codebase-memory` MCP server is available, preloaded with a graph of this codebase by `.github/workflows/copilot-setup-steps.yml`. **Use it before claiming a change is complete.**
+A `codebase-memory` MCP server is preloaded with a graph of this repo.
 
-- `list_projects` first — the project name comes from the checkout path, so do not guess it.
-- `trace_path` before changing any signature, return shape, or column: it answers "what else depends on this?" A claim that nothing else is affected is not credible without it.
-- `search_graph` to locate a symbol, `get_code_snippet` for its exact source, `query_graph` for multi-hop questions.
+- `list_projects` first — the project name comes from the checkout path; never guess it.
+- `trace_path` before changing any signature, return shape, or schema column. "Nothing else depends on this" is not a claim you may make without it.
+- `search_graph` to find a symbol, `get_code_snippet` for its source, `query_graph` for multi-hop questions.
 - `search_code` only for literal or non-code text.
 
-**When you are asked to address review findings, verify each one against the graph before reporting it fixed.** Editing the file a finding points at is not the same as closing it — a fix that misses a second call site, or that reintroduces the problem one layer up, will be re-raised on the next review round. Say which findings you verified and how.
+Before reporting a review finding as fixed, verify it against the graph. Editing the file a finding points at is not the same as closing it. State which findings you verified and how.
 
 ## Primary concerns
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,17 @@
 
 This repo is a TypeScript SQLite daemon that persists Claude session memories across context resets. It uses Node.js `DatabaseSync` (synchronous SQLite API) and exposes an HTTP daemon with REST routes.
 
+## Use the codebase-memory MCP server
+
+A `codebase-memory` MCP server is available, preloaded with a graph of this codebase by `.github/workflows/copilot-setup-steps.yml`. **Use it before claiming a change is complete.**
+
+- `list_projects` first — the project name comes from the checkout path, so do not guess it.
+- `trace_path` before changing any signature, return shape, or column: it answers "what else depends on this?" A claim that nothing else is affected is not credible without it.
+- `search_graph` to locate a symbol, `get_code_snippet` for its exact source, `query_graph` for multi-hop questions.
+- `search_code` only for literal or non-code text.
+
+**When you are asked to address review findings, verify each one against the graph before reporting it fixed.** Editing the file a finding points at is not the same as closing it — a fix that misses a second call site, or that reintroduces the problem one layer up, will be re-raised on the next review round. Say which findings you verified and how.
+
 ## Primary concerns
 
 ### Database connection pattern (highest priority)

--- a/.github/copilot-mcp-setup.md
+++ b/.github/copilot-mcp-setup.md
@@ -52,7 +52,7 @@ The tool list is read-only on purpose: `index_repository`, `manage_adr`, `ingest
 
 ## Why MCP and not the CLI
 
-The CLI would be preferable — it would live entirely in the repo, be reviewable in a PR, and testable on a branch. But GitHub documents the reviewer's agentic surface as *full project context gathering* and *passing suggestions to the cloud agent*, with tool use defined as MCP servers plus agent skills. There is no documented way for a review to run a shell command, so there is nowhere for a CLI call to execute.
+The CLI would live entirely in the repo — reviewable and testable on a branch. But GitHub documents the reviewer's tool surface as MCP servers plus agent skills, with no shell, so a CLI call would have nowhere to execute.
 
 ## One workflow, both agents
 
@@ -61,9 +61,7 @@ The MCP registration is shared by Copilot code review and Copilot cloud agent, b
 - `copilot-setup-steps.yml` — used by the cloud agent, **and by code review when `copilot-code-review.yml` is absent**.
 - `copilot-code-review.yml` — used by code review instead, when present.
 
-So this repo deliberately keeps **only `copilot-setup-steps.yml`**. Both agents get the same binary and the same index, and there is no second file to forget when the version is bumped. Add `copilot-code-review.yml` only if the two ever genuinely need different environments.
-
-Giving the cloud agent the graph is arguably the more valuable half. On #302 it reported four Codex findings as fixed that were still open on the next round — the kind of thing `trace_path` exists to catch. `.github/copilot-instructions.md` tells it to verify findings against the graph before claiming them closed.
+This repo keeps **only `copilot-setup-steps.yml`**, so both agents share one binary and one index, and there is no second file to forget when the version is bumped. Add `copilot-code-review.yml` only if the two ever need different environments.
 
 ## Verifying it works
 

--- a/.github/copilot-mcp-setup.md
+++ b/.github/copilot-mcp-setup.md
@@ -1,0 +1,63 @@
+# Copilot code review — MCP setup
+
+This file is **documentation, not configuration**. GitHub does not read it.
+
+Copilot's MCP configuration lives in repository settings, not in the repo, so it cannot be version-controlled, reviewed in a pull request, or tested on a branch. This file exists so the configuration that *is* live has something in the repo to be checked against.
+
+## One-time setup
+
+**Settings → Copilot → coding agent → MCP configuration**, paste:
+
+```json
+{
+  "mcpServers": {
+    "codebase-memory": {
+      "type": "local",
+      "command": "/home/runner/.local/bin/codebase-memory-mcp",
+      "args": [],
+      "tools": [
+        "list_projects",
+        "index_status",
+        "check_index_coverage",
+        "get_architecture",
+        "search_graph",
+        "trace_path",
+        "get_code_snippet",
+        "query_graph",
+        "get_graph_schema",
+        "search_code",
+        "detect_changes"
+      ]
+    }
+  }
+}
+```
+
+Also confirm **Allow Copilot to use MCP tools when reviewing pull requests** is enabled. It is on by default.
+
+## How the pieces fit
+
+| Piece | Where it lives | What it does |
+|---|---|---|
+| `.github/workflows/copilot-code-review.yml` | this repo | installs the pinned binary at `/home/runner/.local/bin/` and indexes the checkout, so the graph exists before Copilot starts |
+| the JSON above | repo settings | registers the binary as a local stdio MCP server and declares which tools Copilot may call |
+| `.github/skills/code-review/SKILL.md` | this repo | tells Copilot to actually use it — per GitHub's docs, the reviewer is *more likely* to use MCP context when a skill says so explicitly |
+
+The tool list is read-only on purpose: `index_repository`, `manage_adr`, `ingest_traces` and `delete_project` are omitted so a review cannot mutate the graph. Indexing is the workflow's job.
+
+## Why MCP and not the CLI
+
+The CLI would be preferable — it would live entirely in the repo, be reviewable in a PR, and testable on a branch. But GitHub documents the reviewer's agentic surface as *full project context gathering* and *passing suggestions to the cloud agent*, with tool use defined as MCP servers plus agent skills. There is no documented way for a review to run a shell command, so there is nowhere for a CLI call to execute.
+
+## Verifying it works
+
+Two signals, both after a review runs:
+
+1. **Attributions** at the bottom of review comments name the MCP server or skill that produced them.
+2. **Session logs** — open the review session from the pull request timeline and check which MCP servers and tools were called.
+
+If neither shows `codebase-memory`, check in order: the setup workflow succeeded, the binary path in the JSON matches where the workflow installed it, and MCP tools are enabled for code review.
+
+## Keeping the version honest
+
+`CBM_VERSION` in the workflow is pinned. Bumping it is a normal PR. An unpinned `latest` would change the review environment with no commit to point at, which is exactly the kind of silent drift the review rules elsewhere in this repo exist to prevent.

--- a/.github/copilot-mcp-setup.md
+++ b/.github/copilot-mcp-setup.md
@@ -6,7 +6,7 @@ Copilot's MCP configuration lives in repository settings, not in the repo, so it
 
 ## One-time setup
 
-**Settings → Copilot → coding agent → MCP configuration**, paste:
+**Settings → Copilot → MCP servers** (sidebar, under "Code, planning, and automation"), paste into the "MCP configuration" section and click **Save MCP configuration** — the JSON is validated on save:
 
 ```json
 {
@@ -33,7 +33,11 @@ Copilot's MCP configuration lives in repository settings, not in the repo, so it
 }
 ```
 
-Also confirm **Allow Copilot to use MCP tools when reviewing pull requests** is enabled. It is on by default.
+Then confirm **Settings → Copilot → Code review → Allow Copilot to use MCP tools when reviewing pull requests** is enabled. It is on by default, and it lives on a different page from the MCP configuration above.
+
+The GitHub and Playwright MCP servers are enabled by default; the block above is added alongside them, not instead of them.
+
+> **Copilot uses these tools autonomously and will not ask for approval first.** That is why the `tools` list below is read-only — GitHub's own guidance is to allowlist specific read-only tools rather than `"*"`.
 
 ## How the pieces fit
 
@@ -49,14 +53,22 @@ The tool list is read-only on purpose: `index_repository`, `manage_adr`, `ingest
 
 The CLI would be preferable — it would live entirely in the repo, be reviewable in a PR, and testable on a branch. But GitHub documents the reviewer's agentic surface as *full project context gathering* and *passing suggestions to the cloud agent*, with tool use defined as MCP servers plus agent skills. There is no documented way for a review to run a shell command, so there is nowhere for a CLI call to execute.
 
+## The cloud agent does not get this
+
+The MCP *registration* is shared by Copilot code review and Copilot cloud agent, but the *environment* is not: code review uses `copilot-code-review.yml` when it exists, and the cloud agent uses `copilot-setup-steps.yml`. This repo only has the former, so the binary is installed for reviews and **not** for the agent that writes fixes.
+
+That is worth revisiting. On #302 the cloud agent claimed to have closed four findings it had not actually closed — the kind of mistake `trace_path` exists to prevent. Giving the fixer the graph may matter more than giving the reviewer it. The change is to add a `copilot-setup-steps.yml` with the same install and index steps, or to move those steps there and let code review inherit them (it falls back to `copilot-setup-steps.yml` when `copilot-code-review.yml` is absent).
+
+Left undone deliberately: reviews are the cheaper place to find out whether this works at all.
+
 ## Verifying it works
 
-Two signals, both after a review runs:
+After a review runs, in order of directness:
 
-1. **Attributions** at the bottom of review comments name the MCP server or skill that produced them.
-2. **Session logs** — open the review session from the pull request timeline and check which MCP servers and tools were called.
+1. **Session logs** — open the review session from the pull request timeline (**View session**) and read the "Setting up environment" section. It lists which MCP servers and tools were started and called. This is the authoritative signal.
+2. **Attributions** at the bottom of individual review comments name the MCP server or skill that produced them. Absence here only means that *comment* did not use it.
 
-If neither shows `codebase-memory`, check in order: the setup workflow succeeded, the binary path in the JSON matches where the workflow installed it, and MCP tools are enabled for code review.
+If `codebase-memory` never appears, check in this order: the setup workflow succeeded, the `command` path in the JSON matches where the workflow installed the binary (`/home/runner/.local/bin/`), and MCP tools are enabled for code review.
 
 ## Keeping the version honest
 

--- a/.github/copilot-mcp-setup.md
+++ b/.github/copilot-mcp-setup.md
@@ -1,4 +1,4 @@
-# Copilot code review — MCP setup
+# Copilot MCP setup — code review and cloud agent
 
 This file is **documentation, not configuration**. GitHub does not read it.
 
@@ -43,33 +43,39 @@ The GitHub and Playwright MCP servers are enabled by default; the block above is
 
 | Piece | Where it lives | What it does |
 |---|---|---|
-| `.github/workflows/copilot-code-review.yml` | this repo | installs the pinned binary at `/home/runner/.local/bin/` and indexes the checkout, so the graph exists before Copilot starts |
+| `.github/workflows/copilot-setup-steps.yml` | this repo | installs the pinned binary at `/home/runner/.local/bin/` and indexes the checkout, so the graph exists before either agent starts |
 | the JSON above | repo settings | registers the binary as a local stdio MCP server and declares which tools Copilot may call |
-| `.github/skills/code-review/SKILL.md` | this repo | tells Copilot to actually use it — per GitHub's docs, the reviewer is *more likely* to use MCP context when a skill says so explicitly |
+| `.github/skills/code-review/SKILL.md` | this repo | tells the **reviewer** to actually use it — per GitHub's docs, it is *more likely* to reach for MCP context when a skill says so explicitly |
+| `.github/copilot-instructions.md` | this repo | tells the **cloud agent** the same, plus: verify each review finding against the graph before reporting it fixed |
 
-The tool list is read-only on purpose: `index_repository`, `manage_adr`, `ingest_traces` and `delete_project` are omitted so a review cannot mutate the graph. Indexing is the workflow's job.
+The tool list is read-only on purpose: `index_repository`, `manage_adr`, `ingest_traces` and `delete_project` are omitted so neither agent can mutate the graph. Indexing is the workflow's job.
 
 ## Why MCP and not the CLI
 
 The CLI would be preferable — it would live entirely in the repo, be reviewable in a PR, and testable on a branch. But GitHub documents the reviewer's agentic surface as *full project context gathering* and *passing suggestions to the cloud agent*, with tool use defined as MCP servers plus agent skills. There is no documented way for a review to run a shell command, so there is nowhere for a CLI call to execute.
 
-## The cloud agent does not get this
+## One workflow, both agents
 
-The MCP *registration* is shared by Copilot code review and Copilot cloud agent, but the *environment* is not: code review uses `copilot-code-review.yml` when it exists, and the cloud agent uses `copilot-setup-steps.yml`. This repo only has the former, so the binary is installed for reviews and **not** for the agent that writes fixes.
+The MCP registration is shared by Copilot code review and Copilot cloud agent, but the *environment* is not — each reads its own workflow file. GitHub resolves it like this:
 
-That is worth revisiting. On #302 the cloud agent claimed to have closed four findings it had not actually closed — the kind of mistake `trace_path` exists to prevent. Giving the fixer the graph may matter more than giving the reviewer it. The change is to add a `copilot-setup-steps.yml` with the same install and index steps, or to move those steps there and let code review inherit them (it falls back to `copilot-setup-steps.yml` when `copilot-code-review.yml` is absent).
+- `copilot-setup-steps.yml` — used by the cloud agent, **and by code review when `copilot-code-review.yml` is absent**.
+- `copilot-code-review.yml` — used by code review instead, when present.
 
-Left undone deliberately: reviews are the cheaper place to find out whether this works at all.
+So this repo deliberately keeps **only `copilot-setup-steps.yml`**. Both agents get the same binary and the same index, and there is no second file to forget when the version is bumped. Add `copilot-code-review.yml` only if the two ever genuinely need different environments.
+
+Giving the cloud agent the graph is arguably the more valuable half. On #302 it reported four Codex findings as fixed that were still open on the next round — the kind of thing `trace_path` exists to catch. `.github/copilot-instructions.md` tells it to verify findings against the graph before claiming them closed.
 
 ## Verifying it works
 
-After a review runs, in order of directness:
+**Code review** — after a review runs, in order of directness:
 
 1. **Session logs** — open the review session from the pull request timeline (**View session**) and read the "Setting up environment" section. It lists which MCP servers and tools were started and called. This is the authoritative signal.
 2. **Attributions** at the bottom of individual review comments name the MCP server or skill that produced them. Absence here only means that *comment* did not use it.
 
-If `codebase-memory` never appears, check in this order: the setup workflow succeeded, the `command` path in the JSON matches where the workflow installed the binary (`/home/runner/.local/bin/`), and MCP tools are enabled for code review.
+**Cloud agent** — assign an issue to Copilot, open the pull request it creates from the issue timeline, click **View session**, then expand the **Start MCP Servers** step. A successful start lists the server's tools at the bottom of that log.
+
+If `codebase-memory` never appears, check in this order: the setup workflow succeeded, the `command` path in the JSON matches where the workflow installed the binary (`/home/runner/.local/bin/`), and — for reviews specifically — that MCP tools are enabled for code review.
 
 ## Keeping the version honest
 
-`CBM_VERSION` in the workflow is pinned. Bumping it is a normal PR. An unpinned `latest` would change the review environment with no commit to point at, which is exactly the kind of silent drift the review rules elsewhere in this repo exist to prevent.
+`CBM_VERSION` in the workflow is pinned. Bumping it is a normal PR. An unpinned `latest` would change both agents' environment with no commit to point at, which is exactly the kind of silent drift the review rules elsewhere in this repo exist to prevent.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -71,6 +71,12 @@ TypeScript SQLite daemon that persists Claude session memories across context re
 - Daemon HTTP requests must send the `Authorization: ******` header; the token is read via `readAuthToken(join(homedir(), ".lossless-claude", "daemon.token"))`. Auth is mandatory; a 401 arrives as a normal HTTP response, not a socket error — flag client code paths that drop the header or mishandle 401s.
 - `DaemonClient` throws `Error` objects annotated with the HTTP status and parsed JSON body (`e.status`, `e.body`) on non-2xx responses — flag client code that swallows non-2xx responses or loses the status/body annotations.
 
+### 10. Source references in docs and comments
+
+- Prose that points at code must name **symbols**, not line numbers: `CompactionEngine.persistCompactionEvent`, not `src/compaction.ts:1331`. Line numbers rot on any edit above them — nobody has to touch the described code for the reference to go stale, and the stale number still looks plausible. A renamed symbol is greppable; a wrong line number is silent.
+- Flag any `path/to/file.ts:NNN` in Markdown, in a doc comment, or in a commit message, unless it is pinned to an immutable ref (a commit SHA, or an explicitly labelled review-finding identifier).
+- This applies to `.xgh/specs/`, `.xgh/plans/`, `docs/`, `AGENTS.md`, and skill files — anywhere a reader may follow the reference against a branch other than the one it was written on.
+
 ## What to skip
 
 - Do not flag `DatabaseSync` usage in test fixtures that mock the connection — context matters.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -7,6 +7,22 @@ description: Review code changes in the lossless-claude/lcm repository. Use when
 
 Review code changes in this repository against the project rules below. These rules exist because they have caused real production bugs — flag violations with high confidence.
 
+## Use the codebase-memory MCP server
+
+This repository has a `codebase-memory` MCP server available, preloaded with a graph of the whole codebase by `.github/workflows/copilot-code-review.yml`. **Use it** — a diff alone cannot tell you whether a change breaks a caller three files away.
+
+Reach for it whenever a rule below needs evidence from outside the diff:
+
+- `list_projects` first — the project name is derived from the checkout path, so do not guess it.
+- `search_graph` to find a symbol; `get_code_snippet` for its exact source.
+- `trace_path` for callers and callees — this is what answers "does anything else depend on this?" before you flag or clear a signature change.
+- `query_graph` for multi-hop questions; `get_architecture` for orientation.
+- `search_code` only for literal or non-code text, or where graph coverage is thin.
+
+Concretely, the rules below that are unreliable without it: **#1** (a `getLcmConnection()` without a matching close may be closed by a caller), **#4** (`collectStats()` may be reached indirectly — trace it rather than eyeballing the diff), **#5** (whether a route already has tests lives outside the diff), and **#10** (whether a symbol named in prose still exists).
+
+Cite what you looked up. A finding backed by a `trace_path` result is worth more than one backed by a guess, and a claim that "nothing else calls this" is not reviewable unless you say how you checked.
+
 ## Repository context
 
 TypeScript SQLite daemon that persists Claude session memories across context resets. Uses Node.js `DatabaseSync` (synchronous SQLite API from `node:sqlite`) and exposes an HTTP daemon with REST routes.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -7,21 +7,18 @@ description: Review code changes in the lossless-claude/lcm repository. Use when
 
 Review code changes in this repository against the project rules below. These rules exist because they have caused real production bugs — flag violations with high confidence.
 
-## Use the codebase-memory MCP server
+## codebase-memory MCP
 
-This repository has a `codebase-memory` MCP server available, preloaded with a graph of the whole codebase by `.github/workflows/copilot-code-review.yml`. **Use it** — a diff alone cannot tell you whether a change breaks a caller three files away.
+A `codebase-memory` MCP server is preloaded with a graph of this repo. Use it whenever a rule below needs evidence from outside the diff.
 
-Reach for it whenever a rule below needs evidence from outside the diff:
-
-- `list_projects` first — the project name is derived from the checkout path, so do not guess it.
-- `search_graph` to find a symbol; `get_code_snippet` for its exact source.
-- `trace_path` for callers and callees — this is what answers "does anything else depend on this?" before you flag or clear a signature change.
-- `query_graph` for multi-hop questions; `get_architecture` for orientation.
+- `list_projects` first — the project name comes from the checkout path; never guess it.
+- `trace_path` for callers and callees. This is what settles "does anything else depend on this?"
+- `search_graph` to find a symbol, `get_code_snippet` for its source, `query_graph` for multi-hop questions, `get_architecture` for orientation.
 - `search_code` only for literal or non-code text, or where graph coverage is thin.
 
-Concretely, the rules below that are unreliable without it: **#1** (a `getLcmConnection()` without a matching close may be closed by a caller), **#4** (`collectStats()` may be reached indirectly — trace it rather than eyeballing the diff), **#5** (whether a route already has tests lives outside the diff), and **#10** (whether a symbol named in prose still exists).
+Rules that are unreliable without it: **#1** (a caller may own the close), **#4** (`collectStats()` is often reached indirectly), **#5** (existing tests live outside the diff), **#10** (whether a named symbol still exists).
 
-Cite what you looked up. A finding backed by a `trace_path` result is worth more than one backed by a guess, and a claim that "nothing else calls this" is not reviewable unless you say how you checked.
+Cite what you looked up. "Nothing else calls this" is not reviewable unless you say how you checked.
 
 ## Repository context
 
@@ -87,11 +84,11 @@ TypeScript SQLite daemon that persists Claude session memories across context re
 - Daemon HTTP requests must send the `Authorization: ******` header; the token is read via `readAuthToken(join(homedir(), ".lossless-claude", "daemon.token"))`. Auth is mandatory; a 401 arrives as a normal HTTP response, not a socket error — flag client code paths that drop the header or mishandle 401s.
 - `DaemonClient` throws `Error` objects annotated with the HTTP status and parsed JSON body (`e.status`, `e.body`) on non-2xx responses — flag client code that swallows non-2xx responses or loses the status/body annotations.
 
-### 10. Source references in docs and comments
+### 10. Source references in prose
 
-- Prose that points at code must name **symbols**, not line numbers: `CompactionEngine.persistCompactionEvent`, not `src/compaction.ts:1331`. Line numbers rot on any edit above them — nobody has to touch the described code for the reference to go stale, and the stale number still looks plausible. A renamed symbol is greppable; a wrong line number is silent.
-- Flag any `path/to/file.ts:NNN` in Markdown, in a doc comment, or in a commit message, unless it is pinned to an immutable ref (a commit SHA, or an explicitly labelled review-finding identifier).
-- This applies to `.xgh/specs/`, `.xgh/plans/`, `docs/`, `AGENTS.md`, and skill files — anywhere a reader may follow the reference against a branch other than the one it was written on.
+- Point at **symbols**, not line numbers: `CompactionEngine.persistCompactionEvent`, not `src/compaction.ts:1331`. Line numbers rot on any edit above them, and a stale one still looks plausible; a renamed symbol is greppable.
+- Flag any `path/to/file.ts:NNN` in Markdown, doc comments, or commit messages, unless pinned to an immutable ref (a commit SHA, or a labelled review-finding identifier).
+- Applies to `.xgh/specs/`, `.xgh/plans/`, `docs/`, `AGENTS.md`, and skill files.
 
 ## What to skip
 

--- a/.github/workflows/copilot-code-review.yml
+++ b/.github/workflows/copilot-code-review.yml
@@ -1,0 +1,69 @@
+# Configures the ephemeral environment GitHub Copilot code review runs in.
+# Preinstalls codebase-memory-mcp and indexes this repo, so the MCP server
+# registered in repo settings has a graph to answer from.
+name: Copilot code review setup
+
+# Copilot invokes the `copilot-setup-steps` job directly; the triggers below only
+# exist so the job can be exercised manually and validated on its own PRs.
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-code-review.yml
+
+jobs:
+  # The job MUST be called `copilot-setup-steps` or Copilot will not pick it up.
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      # Pin the version: an unpinned "latest" changes the review environment
+      # underneath us without a commit to point at.
+      CBM_VERSION: v0.10.8
+      CBM_ASSET: codebase-memory-mcp-linux-amd64-portable.tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache codebase-memory-mcp binary
+        id: cbm-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.local/bin/codebase-memory-mcp
+          key: cbm-${{ env.CBM_VERSION }}-linux-amd64
+
+      - name: Install codebase-memory-mcp
+        if: steps.cbm-cache.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.local/bin
+          tmp="$(mktemp -d)"
+          gh release download "$CBM_VERSION" \
+            --repo DeusData/codebase-memory-mcp \
+            --pattern "$CBM_ASSET" \
+            --pattern checksums.txt \
+            --dir "$tmp"
+          # Verify before extracting — the checksums file covers every asset,
+          # so filter to the one we actually downloaded.
+          ( cd "$tmp" && grep " $CBM_ASSET\$" checksums.txt | sha256sum -c - )
+          tar -xzf "$tmp/$CBM_ASSET" -C "$tmp"
+          install -m 0755 "$(find "$tmp" -name codebase-memory-mcp -type f | head -1)" ~/.local/bin/codebase-memory-mcp
+          rm -rf "$tmp"
+
+      - name: Index the repository
+        run: |
+          set -euo pipefail
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          ~/.local/bin/codebase-memory-mcp --version
+          # Indexing this repo takes ~2s; the graph lands in ~/.cache and the
+          # MCP server reads it from there when Copilot starts.
+          ~/.local/bin/codebase-memory-mcp cli index_repository \
+            --repo-path "$GITHUB_WORKSPACE" --progress
+          ~/.local/bin/codebase-memory-mcp cli list_projects --json

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,7 +1,12 @@
-# Configures the ephemeral environment GitHub Copilot code review runs in.
-# Preinstalls codebase-memory-mcp and indexes this repo, so the MCP server
-# registered in repo settings has a graph to answer from.
-name: Copilot code review setup
+# Configures the ephemeral environment for BOTH Copilot code review and
+# Copilot cloud agent. Preinstalls codebase-memory-mcp and indexes this repo,
+# so the MCP server registered in repo settings has a graph to answer from.
+#
+# One file serves both on purpose: code review falls back to
+# copilot-setup-steps.yml when copilot-code-review.yml is absent, so keeping
+# only this one means the reviewer and the agent that writes fixes cannot
+# drift apart.
+name: Copilot setup steps
 
 # Copilot invokes the `copilot-setup-steps` job directly; the triggers below only
 # exist so the job can be exercised manually and validated on its own PRs.
@@ -9,10 +14,10 @@ on:
   workflow_dispatch:
   push:
     paths:
-      - .github/workflows/copilot-code-review.yml
+      - .github/workflows/copilot-setup-steps.yml
   pull_request:
     paths:
-      - .github/workflows/copilot-code-review.yml
+      - .github/workflows/copilot-setup-steps.yml
 
 jobs:
   # The job MUST be called `copilot-setup-steps` or Copilot will not pick it up.

--- a/.xgh/plans/2026-09-07-replay-ledger-redesign.md
+++ b/.xgh/plans/2026-09-07-replay-ledger-redesign.md
@@ -20,7 +20,7 @@ Steps 1–4 are the redesign. Steps 5–7 are ordinary bugs Codex found that are
 
 That change alone dissolves `import.ts:440`: a `no_work` row with `summary_id = NULL` is now a complete, valid row — the anchor search simply walks further back to the most recent non-null one.
 
-The anchor's definition matches today's de-facto behaviour, which should be written down rather than reinvented: `getSummariesByConversation` orders `BY created_at`, and `compact.ts:367` takes the last element. So **the anchor is the most recently created summary of that conversation**, regardless of depth.
+The anchor's definition matches today's de-facto behaviour, which should be written down rather than reinvented: `getSummariesByConversation` orders `BY created_at`, and the `else if (allSummaries.length > 0)` fallback in `createCompactHandler` (`src/daemon/routes/compact.ts`) takes the last element. So **the anchor is the most recently created summary of that conversation**, regardless of depth.
 
 **Migrations stay additive.** `.github/skills/code-review/SKILL.md` §7 (merged in #310) forbids destructive DDL, so nothing below drops a table or a column.
 
@@ -73,7 +73,7 @@ In one transaction:
    ORDER BY m.seq
    ```
 
-**Why the exclusion is mandatory:** `CompactionEngine.writeEvent` (`src/compaction.ts:1331`) calls `createMessage` + `createMessageParts` but **never** `appendContextMessage` — verified, `appendContextMessage` has no callers outside its own definition. So event rows live in `messages` and have never been in `context_items`. A naive `INSERT … SELECT FROM messages` would surface `"LCM compaction leaf pass (normal): 5000 -> 200"` into the model's context, which is a regression the current code does not have. Step 6 makes step 7's predicate redundant, but keep both — step 7 must be correct on its own if step 6 is ever reordered or dropped.
+**Why the exclusion is mandatory:** `CompactionEngine.persistCompactionEvent` (its local `writeEvent` closure, `src/compaction.ts`) calls `createMessage` + `createMessageParts` but **never** `appendContextMessage` — verified, `appendContextMessage` has no callers outside its own definition. So event rows live in `messages` and have never been in `context_items`. A naive `INSERT … SELECT FROM messages` would surface `"LCM compaction leaf pass (normal): 5000 -> 200"` into the model's context, which is a regression the current code does not have. Step 6 makes step 7's predicate redundant, but keep both — step 7 must be correct on its own if step 6 is ever reordered or dropped.
 
 Check the FTS5 mirror: `deleteMessageFromFullText` exists for messages — confirm whether summaries have an equivalent index that also needs clearing, and call it for both the summaries and the deleted event messages.
 
@@ -107,7 +107,7 @@ Run `countSummaries` over the affected conversations first and print the total, 
 
 **`src/batch-compact.ts`** — `findUncompacted`'s `source_messages` / `source_tokens` subquery currently uses `role != 'system'`, which over-excludes: `parseTranscript()` accepts `system` and the ingest route persists it.
 
-Use the exact discriminator instead — the compaction event's message part (`src/compaction.ts:1327` writes `role: "system"`, then a part with `part_type: "compaction"`):
+Use the exact discriminator instead — the compaction event's message part — `CompactionEngine.persistCompactionEvent` writes the row with `role: "system"`, then a part with `partType: "compaction"`:
 
 ```sql
 LEFT JOIN (

--- a/.xgh/plans/2026-09-07-replay-ledger-redesign.md
+++ b/.xgh/plans/2026-09-07-replay-ledger-redesign.md
@@ -1,32 +1,26 @@
 # Replay ledger redesign — implementation plan
 
-**Spec:** `.xgh/specs/2026-09-07-replay-ledger-redesign-design.md`
-**Supersedes:** the ledger implementation in PR #302 (draft)
-**Date:** 2026-09-07
-
-> **Reference convention:** `file.ts:NNN` labels are Codex finding identifiers against PR #302 @ `aa57b3f`, not line numbers in `main`. Claims about current behaviour name symbols instead.
+**Spec:** `.xgh/specs/2026-09-07-replay-ledger-redesign-design.md` · **Date:** 2026-09-07
 
 ## Approach
 
-Rework `copilot/make-replay-resumable` in place rather than starting a new branch — the manifest model, the `seenGap` suffix-resume rule and the SIGINT drain work are sound and should survive. What comes out is the ledger's summary bookkeeping and the `--restart` lineage machinery.
+Rework the `copilot/make-replay-resumable` branch in place. The manifest model, the suffix-resume rule and the SIGINT drain are sound and survive; what comes out is the ledger's summary bookkeeping and the `--restart` lineage machinery.
 
-Steps 1–4 are the redesign. Steps 5–7 are ordinary bugs Codex found that are independent of the model; they can land in any order. Step 8 is unrelated hygiene and should be its own PR.
+Steps 1–4 are the redesign. Steps 5–7 are bugs independent of the model and can land in any order. Step 8 is unrelated hygiene for its own PR.
 
 ---
 
 ## 0. Decisions that shape the steps
 
-**Threading stays** (Pedro, 2026-09-07). `previous_summary` continues to cross sessions, so steps 6–7 are in scope rather than dissolving.
+**Threading stays.** `previous_summary` continues to cross sessions, so steps 6–7 are in scope.
 
-**The anchor rule, formalised.** With threading kept, resume must re-establish the chain in a fresh process. Rather than re-deriving it by query, `replay_ledger` **keeps `summary_id` as a nullable anchor-only column**. Its *purpose* changes: it is no longer what `--restart` deletes (that is now conversation-scoped), only where the chain picks up.
+**`summary_id` stays as a nullable anchor-only column.** Resume must re-establish the chain in a fresh process; keeping the column is fewer moving parts than re-deriving it by query. Its purpose changes: it is no longer what `--restart` deletes. A `no_work` row with a NULL anchor is then complete and valid, and the anchor search walks further back.
 
-That change alone dissolves `import.ts:440`: a `no_work` row with `summary_id = NULL` is now a complete, valid row — the anchor search simply walks further back to the most recent non-null one.
+**Anchor rule.** `getSummariesByConversation` orders `BY created_at` and the `else if (allSummaries.length > 0)` fallback in `createCompactHandler` takes the last element. Written down: *the anchor is the most recently created summary of that conversation, regardless of depth.*
 
-The anchor's definition matches today's de-facto behaviour, which should be written down rather than reinvented: `getSummariesByConversation` orders `BY created_at`, and the `else if (allSummaries.length > 0)` fallback in `createCompactHandler` (`src/daemon/routes/compact.ts`) takes the last element. So **the anchor is the most recently created summary of that conversation**, regardless of depth.
+**Migrations stay additive.** `.github/skills/code-review/SKILL.md` §7 forbids destructive DDL, so nothing below drops a table or column.
 
-**Migrations stay additive.** `.github/skills/code-review/SKILL.md` §7 (merged in #310) forbids destructive DDL, so nothing below drops a table or a column.
-
-## 1. Adjust the ledger schema (additive only)
+## 1. Adjust the ledger schema
 
 **`src/db/migration.ts`**
 
@@ -34,22 +28,23 @@ The anchor's definition matches today's de-facto behaviour, which should be writ
   ```sql
   ALTER TABLE replay_ledger ADD COLUMN outcome TEXT NOT NULL DEFAULT 'compacted';
   ```
-- Remove the `CREATE TABLE IF NOT EXISTS replay_ledger_summaries` block and its index so new databases never get it. **Do not `DROP` it** — dev databases that ran round 1 keep a harmless orphan table.
-- `prev_session_id` and `model` stay in the schema as nullable columns but stop being written. `summary_id` stays and keeps being written, now as the threading anchor only (see §0).
+- Remove the `CREATE TABLE IF NOT EXISTS replay_ledger_summaries` block and its index so new databases never get it. **Do not `DROP` it** — existing dev databases keep a harmless orphan table.
+- `prev_session_id` and `model` stay in the schema as nullable columns but stop being written. `summary_id` stays and keeps being written, as the threading anchor.
 
 Resulting row: `(run_id, session_id, position, content_fingerprint, summary_id?, outcome, completed_at)`.
 
 ## 2. Add the wipe-and-rebuild helper
 
-**`src/store/summary-store.ts`** — new method, since no wipe path exists today (`grep -rn "DELETE FROM context_items" src/` returns only `replaceContextRangeWithSummary` and the redaction path in `conversation-store.ts`).
+**`src/store/summary-store.ts`** — new method; no wipe path exists today.
 
 ```ts
 async resetConversationContext(conversationId: number): Promise<number>
 ```
 
-Pair it with a read-only `countSummaries(conversationId)` so `--restart` can report the total **before** wiping anything (the spec requires the warning to precede the deletion, and the reset method can only return a count after the fact).
+Pair it with a read-only `countSummaries(conversationId)`, so `--restart` can report the total **before** wiping — the reset method can only count after the fact.
 
 In one transaction:
+
 1. Collect `summary_id`s for the conversation.
 2. `DELETE FROM summary_messages WHERE summary_id IN (...)`
 3. `DELETE FROM summary_parents WHERE summary_id IN (...) OR parent_summary_id IN (...)`
@@ -62,7 +57,7 @@ In one transaction:
      WHERE p.message_id = messages.message_id AND p.part_type = 'compaction'
    )
    ```
-7. Rebuild — **excluding compaction events**:
+7. Rebuild, **excluding compaction events**:
    ```sql
    INSERT INTO context_items (conversation_id, ordinal, item_type, message_id)
    SELECT ?, ROW_NUMBER() OVER (ORDER BY m.seq) - 1, 'message', m.message_id
@@ -75,41 +70,31 @@ In one transaction:
    ORDER BY m.seq
    ```
 
-**Why the exclusion is mandatory:** `CompactionEngine.persistCompactionEvent` (its local `writeEvent` closure, `src/compaction.ts`) calls `createMessage` + `createMessageParts` but **never** `appendContextMessage` — verified, `appendContextMessage` has no callers outside its own definition. So event rows live in `messages` and have never been in `context_items`. A naive `INSERT … SELECT FROM messages` would surface `"LCM compaction leaf pass (normal): 5000 -> 200"` into the model's context, which is a regression the current code does not have. Step 6 makes step 7's predicate redundant, but keep both — step 7 must be correct on its own if step 6 is ever reordered or dropped.
+The exclusion is mandatory: event rows have never been in `context_items`, so an unfiltered rebuild would surface `"LCM compaction leaf pass…"` into the model's context. Step 6 makes step 7's predicate redundant — keep both, so step 7 stays correct on its own.
 
-Check the FTS5 mirror: `deleteMessageFromFullText` exists for messages — confirm whether summaries have an equivalent index that also needs clearing, and call it for both the summaries and the deleted event messages.
+Check the FTS5 mirror: `deleteMessageFromFullText` exists for messages; confirm whether summaries have an equivalent index needing the same treatment, and call it for both the summaries and the deleted event rows.
 
 ## 3. Rewrite `clearReplayState`
 
-**`src/replay-resume.ts`**
+**`src/replay-resume.ts`** — delete `loadReplaySummaryIds`, `expandSummaryToMessageIds`, `restoreContextFromReplaySummaries`, and every `UNION ALL` subquery over the ledger tables.
 
-Delete outright:
-- `loadReplaySummaryIds`
-- `expandSummaryToMessageIds`
-- `restoreContextFromReplaySummaries`
-- every `UNION ALL` subquery over `replay_ledger` + `replay_ledger_summaries`
-
-Replace with: resolve the conversations for the run's manifest sessions → `resetConversationContext` on each → delete the run's `replay_ledger` rows. Keep the `missing` / `error` / `ready` distinction from round 1 — it was right, and it is what makes `clearReplayState` return `false` on an unusable database.
+Replace with: resolve the conversations for the run's manifest sessions → `resetConversationContext` on each → delete the run's `replay_ledger` rows. Keep the `missing` / `error` / `ready` distinction in `openProjectDb` — it is what lets `clearReplayState` return `false` on an unusable database rather than silently reporting success.
 
 Run `countSummaries` over the affected conversations first and print the total, then wipe.
 
 ## 4. Record `outcome`; keep `summary_id` as the anchor
 
-**`src/import.ts`, `src/batch-compact.ts`**
+**`src/import.ts`, `src/batch-compact.ts`** — `recordReplayProgress` loses `summaryIds` and `prevSessionId`, gains `outcome: "compacted" | "no_work"`, and keeps `summaryId` (nullable). Keep the `replayOutcome` gating that prevents disabled compactions being recorded as done.
 
-`recordReplayProgress` loses `summaryIds` and `prevSessionId`; gains `outcome: "compacted" | "no_work"`; **keeps** `summaryId` (nullable) per §0. The `replayOutcome` gating from round 1 stays — it is the fix for "disabled compactions recorded as done" and is independent of this rework.
+**Resume anchor lookup** in `planProject`: from the last done row before the first gap, walk backwards to the most recent row with a non-null `summary_id` and load its content. A run of `no_work` rows is skipped, not treated as a broken chain.
 
-**Resume anchor lookup** in `planProject`: from the last done row before the first gap, walk backwards to the most recent row with a non-null `summary_id` and load its content. A run of `no_work` rows is skipped rather than treated as a broken chain — that is what dissolves `import.ts:440`.
+**`src/daemon/routes/compact.ts`** — drop `latestSummaryIds` from the response; keep `latestSummaryContent` (threading), `latestSummaryId` (ledger) and `replayOutcome`. The `else if (allSummaries.length > 0)` fallback stays, now as the documented anchor rule.
 
-**`src/daemon/routes/compact.ts`** — `latestSummaryIds` goes from the response; `latestSummaryContent` and `latestSummaryId` stay (threading needs the content, the ledger needs the id). Keep `replayOutcome`. The `else if (allSummaries.length > 0)` fallback stays and is now the *documented* anchor rule (§0) rather than an accident.
+**`src/compaction.ts`** — `createdSummaryIds` on `CompactionResult` is no longer read by replay. Keep it in the compaction-event `metadata`; drop it from the route response only.
 
-**`src/compaction.ts`** — `createdSummaryIds` on `CompactionResult` is no longer read by replay. Keep it in the compaction-event `metadata` (harmless, useful for debugging); drop it from the route response only.
+## 5. Fix the fingerprint predicate
 
-## 5. Fix the fingerprint predicate (2 findings)
-
-**`src/batch-compact.ts`** — `findUncompacted`'s `source_messages` / `source_tokens` subquery currently uses `role != 'system'`, which over-excludes: `parseTranscript()` accepts `system` and the ingest route persists it.
-
-Use the exact discriminator instead — the compaction event's message part — `CompactionEngine.persistCompactionEvent` writes the row with `role: "system"`, then a part with `partType: "compaction"`:
+**`src/batch-compact.ts`** — `findUncompacted`'s `source_messages` / `source_tokens` subquery uses `role != 'system'`, which over-excludes: `parseTranscript()` accepts `system` and the ingest route persists it. Use the exact discriminator:
 
 ```sql
 LEFT JOIN (
@@ -123,21 +108,21 @@ LEFT JOIN (
 ) src ON src.conversation_id = c.conversation_id
 ```
 
-Closes `batch-compact.ts:274` and `batch-compact.ts:72` together. Add a test that compacts twice and asserts the fingerprint is unchanged.
+Add a test that compacts twice and asserts the fingerprint is unchanged.
 
 ## 6. Send `previous_summary` from `batchCompact`
 
-**`src/batch-compact.ts:156`** — Codex re-raised this on `aa57b3f`, so verify against the current branch state rather than assuming the round-1 edit landed correctly. The `/compact` request must carry `previous_summary` from `previousSummaryByCwd`, and the response's `latestSummaryContent` must write back into it.
+The `/compact` request must carry `previous_summary` from `previousSummaryByCwd`, and the response's `latestSummaryContent` must write back into it. Verify against the current branch state rather than assuming an earlier edit landed correctly.
 
 ## 7. Per-project chain state and double-clear
 
-- **`src/replay-resume.ts:509`** — restored chains still collapse to one value across projects. Round 1 added `restoredPreviousSummaries` (per `cwd`); confirm every consumer reads the per-`cwd` map and that the legacy single-value `restoredPreviousSummary` / `droppedPreviousSummary` fields are removed, not merely shadowed.
-- **`src/import.ts:276`** — with `provider: "all"`, `ingestSessionList()` runs twice. Hoist the `--restart` clear out of `ingestSessionList` into `importSessions`, or guard it with a per-`(cwd, command)` set for the whole call, so a shared `cwd` is cleared once.
+- **`src/replay-resume.ts`** — confirm every consumer reads the per-`cwd` `restoredPreviousSummaries` map, and that the single-value `restoredPreviousSummary` / `droppedPreviousSummary` fields are removed rather than merely shadowed.
+- **`src/import.ts`** — with `provider: "all"`, `ingestSessionList()` runs twice. Hoist the `--restart` clear into `importSessions`, or guard it with a per-`(cwd, command)` set for the whole call, so a shared `cwd` is cleared once.
 
 ## 8. Unrelated — separate PR
 
-- **`src/cli/pipeline-runner.ts:76`** — a second SIGINT/SIGTERM is discarded, so a hung daemon POST cannot be interrupted. Let the second signal force exit.
-- **`docs/architecture.md:113`** — docs describe size + line count + mtime; `fingerprintFile` now persists size + floored mtime. Align the doc (or restore the line count, but the streaming version was removed deliberately).
+- **`src/cli/pipeline-runner.ts`** — a second SIGINT/SIGTERM is discarded, so a hung daemon POST cannot be interrupted. Let the second signal force exit.
+- **`docs/architecture.md`** — the doc describes a size + line-count + mtime fingerprint; `fingerprintFile` persists size + floored mtime.
 
 ---
 
@@ -146,18 +131,18 @@ Closes `batch-compact.ts:274` and `batch-compact.ts:72` together. Add a test tha
 - `test/replay-resume.test.ts` — replace summary-id assertions with `outcome`; add: restart on a conversation carrying both hook and replay summaries wipes both and rebuilds `context_items` from `messages` in `seq` order.
 - New: fingerprint stability across two consecutive compactions of an unchanged conversation.
 - New: `provider: "all"` with a shared `cwd` clears replay state exactly once.
-- Keep the round-1 `seenGap` suffix-resume tests unchanged — that rule survives.
+- Keep the existing suffix-resume tests unchanged.
 
 ## Verification
 
-`npm run typecheck` and `npm test`. Note two pre-existing unrelated failures observed on this branch: `test/daemon/routes/restore.test.ts` and `test/daemon/routes/stats.test.ts` (the latter a 60s `/stats` timeout).
+`npm run typecheck` and `npm test`. Two pre-existing unrelated failures have been observed on this branch: `test/daemon/routes/restore.test.ts` and `test/daemon/routes/stats.test.ts` (the latter a 60s `/stats` timeout).
 
 ## Known gap, not addressed here
 
-`--restart` runs in the CLI process and wipes summaries while the daemon may be compacting the same conversation. The daemon's `compactingNow` guard is per-request and in-process, so it does not serialise against an external wipe. This is pre-existing to #302 and not introduced by the redesign, but it is the kind of thing Codex raises — either refuse `--restart` while a daemon lock is held, or state explicitly that `--restart` assumes no concurrent compaction. Decide before the review round rather than during it.
+`--restart` runs in the CLI process and wipes summaries while the daemon may be compacting the same conversation. The daemon's `compactingNow` guard is per-request and in-process, so it does not serialise against an external wipe. Pre-existing, not introduced by this redesign — either refuse `--restart` while a daemon lock is held, or state explicitly that it assumes no concurrent compaction.
 
 ## Docs to update in the same PR
 
-- **PR #302's description** — the "hook-written summaries are untouched" line is now false and must be replaced with the wipe semantics.
+- The pull request description — the "hook-written summaries are untouched" claim is now false and must be replaced with the wipe semantics.
 - `docs/architecture.md` — replay/restart section, if one exists.
-- Help text for `--restart` on both `import` and `compact`: it must say it discards **all** summaries in the conversations the run touched.
+- Help text for `--restart` on both `import` and `compact`: it discards **all** summaries in the conversations the run touched.

--- a/.xgh/plans/2026-09-07-replay-ledger-redesign.md
+++ b/.xgh/plans/2026-09-07-replay-ledger-redesign.md
@@ -4,6 +4,8 @@
 **Supersedes:** the ledger implementation in PR #302 (draft)
 **Date:** 2026-09-07
 
+> **Reference convention:** `file.ts:NNN` labels are Codex finding identifiers against PR #302 @ `aa57b3f`, not line numbers in `main`. Claims about current behaviour name symbols instead.
+
 ## Approach
 
 Rework `copilot/make-replay-resumable` in place rather than starting a new branch — the manifest model, the `seenGap` suffix-resume rule and the SIGINT drain work are sound and should survive. What comes out is the ledger's summary bookkeeping and the `--restart` lineage machinery.

--- a/.xgh/specs/2026-09-07-replay-ledger-redesign-design.md
+++ b/.xgh/specs/2026-09-07-replay-ledger-redesign-design.md
@@ -7,6 +7,8 @@
 
 PR #302 went through two Codex review rounds. Round 1 filed 13 findings (10 P1); all 13 were addressed in `e6007b3` and the diff was sound on its own terms. Round 2 on `aa57b3f` filed 10 more (7 P1) — and **four were the same findings re-raised**, meaning the round-1 fix had not actually closed them. One P1 was *created* by the round-1 fix. That is not a patch queue converging; it is a model that does not fit.
 
+> **Reference convention:** `file.ts:NNN` labels below are Codex finding identifiers against PR #302 @ `aa57b3f`, not line numbers in `main`. Claims about current behaviour name symbols instead.
+
 ## The mismatch, in one line
 
 `replay_ledger` records a compaction as **one row: `(session_id, summary_id, fingerprint)`**. A compaction is not one summary.
@@ -60,7 +62,7 @@ The argument that settles it: **wiping summaries loses no information.** Message
 
 **`context_items` is a derived view.** Three facts make this true today:
 
-1. **Compaction never deletes messages.** `replaceContextRangeWithSummary` (`src/store/summary-store.ts:617`) deletes only `context_items` rows in a range, inserts one summary item, and resequences ordinals. The only `DELETE FROM messages` in the codebase is `ConversationStore.deleteMessages`, a separate redaction path.
+1. **Compaction never deletes messages.** `SummaryStore.replaceContextRangeWithSummary` deletes only `context_items` rows in a range, inserts one summary item, and resequences ordinals. The only `DELETE FROM messages` in the codebase is `ConversationStore.deleteMessages`, a separate redaction path.
 2. **`messages.seq` is the authoritative order.** Ingest appends in `seq` order; `context_items.ordinal` is a compacted projection of it.
 3. **`summary_messages` records exactly what each summary covers**, so a summary is invertible by construction.
 
@@ -101,15 +103,15 @@ Note the migration is **additive**: `.github/skills/code-review/SKILL.md` §7 fo
 
 ### The rebuild must exclude compaction events
 
-`CompactionEngine.writeEvent` (`src/compaction.ts:1331`) writes its `"LCM compaction leaf pass (normal): 5000 -> 200"` row into `messages` + `message_parts` but **never** into `context_items` — `appendContextMessage` has no callers outside its own definition. So a naive `INSERT … SELECT FROM messages` would surface compaction noise into the model's context, a regression the current code does not have. The rebuild filters on the same `part_type = 'compaction'` predicate used for the fingerprint below, and the wipe deletes those now-stale event rows outright.
+`CompactionEngine.persistCompactionEvent` (its local `writeEvent` closure, `src/compaction.ts`) writes its `"LCM compaction leaf pass (normal): 5000 -> 200"` row into `messages` + `message_parts` but **never** into `context_items` — `appendContextMessage` has no callers outside its own definition. So a naive `INSERT … SELECT FROM messages` would surface compaction noise into the model's context, a regression the current code does not have. The rebuild filters on the same `part_type = 'compaction'` predicate used for the fingerprint below, and the wipe deletes those now-stale event rows outright.
 
 ### The fingerprint has an exact discriminator
 
 Both fingerprint findings reduce to one question — *how do I count source messages while excluding compaction events?* — and it has a factual answer, not a design choice.
 
-`CompactionEngine` writes its event row as `role: "system"` (`src/compaction.ts:1327`), which is why the round-1 fix used `WHERE role != 'system'`. Codex correctly rejected that: `parseTranscript()` also accepts `system` and the ingest route persists it, so genuine transcript system messages get excluded too.
+`CompactionEngine.persistCompactionEvent` writes its event row as `role: "system"`, which is why the round-1 fix used `WHERE role != 'system'`. Codex correctly rejected that: `parseTranscript()` also accepts `system` and the ingest route persists it, so genuine transcript system messages get excluded too.
 
-But the event row also gets a message part with **`part_type = 'compaction'`** (`src/compaction.ts:~1335`). That is exact:
+But the same method also attaches a message part with **`partType: "compaction"`**. That is exact:
 
 ```sql
 WHERE NOT EXISTS (
@@ -145,7 +147,7 @@ That has one consequence for the row shape above: resume must re-establish the c
 
 This is also what dissolves `import.ts:440` cleanly: a `no_work` row with `summary_id = NULL` is a complete, valid row, and the anchor search walks further back to the most recent non-null one instead of treating it as a broken chain.
 
-**The anchor rule, written down.** Today it is implicit: `getSummariesByConversation` orders `BY created_at` and `compact.ts:367` takes the last element. Formalised: *the anchor is the most recently created summary of that conversation, regardless of depth.*
+**The anchor rule, written down.** Today it is implicit: `getSummariesByConversation` orders `BY created_at` and the `else if (allSummaries.length > 0)` fallback in `createCompactHandler` (`src/daemon/routes/compact.ts`) takes the last element. Formalised: *the anchor is the most recently created summary of that conversation, regardless of depth.*
 
 ## Not covered here
 

--- a/.xgh/specs/2026-09-07-replay-ledger-redesign-design.md
+++ b/.xgh/specs/2026-09-07-replay-ledger-redesign-design.md
@@ -1,72 +1,47 @@
 # Replay ledger redesign
 
-**Status:** design, not implemented · **Supersedes:** the ledger model in PR #302 (now draft)
-**Date:** 2026-09-07
+**Status:** design, not implemented · **Date:** 2026-09-07
 
-## Why this exists
+## The mismatch
 
-PR #302 went through two Codex review rounds. Round 1 filed 13 findings (10 P1); all 13 were addressed in `e6007b3` and the diff was sound on its own terms. Round 2 on `aa57b3f` filed 10 more (7 P1) — and **four were the same findings re-raised**, meaning the round-1 fix had not actually closed them. One P1 was *created* by the round-1 fix. That is not a patch queue converging; it is a model that does not fit.
+`replay_ledger` records a compaction as one row: `(session_id, summary_id, fingerprint)`. A compaction is not one summary. Four consequences, each of which has to be handled somewhere:
 
-> **Reference convention:** `file.ts:NNN` labels below are Codex finding identifiers against PR #302 @ `aa57b3f`, not line numbers in `main`. Claims about current behaviour name symbols instead.
+| Reality | The row cannot express it |
+|---|---|
+| One `/compact` produces several summaries across depths | only a single `latestSummaryId` fits |
+| A session can complete producing **no** summary | `summary_id = NULL` reads as a broken chain, destroying the resume anchor |
+| A replay summary is later absorbed by a normal or hook-created condensed summary | a direct-membership check finds nothing to restore, and the parent is deleted anyway |
+| The "unchanged" fingerprint counts rows compaction itself writes | every completed session looks changed and is replayed again |
 
-## The mismatch, in one line
+Patching these individually keeps exposing the next one: they are the same defect from four angles.
 
-`replay_ledger` records a compaction as **one row: `(session_id, summary_id, fingerprint)`**. A compaction is not one summary.
+## Decision: `--restart` wipes, it does not undo
 
-Every recurring P1 is a place where that shape is too narrow:
+The constraint that forces surgical undo is the promise that hook-written summaries survive `--restart`, by scoping deletes to replay-owned `summary_id`s. **That promise is dropped.**
 
-| Reality | Row can't express it | Finding |
-|---|---|---|
-| One `/compact` produces several summaries across depths | only `latestSummaryId` fits | `db/migration.ts:650` |
-| A session can complete producing **no** summary (`no_work`) | row records `summary_id = NULL`, destroying the resume anchor | `import.ts:440` (introduced by the round-1 fix) |
-| A replay summary is later absorbed by a normal/hook condensed summary | direct-membership check restores nothing, then the parent is deleted anyway | `replay-resume.ts:642` |
-| The "unchanged" fingerprint is computed over rows compaction itself writes | every completed session looks changed | `batch-compact.ts:274`, `batch-compact.ts:72` |
-
-Patching each symptom keeps exposing the next one because they are the same defect seen from four angles.
-
-## The decision: drop the "untouched summaries" promise
-
-The constraint that forced all the surgery is stated in **PR #302's own description**, not in `AGENTS.md` or any pre-existing repo contract:
-
-> `--restart` (new flag on both commands) deletes ledger rows and the summaries they recorded — **hook-written summaries are untouched** since deletes are scoped to ledger `summary_id`s.
-
-(Codex's `AGENTS.md:L78` citations point at the generic "Doc/code alignment" review bullet, not at a summary-lifetime guarantee. There was no older promise to honour.)
-
-Keeping it required walking `summary_parents` lineage, expanding summaries back into source messages, and splicing `context_items` in place — the machinery that did not converge across two review rounds.
-
-### Why the promise is hard to keep
-
-Mixing is the *normal* case, not the exception. `findUncompacted` deliberately includes already-compacted conversations under replay:
+**It cannot hold as written.** Mixing is the normal case: `findUncompacted` deliberately includes already-compacted conversations under replay —
 
 ```sql
 AND (? OR COALESCE(s.sum_count, 0) = 0)   -- replay=1 → include already-summarised conversations
 ```
 
-So a replay routinely compacts on top of hook-written summaries, and a replay summary can **absorb** a hook summary as a parent. Deleting only replay-scoped `summary_id`s then leaves the conversation without the hook summaries anyway — the promise fails precisely where it was meant to hold.
+— so a replay routinely compacts on top of hook summaries, and a replay summary can absorb a hook summary as a parent. Scoped deletes then leave the conversation without its hook summaries anyway. The promise fails exactly where it was meant to hold.
 
-### Three positions, and the one chosen
+**Dropping it is cheap.** Wiping summaries loses no information: messages are never deleted, and `context_items` is a projection over them, so everything wiped is re-derivable. The cost is LLM calls to re-summarise — money and time, not data.
 
-| | Behaviour | Cost |
-|---|---|---|
-| **1. Wipe** *(chosen)* | `--restart` deletes **all** summaries in the conversations the run touched and rebuilds `context_items` from `messages` | Hook summaries are regenerated by the next compaction |
-| 2. Refuse | `--restart` skips conversations carrying non-replay summaries | Since mixing is normal, `--restart` would refuse almost always — a flag that rarely works |
-| 3. Exact undo | current #302 approach | Two rounds without convergence; source of 3 of the P1s |
+The alternative — refusing `--restart` on conversations carrying non-replay summaries — keeps the guarantee, but since mixing is normal it would refuse almost every run.
 
-**Decision (Pedro, 2026-09-07): option 1.**
+`--restart` reports how many summaries it will discard before discarding them.
 
-The argument that settles it: **wiping summaries loses no information.** Messages are never deleted; `context_items` is a projection. Everything wiped is re-derivable. The real cost is LLM calls to re-summarise — money and time, not data. Option 2 protects cheap-to-rebuild work at the price of a `--restart` that almost never runs.
+## The model
 
-`--restart` must therefore print how many summaries it will regenerate before doing it.
+**`context_items` is a derived view.** Three facts:
 
-## The model, if the promise is relaxed
+1. **Compaction never deletes messages.** `SummaryStore.replaceContextRangeWithSummary` deletes only `context_items` rows in a range, inserts one summary item, and resequences ordinals. The only `DELETE FROM messages` is `ConversationStore.deleteMessages`, a separate redaction path.
+2. **`messages.seq` is the authoritative order.** `context_items.ordinal` is a compacted projection of it.
+3. **`summary_messages` records what each summary covers**, so a summary is invertible by construction.
 
-**`context_items` is a derived view.** Three facts make this true today:
-
-1. **Compaction never deletes messages.** `SummaryStore.replaceContextRangeWithSummary` deletes only `context_items` rows in a range, inserts one summary item, and resequences ordinals. The only `DELETE FROM messages` in the codebase is `ConversationStore.deleteMessages`, a separate redaction path.
-2. **`messages.seq` is the authoritative order.** Ingest appends in `seq` order; `context_items.ordinal` is a compacted projection of it.
-3. **`summary_messages` records exactly what each summary covers**, so a summary is invertible by construction.
-
-Therefore `--restart` does not need to *invert* anything:
+So `--restart` rebuilds rather than inverts:
 
 ```
 restart(conversation):
@@ -77,41 +52,39 @@ restart(conversation):
   -- then drop the summaries the run produced, with their parents/messages links
 ```
 
-No lineage walk, no expansion, no ordinal splicing, no cache keyed by the wrong thing. Roughly 20 lines; no such helper exists today (`grep -rn "DELETE FROM context_items" src/` returns only the two call sites above).
+No lineage walk, no expansion, no ordinal splicing. No such helper exists today.
 
-### The ledger row becomes
+### The rebuild must exclude compaction events
+
+`CompactionEngine.persistCompactionEvent` writes its `"LCM compaction leaf pass…"` row into `messages` + `message_parts` but never into `context_items` — `appendContextMessage` has no callers outside its own definition. A naive `INSERT … SELECT FROM messages` would therefore surface compaction noise into the model's context, a regression the current code does not have. The rebuild filters on the `part_type = 'compaction'` predicate below, and the wipe deletes those now-stale event rows.
+
+### The ledger row
 
 ```sql
 CREATE TABLE replay_ledger (
-  run_id             TEXT NOT NULL,
-  session_id         TEXT NOT NULL,
-  position           INTEGER NOT NULL,
+  run_id              TEXT NOT NULL,
+  session_id          TEXT NOT NULL,
+  position            INTEGER NOT NULL,
   content_fingerprint TEXT NOT NULL,
-  summary_id         TEXT,             -- nullable; threading anchor ONLY (see below)
-  outcome            TEXT NOT NULL,   -- 'compacted' | 'no_work'
-  completed_at       TEXT NOT NULL,
+  summary_id          TEXT,            -- nullable; threading anchor only
+  outcome             TEXT NOT NULL,   -- 'compacted' | 'no_work'
+  completed_at        TEXT NOT NULL,
   PRIMARY KEY (run_id, session_id)
 );
 ```
 
-Gone: `prev_session_id`, and the whole `replay_ledger_summaries` table added in round 1. `summary_id` survives but stops being the thing `--restart` deletes — see "Cross-session threading" below.
+`prev_session_id` goes, as does the separate per-summary table. `summary_id` survives but stops being what `--restart` deletes.
 
-Note the migration is **additive**: `.github/skills/code-review/SKILL.md` §7 forbids destructive DDL, so the unused columns stay in the schema and simply stop being written, and `replay_ledger_summaries` is removed from the create path rather than dropped.
+The migration is **additive** — `.github/skills/code-review/SKILL.md` §7 forbids destructive DDL — so retired columns stay in the schema and simply stop being written.
 
-- **Resume** = skip rows whose fingerprint matches *and* that precede the first gap (the `seenGap` rule from round 1 is right and survives).
-- **Restart** = for each session in the run's manifest: wipe that conversation's summaries, rebuild `context_items`, delete its ledger rows.
+- **Resume** — skip rows whose fingerprint matches *and* that precede the first gap.
+- **Restart** — for each session in the run's manifest: wipe that conversation's summaries, rebuild `context_items`, delete its ledger rows.
 
-### The rebuild must exclude compaction events
+### The fingerprint discriminator
 
-`CompactionEngine.persistCompactionEvent` (its local `writeEvent` closure, `src/compaction.ts`) writes its `"LCM compaction leaf pass (normal): 5000 -> 200"` row into `messages` + `message_parts` but **never** into `context_items` — `appendContextMessage` has no callers outside its own definition. So a naive `INSERT … SELECT FROM messages` would surface compaction noise into the model's context, a regression the current code does not have. The rebuild filters on the same `part_type = 'compaction'` predicate used for the fingerprint below, and the wipe deletes those now-stale event rows outright.
+Counting source messages while excluding compaction events has a factual answer, not a design choice.
 
-### The fingerprint has an exact discriminator
-
-Both fingerprint findings reduce to one question — *how do I count source messages while excluding compaction events?* — and it has a factual answer, not a design choice.
-
-`CompactionEngine.persistCompactionEvent` writes its event row as `role: "system"`, which is why the round-1 fix used `WHERE role != 'system'`. Codex correctly rejected that: `parseTranscript()` also accepts `system` and the ingest route persists it, so genuine transcript system messages get excluded too.
-
-But the same method also attaches a message part with **`partType: "compaction"`**. That is exact:
+`CompactionEngine.persistCompactionEvent` writes its event row with `role: "system"`, so `WHERE role != 'system'` looks right — but `parseTranscript()` also accepts `system` and the ingest route persists it, so that over-excludes genuine transcript messages. The same method attaches a message part with `partType: "compaction"`. That is exact:
 
 ```sql
 WHERE NOT EXISTS (
@@ -120,35 +93,16 @@ WHERE NOT EXISTS (
 )
 ```
 
-(Side note: that part's `metadata` already carries `createdSummaryIds`. The information the round-1 ledger table was invented to store already exists — another sign the table was the wrong answer.)
-
-## What this does to the round-2 findings
-
-| Finding | Under the rebuild model |
-|---|---|
-| `db/migration.ts:650` — only final `latestSummaryId` retained | **Dissolves.** No summary ids in the ledger at all. |
-| `import.ts:440` — `no_work` records `summary_id = NULL`, kills the anchor | **Dissolves.** `outcome` is a first-class column, so a NULL-anchor row is complete and valid; the anchor search walks further back. |
-| `replay-resume.ts:642` — sources hidden beneath surviving summaries | **Dissolves.** No expansion; rebuild from `messages`. |
-| `batch-compact.ts:274` — unstable batch fingerprint | **Collapses** into the `part_type = 'compaction'` predicate. |
-| `batch-compact.ts:72` — `role = 'system'` over-excludes | **Same predicate.** One fix, both findings. |
-| `batch-compact.ts:156` — `batchCompact()` never sends `previous_summary` | **Ordinary bug.** Independent of the ledger model. |
-| `replay-resume.ts:509` — restored chains collapse across projects | **Ordinary bug.** Per-`cwd` map; round-1 fix was on the right track. |
-| `import.ts:276` — `provider: "all"` clears replay state twice | **Ordinary bug.** Guard the clear per `(cwd, command)` for the whole `importSessions` call. |
-| `cli/pipeline-runner.ts:76` — second SIGINT discarded | **Unrelated.** Separate commit. |
-| `docs/architecture.md:113` — fingerprint doc drift | **Unrelated.** Separate commit (docs say size + line count + mtime; `fingerprintFile` persists size + floored mtime). |
-
-Three P1s vanish. Two collapse into one predicate. Three are plain bugs. Two are unrelated hygiene. That is what convergence looks like.
+That part's `metadata` already carries `createdSummaryIds` — the information a separate ledger table would exist to store is already recorded.
 
 ## Cross-session threading — kept
 
-**Decision (Pedro, 2026-09-07): `previous_summary` continues to cross sessions.** It is worth the per-project chain bookkeeping.
+`previous_summary` continues to cross sessions; it is worth the per-project chain bookkeeping.
 
-That has one consequence for the row shape above: resume must re-establish the chain in a fresh process, so **`summary_id` stays as a nullable anchor-only column**. Its purpose changes rather than disappearing — it is no longer what `--restart` deletes (that is conversation-scoped now), only where the chain picks up. `prev_session_id` still goes.
+Resume must therefore re-establish the chain in a fresh process, which is why `summary_id` stays as a nullable anchor. A `no_work` row with a NULL anchor is complete and valid — the anchor search walks further back to the most recent non-null one rather than treating it as a broken chain.
 
-This is also what dissolves `import.ts:440` cleanly: a `no_work` row with `summary_id = NULL` is a complete, valid row, and the anchor search walks further back to the most recent non-null one instead of treating it as a broken chain.
+**Anchor rule.** Implicit today: `getSummariesByConversation` orders `BY created_at` and the `else if (allSummaries.length > 0)` fallback in `createCompactHandler` takes the last element. Formalised: *the anchor is the most recently created summary of that conversation, regardless of depth.*
 
-**The anchor rule, written down.** Today it is implicit: `getSummariesByConversation` orders `BY created_at` and the `else if (allSummaries.length > 0)` fallback in `createCompactHandler` (`src/daemon/routes/compact.ts`) takes the last element. Formalised: *the anchor is the most recently created summary of that conversation, regardless of depth.*
+## Not covered
 
-## Not covered here
-
-The manifest model (`replay_manifest`, frozen order, appends on adoption) is sound and survives unchanged, as does the `seenGap` suffix-resume rule. This redesign touches the ledger and `--restart` only.
+The manifest model (`replay_manifest`, frozen order, appends on adoption) is sound and survives unchanged, as does the suffix-resume rule that replays everything after the first incomplete position. This redesign touches the ledger and `--restart` only.


### PR DESCRIPTION
Started as a fix for two stale source references Copilot flagged on #318, then grew into the reason those references went stale unnoticed.

## 1. The two findings (both correct)

- The compaction event writer is `CompactionEngine.persistCompactionEvent` (with a local `writeEvent` closure), not a `writeEvent` method.
- The anchor fallback cited as `compact.ts:367` sits around line 354 in `main`.

**Cause:** I read those line numbers off the #302 diff (`aa57b3f`) and wrote them as if they were `main` — where these docs live, and where a reader following the reference lands.

**Fix:** every brittle `src/…:NNN` reference now names the symbol instead. A convention note at the top of the spec marks the `file.ts:NNN` labels in the finding tables as Codex identifiers against `aa57b3f`, not `main` positions.

## 2. The rule, so it is caught next time

`AGENTS.md` says a pattern learned from a review round belongs in the skill. Adds §10 to `.github/skills/code-review/SKILL.md`: prose points at symbols, `file:NNN` only when pinned to an immutable ref.

Line numbers rot on any edit above them — nobody has to touch the described code for the reference to go stale, and a wrong line number still looks plausible. A renamed symbol is greppable; a wrong line is silent.

## 3. Giving the reviewer a graph

The deeper problem: a diff alone cannot tell Copilot whether a change breaks a caller three files away. Several rules in the skill were unreliable for that reason — "does anything else call this" was being answered by eyeballing the diff.

- **`.github/workflows/copilot-code-review.yml`** — installs a pinned `codebase-memory-mcp` into the review environment and indexes the checkout. Measured: ~2s to index this repo; 37MB binary, cached by version.
- **Skill** — a new section names the tools and, concretely, the rules that need them (#1 connection lifecycle, #4 `collectStats()` reachability, #5 test coverage, #10 symbol existence). GitHub's docs say the reviewer only reaches for MCP context when a skill asks explicitly.
- **`.github/copilot-mcp-setup.md`** — the MCP registration lives in repository settings and cannot be committed, so this carries the JSON to paste, how the three pieces fit, and how to verify from review attributions.

**MCP rather than CLI:** the CLI would be preferable — entirely in the repo, reviewable, testable on a branch. But GitHub documents the reviewer's agentic surface as *full project context gathering* and *passing suggestions to the cloud agent*, with tool use defined as MCP servers plus agent skills. There is no documented way for a review to run a shell command, so a CLI call would have nowhere to execute.

The declared tool list is read-only — `index_repository`, `manage_adr`, `ingest_traces` and `delete_project` are omitted so a review cannot mutate the graph.

## Manual step required

The MCP server must be registered once in **Settings → Copilot → coding agent → MCP configuration**; the JSON is in `.github/copilot-mcp-setup.md`. Until that is done the workflow runs and indexes, but no reviewer will call it.

## Type of change

- [x] Documentation
- [x] CI / tooling

## Testing done

- Both symbol names verified against `main` with grep before editing.
- Workflow YAML parsed and the `copilot-setup-steps` job name confirmed.
- Index timing measured locally (2.4s, 3424 nodes); release asset names and sizes read from the `DeusData/codebase-memory-mcp` v0.10.8 release.
- Copilot reads skills and instructions from the head branch, so this PR exercises its own skill changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DJ71TAxF8W69PuzX6etVHc