### PR TITLE
fix(ci): declare the codebase-memory-mcp pin on the Copilot setup steps

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -8,6 +8,9 @@
 # drift apart.
 name: Copilot setup steps
 
+# Copilot copies only the job's `steps` into its own environment: workflow- and
+# job-level `env` are dropped there, so every value a step needs is declared
+# on that step. Keep the pin identical in both places below.
 # Copilot invokes the `copilot-setup-steps` job directly; the triggers below only
 # exist so the job can be exercised manually and validated on its own PRs.
 on:
@@ -26,12 +29,6 @@ jobs:
     permissions:
       contents: read
 
-    env:
-      # Pin the version: an unpinned "latest" changes the review environment
-      # underneath us without a commit to point at.
-      CBM_VERSION: v0.10.8
-      CBM_ASSET: codebase-memory-mcp-linux-amd64-portable.tar.gz
-
     steps:
       - uses: actions/checkout@v4
 
@@ -40,12 +37,16 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.local/bin/codebase-memory-mcp
-          key: cbm-${{ env.CBM_VERSION }}-linux-amd64
+          key: cbm-v0.10.8-linux-amd64
 
       - name: Install codebase-memory-mcp
         if: steps.cbm-cache.outputs.cache-hit != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          # Pin the version: an unpinned "latest" changes the review environment
+          # underneath us without a commit to point at.
+          CBM_VERSION: v0.10.8
+          CBM_ASSET: codebase-memory-mcp-linux-amd64-portable.tar.gz
         run: |
           set -euo pipefail
           mkdir -p ~/.local/bin


### PR DESCRIPTION
## Changes
- Copilot code review and the cloud agent copy only the `steps` of the `copilot-setup-steps` job; job-level `env` is ignored, so `Install codebase-memory-mcp` failed with `CBM_VERSION: unbound variable` on every review. The pin now lives on the install step and is inlined in the cache key.
- Per GitHub docs, this file is only honored from the default branch, so the fix must land on `main` before reviews on open PRs recover.

## Files Touched
- `.github/workflows/copilot-setup-steps.yml` — move the pin into step env

## Issue Reference
No issue: hotfix requested by the owner.

## Test Evidence
Workflow YAML parses; the `Copilot setup steps` workflow runs on this PR via its `pull_request` path trigger.

## Risks & Follow-ups
- The pin is written in two places (cache key and install step); keep them equal when bumping.

## AR Status
[SKIP_AR: single workflow file, config-only change, owner asked to bypass gates]

## Introspection Findings
Copilot honors only `steps`, `permissions`, `runs-on`, `services`, `snapshot`, `timeout-minutes` in that job and reads the file from the default branch.

## Token Cost
~10k tokens (Claude Fable 5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSEq8trJhpwPuajqRQ4Hvq