### PR TITLE
chore(copilot): require codebase-memory graph queries as the first review step

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,9 +2,19 @@
 
 This repo is a TypeScript SQLite daemon that persists Claude session memories across context resets. It uses Node.js `DatabaseSync` (synchronous SQLite API) and exposes an HTTP daemon with REST routes.
 
-## codebase-memory MCP
+## Required first step: query the codebase-memory graph
 
-A `codebase-memory` MCP server is preloaded with a graph of this repo.
+A `codebase-memory` MCP server is running with a prebuilt graph of this repo. Use it before any text search or file view; built-in grep/regex search and line-range file reads are fallbacks, not the starting point.
+
+Do this, in order, before reading any diff hunk:
+
+1. `list_projects` — the project name comes from the checkout path; never guess it.
+2. For every changed exported function, class, route or schema column, `search_graph` to locate it and `trace_path` to list its callers and callees.
+3. `get_code_snippet` for the source you need; `query_graph` for multi-hop questions.
+
+Fall back to built-in search only when a graph call errors, and say so. The review body must open with a short "Graph calls" list naming the tools used and the symbols traced; a review without that list is incomplete.
+
+## codebase-memory MCP
 
 - `list_projects` first — the project name comes from the checkout path; never guess it.
 - `trace_path` before changing any signature, return shape, or schema column. "Nothing else depends on this" is not a claim you may make without it.


### PR DESCRIPTION
## Changes
- Copilot reviews started with built-in regex search and file views even though the codebase-memory server and index were ready (verified in the review session for #321). The instructions now make `list_projects`, `search_graph` and `trace_path` a required first step and ask the review body to open with the graph calls it made, so compliance is visible.

## Files Touched
- `.github/copilot-instructions.md` — required first step section

## Issue Reference
No issue: review-config change requested by the owner.

## Test Evidence
[NO_TEST_SUITE: markdown instructions only]

## Risks & Follow-ups
- Copilot may still ignore instructions; the "Graph calls" list makes that visible on the next paid review rather than requiring a session inspection.

## AR Status
[SKIP_AR: single markdown file, config-only change]

## Introspection Findings
Custom review instructions are honored from the default branch, like the setup workflow.

## Token Cost
~6k tokens (Claude Fable 5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XSEq8trJhpwPuajqRQ4Hvq