### PR TITLE
fix(replay,stats): persisted-summary chain, refuse --restart during compaction, isolated stats test

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,8 +121,11 @@ conversations the run touched, hook-written ones included, rebuilding each
 conversation's context from its messages before starting from scratch. Ledger
 rows of the other replay command for those sessions are dropped too. Before
 wiping anything it asks the daemon (`/status`) whether it is still compacting
-a session in those projects and refuses with an error if so; the check is not
-atomic with the wipe, so a compaction that starts after it can still race.
+a session in those projects and refuses with an error if so. A daemon that is
+not running counts as idle; one that answers `/status` with an error (bad
+token, 5xx) makes `--restart` refuse, since it cannot confirm idleness. The
+check is not atomic with the wipe, so a compaction that starts after it can
+still race.
 
 SIGINT/SIGTERM let the in-flight compaction settle before exiting, so a resumed
 run never duplicates or skips a half-finished session. A second signal exits

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -119,9 +119,10 @@ version. `--restart` is the way to rebuild that chain.
 `--restart` discards recorded progress and **all** summaries in the
 conversations the run touched, hook-written ones included, rebuilding each
 conversation's context from its messages before starting from scratch. Ledger
-rows of the other replay command for those sessions are dropped too. It
-assumes no daemon is compacting those conversations at the same time; run it
-with the daemon idle.
+rows of the other replay command for those sessions are dropped too. Before
+wiping anything it asks the daemon (`/status`) whether it is still compacting
+a session in those projects and refuses with an error if so; the check is not
+atomic with the wipe, so a compaction that starts after it can still race.
 
 SIGINT/SIGTERM let the in-flight compaction settle before exiting, so a resumed
 run never duplicates or skips a half-finished session. A second signal exits

--- a/src/batch-compact.ts
+++ b/src/batch-compact.ts
@@ -14,6 +14,7 @@ import {
   loadLatestSessionSummary,
   planReplayResume,
   recordReplayProgress,
+  refuseRestartDuringCompaction,
 } from "./replay-resume.js";
 
 export interface UncompactedConversation {
@@ -152,9 +153,12 @@ export async function batchCompact(opts: {
   // --restart clears every tracked project, not only those with eligible
   // conversations: recorded state must go even when nothing currently passes
   // the token threshold.
+  const client = new DaemonClient(`http://127.0.0.1:${opts.port}`, opts.tokenPath);
   if (opts.replay && !opts.dryRun && opts.restart) {
+    const projects = findProjects(opts.cwd);
+    await refuseRestartDuringCompaction(client, projects.map((p) => p.cwd));
     let clearFailed = false;
-    for (const { cwd } of findProjects(opts.cwd)) {
+    for (const { cwd } of projects) {
       const ok = await clearReplayState({
         cwd,
         command: "compact",
@@ -247,7 +251,6 @@ export async function batchCompact(opts: {
   let tokensIn = 0;
   let tokensOut = 0;
   const progressErrors: { sessionId: string; message: string }[] = [];
-  const client = new DaemonClient(`http://127.0.0.1:${opts.port}`, opts.tokenPath);
 
   for (const conv of conversations) {
     // Stop starting new work after SIGINT/SIGTERM; the renderer waits for the

--- a/src/batch-compact.ts
+++ b/src/batch-compact.ts
@@ -10,6 +10,8 @@ import {
   clearReplayState,
   createReplayRun,
   fingerprintStats,
+  isClientGaveUpError,
+  loadLatestSessionSummary,
   planReplayResume,
   recordReplayProgress,
 } from "./replay-resume.js";
@@ -348,13 +350,40 @@ export async function batchCompact(opts: {
         });
       }
     } catch (err) {
+      const errMsg = err instanceof Error ? err.message : "unknown error";
+      let chainNote = "";
       if (opts.replay) {
-        previousSummaryByCwd.set(conv.cwd, undefined);
-        lastCompactedSessionIdByCwd.set(conv.cwd, null);
+        // The chain follows what was persisted: when the client merely gave up
+        // (timeout/abort) the daemon may have stored the summary anyway, so
+        // re-read it; when nothing is stored yet keep the previous link. A real
+        // daemon failure breaks the chain at this link.
+        const gaveUp = isClientGaveUpError(err);
+        const recovered = gaveUp ? await loadLatestSessionSummary({ cwd: conv.cwd, sessionId: conv.sessionId }) : null;
+        if (recovered) {
+          previousSummaryByCwd.set(conv.cwd, recovered.content);
+          const run = replayRuns?.get(conv.cwd);
+          if (run) {
+            recordReplayProgress({
+              cwd: conv.cwd,
+              runId: run.runId,
+              sessionId: conv.sessionId,
+              position: run.positions.get(conv.sessionId) ?? 0,
+              contentFingerprint: fingerprintStats(conv.sourceMessages, conv.sourceTokens),
+              summaryId: recovered.summaryId,
+              outcome: "compacted",
+              model: opts.replayModel ?? null,
+            });
+          }
+          chainNote = "; summary was stored, chain continues";
+        } else if (gaveUp) {
+          chainNote = "; no summary found, chain skips this session";
+        } else {
+          previousSummaryByCwd.set(conv.cwd, undefined);
+          lastCompactedSessionIdByCwd.set(conv.cwd, null);
+        }
       }
       doneCount++;
-      const errMsg = err instanceof Error ? err.message : "unknown error";
-      console.log(` FAILED (${errMsg})`);
+      console.log(` FAILED (${errMsg}${chainNote})`);
       progressErrors.push({ sessionId: conv.sessionId, message: errMsg });
       onProgress?.({
         completed: doneCount,

--- a/src/daemon/routes/compact.ts
+++ b/src/daemon/routes/compact.ts
@@ -74,8 +74,24 @@ export function buildCompactionMessage(p: {
 export const justCompactedMap = new Map<string, number>();
 export const JUST_COMPACTED_TTL_MS = 30_000;
 
-// Guard against concurrent compactions for the same session
-const compactingNow = new Set<string>();
+// Guard against concurrent compactions for the same session (session_id → cwd)
+const compactingNow = new Map<string, string>();
+
+/**
+ * Session ids currently being compacted for a project. Lets CLI callers detect
+ * an in-flight daemon compaction before a `--restart` wipes the project's
+ * summaries; detection only, the check-then-wipe is not atomic.
+ */
+export function compactingSessionsFor(cwd: string): string[] {
+  const id = projectId(cwd);
+  return [...compactingNow].filter(([, c]) => projectId(c) === id).map(([sessionId]) => sessionId);
+}
+
+/** Register an in-flight compaction; returns the release function. */
+export function markCompacting(sessionId: string, cwd: string): () => void {
+  compactingNow.set(sessionId, cwd);
+  return () => { compactingNow.delete(sessionId); };
+}
 
 export type CompactLlmUsage = {
   provider: string;
@@ -180,7 +196,7 @@ export function createCompactHandler(config: DaemonConfig): RouteHandler {
       });
       return;
     }
-    compactingNow.add(session_id);
+    const releaseCompacting = markCompacting(session_id, cwd);
 
     const effectiveProvider = resolveEffectiveProvider(config, client);
     const providerLabels: Record<EffectiveProvider, string> = {
@@ -406,7 +422,7 @@ export function createCompactHandler(config: DaemonConfig): RouteHandler {
         ...(llmUsage ? { llmUsage } : {}),
       });
     } finally {
-      compactingNow.delete(session_id);
+      releaseCompacting();
     }
   };
 }

--- a/src/daemon/routes/status.ts
+++ b/src/daemon/routes/status.ts
@@ -7,6 +7,7 @@ import type { RouteHandler } from "../server.js";
 import { PKG_VERSION } from "../server.js";
 import { validateCwd } from "../validate-cwd.js";
 import { sanitizeError } from "../safe-error.js";
+import { compactingSessionsFor } from "./compact.js";
 
 export function createStatusHandler(config: DaemonConfig, startTime: number, actualPort?: number): RouteHandler {
   return async (_req, res, body) => {
@@ -94,6 +95,7 @@ export function createStatusHandler(config: DaemonConfig, startTime: number, act
           lastIngest,
           lastCompact,
           lastPromote,
+          compactingSessions: compactingSessionsFor(cwd),
         },
       });
     } catch (err) {

--- a/src/import.ts
+++ b/src/import.ts
@@ -12,6 +12,8 @@ import {
   clearReplayState,
   createReplayRun,
   fingerprintFile,
+  isClientGaveUpError,
+  loadLatestSessionSummary,
   planReplayResume,
   recordReplayProgress,
 } from "./replay-resume.js";
@@ -499,12 +501,40 @@ async function ingestSessionList(
             }
           }
         } catch (err) {
-          // Non-fatal: import succeeded; compact failure breaks the chain at this link.
-          previousSummaryByCwd.set(cwd, undefined);
-          lastCompactedSessionIdByCwd.set(cwd, null);
-          // Always warn on chain breakage so users know the DAG is incomplete,
-          // regardless of whether --verbose was passed.
-          console.error(`  \u26a0\ufe0f [replay] compact failed for session ${sessionId}: ${err instanceof Error ? err.message : 'unknown error'}`);
+          // Non-fatal: import succeeded. The chain follows what was persisted:
+          // when the client merely gave up (timeout/abort) the daemon may have
+          // stored the summary anyway, so re-read it; when nothing is stored
+          // yet keep the previous link rather than summarising the next session
+          // blind. A real daemon failure breaks the chain at this link.
+          // Warnings print regardless of --verbose so users know the DAG state.
+          const gaveUp = isClientGaveUpError(err);
+          const recovered = gaveUp
+            ? await loadLatestSessionSummary({ cwd, lcmDir: options._lcmDir, sessionId })
+            : null;
+          if (recovered) {
+            previousSummaryByCwd.set(cwd, recovered.content);
+            const runId = replayRuns.get(cwd);
+            if (runId !== undefined) {
+              recordReplayProgress({
+                cwd,
+                lcmDir: options._lcmDir,
+                runId,
+                sessionId,
+                position: ledgerPositions.get(cwd)?.get(sessionId) ?? 0,
+                contentFingerprint: inputFingerprint,
+                summaryId: recovered.summaryId,
+                outcome: "compacted",
+                model: options.replayModel ?? null,
+              });
+            }
+            console.error(`  \u26a0\ufe0f [replay] compact call gave up for session ${sessionId} (${err instanceof Error ? err.message : 'unknown error'}) but its summary was stored; chain continues`);
+          } else if (gaveUp) {
+            console.error(`  \u26a0\ufe0f [replay] compact call gave up for session ${sessionId} (${err instanceof Error ? err.message : 'unknown error'}) and no summary was found; chain skips this session`);
+          } else {
+            previousSummaryByCwd.set(cwd, undefined);
+            lastCompactedSessionIdByCwd.set(cwd, null);
+            console.error(`  \u26a0\ufe0f [replay] compact failed for session ${sessionId}: ${err instanceof Error ? err.message : 'unknown error'}`);
+          }
           if (err instanceof Error) {
             const llmUsage = (err as Error & { body?: { llmUsage?: CompactLlmUsage } }).body?.llmUsage;
             accumulateReplayUsage(result, llmUsage);

--- a/src/import.ts
+++ b/src/import.ts
@@ -16,6 +16,7 @@ import {
   loadLatestSessionSummary,
   planReplayResume,
   recordReplayProgress,
+  refuseRestartDuringCompaction,
 } from "./replay-resume.js";
 
 export type ImportProvider = "claude" | "codex" | "all";
@@ -281,9 +282,10 @@ async function ingestSessionList(
 
   if (options.replay && !options.dryRun && sessions.length > 0) {
     if (options.restart) {
+      const cwdsToClear = [...new Set(sessions.map((s) => s.cwd))].filter((cwd) => !clearedCwds.has(cwd));
+      await refuseRestartDuringCompaction(client, cwdsToClear);
       let clearFailed = false;
-      for (const cwd of new Set(sessions.map((s) => s.cwd))) {
-        if (clearedCwds.has(cwd)) continue;
+      for (const cwd of cwdsToClear) {
         clearedCwds.add(cwd);
         const ok = await clearReplayState({
           cwd,

--- a/src/replay-resume.ts
+++ b/src/replay-resume.ts
@@ -591,8 +591,10 @@ export function recordReplayProgress(opts: {
  * Refuse `--restart` while the daemon is compacting a conversation in any of
  * the projects about to be wiped: the daemon's in-flight guard is per-process,
  * so a CLI-side wipe would race it. Detection only, the check-then-wipe is not
- * atomic. A daemon that cannot be reached (or predates the field) is treated as
- * idle.
+ * atomic. A daemon that cannot be reached (no process listening) is treated as
+ * idle: nothing can be compacting. A daemon that answers `/status` with an
+ * error (401/403 token mismatch, 5xx) is not: the check cannot confirm it is
+ * idle, so the wipe is refused rather than proceeding blind.
  */
 export async function refuseRestartDuringCompaction(
   client: Pick<DaemonClient, "post">,
@@ -604,8 +606,14 @@ export async function refuseRestartDuringCompaction(
     try {
       const status = await client.post<{ project?: { compactingSessions?: string[] } }>("/status", { cwd });
       sessions = status.project?.compactingSessions ?? [];
-    } catch {
-      continue;
+    } catch (err) {
+      const httpStatus = (err as { status?: unknown }).status;
+      if (typeof httpStatus !== "number") continue; // network failure: no daemon to be busy
+      throw new Error(
+        `--restart refused: could not confirm the daemon is idle for ${cwd} ` +
+          `(/status returned HTTP ${httpStatus}: ${err instanceof Error ? err.message : String(err)}). ` +
+          "Fix or stop the daemon, then retry.",
+      );
     }
     for (const sessionId of sessions) busy.push(`${sessionId} in ${cwd}`);
   }

--- a/src/replay-resume.ts
+++ b/src/replay-resume.ts
@@ -22,6 +22,7 @@ import { projectId } from "./daemon/project.js";
 import { closeLcmConnection, getLcmConnection } from "./db/connection.js";
 import { runLcmMigrations } from "./db/migration.js";
 import { SummaryStore } from "./store/summary-store.js";
+import type { DaemonClient } from "./daemon/client.js";
 
 export type ReplayCommand = "import" | "compact";
 
@@ -584,6 +585,35 @@ export function recordReplayProgress(opts: {
     );
   } catch { /* ledger writes are best-effort — the next run re-does the work */ }
   finally { closeDb(opened); }
+}
+
+/**
+ * Refuse `--restart` while the daemon is compacting a conversation in any of
+ * the projects about to be wiped: the daemon's in-flight guard is per-process,
+ * so a CLI-side wipe would race it. Detection only, the check-then-wipe is not
+ * atomic. A daemon that cannot be reached (or predates the field) is treated as
+ * idle.
+ */
+export async function refuseRestartDuringCompaction(
+  client: Pick<DaemonClient, "post">,
+  cwds: Iterable<string>,
+): Promise<void> {
+  const busy: string[] = [];
+  for (const cwd of cwds) {
+    let sessions: string[] = [];
+    try {
+      const status = await client.post<{ project?: { compactingSessions?: string[] } }>("/status", { cwd });
+      sessions = status.project?.compactingSessions ?? [];
+    } catch {
+      continue;
+    }
+    for (const sessionId of sessions) busy.push(`${sessionId} in ${cwd}`);
+  }
+  if (busy.length > 0) {
+    throw new Error(
+      `--restart refused: the daemon is still compacting ${busy.join(", ")}. Wait for it to finish, then retry.`,
+    );
+  }
 }
 
 /**

--- a/src/replay-resume.ts
+++ b/src/replay-resume.ts
@@ -502,6 +502,45 @@ export function planReplayResume<T extends { sessionId: string; cwd: string }>(o
 }
 
 /**
+ * True when the client gave up on a daemon call (timeout/abort) rather than
+ * the daemon reporting a failure. DaemonClient preserves these error names.
+ */
+export function isClientGaveUpError(err: unknown): boolean {
+  return err instanceof Error && (err.name === "TimeoutError" || err.name === "AbortError");
+}
+
+/**
+ * Latest persisted summary for a session, read straight from the project DB.
+ *
+ * Used when the client gave up on a /compact call (timeout/abort) but the
+ * daemon may have finished the work anyway: the chain follows what was
+ * persisted, not whether the HTTP call returned in time. Ordering mirrors the
+ * daemon's own "latest summary" fallback (`getSummariesByConversation`, last).
+ */
+export async function loadLatestSessionSummary(opts: {
+  cwd: string;
+  lcmDir?: string;
+  sessionId: string;
+}): Promise<{ summaryId: string; content: string } | null> {
+  const opened = openProjectDb(projectDbPathFor(opts.cwd, opts.lcmDir));
+  if (opened.kind !== "ready") return null;
+  const { db } = opened;
+  try {
+    const conv = db
+      .prepare("SELECT conversation_id FROM conversations WHERE session_id = ?")
+      .get(opts.sessionId) as { conversation_id: number } | undefined;
+    if (!conv) return null;
+    const summaries = await new SummaryStore(db).getSummariesByConversation(conv.conversation_id);
+    const latest = summaries[summaries.length - 1];
+    return latest ? { summaryId: latest.summaryId, content: latest.content } : null;
+  } catch {
+    return null;
+  } finally {
+    closeDb(opened);
+  }
+}
+
+/**
  * Record a completed session compaction.
  *
  * `outcome` distinguishes a session that produced a summary from one that had

--- a/test/daemon/routes/stats.test.ts
+++ b/test/daemon/routes/stats.test.ts
@@ -1,29 +1,72 @@
-import { describe, expect, it, beforeAll, afterAll } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
 import { createDaemon, type DaemonInstance } from "../../../src/daemon/server.js";
 import { loadDaemonConfig } from "../../../src/daemon/config.js";
+import { runLcmMigrations } from "../../../src/db/migration.js";
+import { ConversationStore } from "../../../src/store/conversation-store.js";
+import { SummaryStore } from "../../../src/store/summary-store.js";
+
+// collectStats() scans every project database under homedir()/.lossless-claude,
+// opening each one writable and running migrations. Point homedir() at a
+// temporary tree so the test never touches (or waits on) the user's real data.
+vi.mock("node:os", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:os")>();
+  return { ...actual, homedir: vi.fn(actual.homedir) };
+});
 
 describe("GET /stats", () => {
   let daemon: DaemonInstance;
   let port: number;
+  let home: string;
 
   beforeAll(async () => {
+    home = mkdtempSync(join(tmpdir(), "lcm-stats-home-"));
+    vi.mocked(homedir).mockReturnValue(home);
+
+    // One project with two messages and one summary, so the aggregation path
+    // runs instead of the empty-tree early return.
+    const projectDir = join(home, ".lossless-claude", "projects", "stats-fixture");
+    mkdirSync(projectDir, { recursive: true });
+    const db = new DatabaseSync(join(projectDir, "db.sqlite"));
+    runLcmMigrations(db);
+    const conversations = new ConversationStore(db);
+    const conversation = await conversations.getOrCreateConversation("stats-session");
+    await conversations.createMessagesBulk([
+      { conversationId: conversation.conversationId, seq: 0, role: "user", content: "Hello", tokenCount: 5 },
+      { conversationId: conversation.conversationId, seq: 1, role: "assistant", content: "Hi there", tokenCount: 3 },
+    ]);
+    await new SummaryStore(db).insertSummary({
+      summaryId: "sum_stats_1",
+      conversationId: conversation.conversationId,
+      kind: "condensed",
+      content: "User greeted assistant",
+      tokenCount: 10,
+      sourceMessageTokenCount: 8,
+    });
+    db.close();
+
     daemon = await createDaemon(loadDaemonConfig("/nonexistent", { daemon: { port: 0 } }));
     port = daemon.address().port;
   });
 
   afterAll(async () => {
     await daemon.stop();
+    vi.mocked(homedir).mockReset();
+    rmSync(home, { recursive: true, force: true });
   });
 
-  it("returns 200 with OverallStats shape including redactionCounts and llmUsage", { timeout: 60_000 }, async () => {
+  it("returns 200 with OverallStats shape including redactionCounts and llmUsage", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/stats`);
     expect(res.status).toBe(200);
 
     const body = (await res.json()) as Record<string, unknown>;
-    expect(body).toHaveProperty("projects");
-    expect(body).toHaveProperty("conversations");
-    expect(body).toHaveProperty("messages");
-    expect(body).toHaveProperty("summaries");
+    expect(body.projects).toBe(1);
+    expect(body.conversations).toBe(1);
+    expect(body.messages).toBe(2);
+    expect(body.summaries).toBe(1);
     expect(body).toHaveProperty("redactionCounts");
     expect(body).toHaveProperty("llmUsage");
     expect(body.redactionCounts).toMatchObject({
@@ -42,7 +85,7 @@ describe("GET /stats", () => {
     expect(body.llmUsage).not.toHaveProperty("callsFailed");
   });
 
-  it("redactionCounts.total equals sum of built-in, global, and project", { timeout: 60_000 }, async () => {
+  it("redactionCounts.total equals sum of built-in, global, and project", async () => {
     const res = await fetch(`http://127.0.0.1:${port}/stats`);
     expect(res.status).toBe(200);
 

--- a/test/daemon/routes/status.test.ts
+++ b/test/daemon/routes/status.test.ts
@@ -10,6 +10,7 @@ import { ConversationStore } from "../../../src/store/conversation-store.js";
 import { SummaryStore } from "../../../src/store/summary-store.js";
 import { PromotedStore } from "../../../src/db/promoted.js";
 import { projectDbPath, projectMetaPath, ensureProjectDir } from "../../../src/daemon/project.js";
+import { markCompacting } from "../../../src/daemon/routes/compact.js";
 
 const tempDirs: string[] = [];
 
@@ -121,6 +122,33 @@ describe("POST /status", () => {
     expect(data.project.lastIngest).toBe("2026-03-22T10:00:00.000Z");
     expect(data.project.lastCompact).toBe("2026-03-22T09:00:00.000Z");
     expect(data.project.lastPromote).toBe("2026-03-22T08:00:00.000Z");
+    expect(data.project.compactingSessions).toEqual([]);
+  });
+
+  it("reports sessions the daemon is compacting for the project only", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-status-busy-"));
+    tempDirs.push(tempDir);
+    const otherDir = mkdtempSync(join(tmpdir(), "lossless-status-other-"));
+    tempDirs.push(otherDir);
+    daemon = await createDaemon(loadDaemonConfig("/nonexistent", { daemon: { port: 0 } }));
+    const status = async () => {
+      const res = await fetch(`http://127.0.0.1:${daemon!.address().port}/status`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cwd: tempDir }),
+      });
+      return ((await res.json()) as any).project.compactingSessions as string[];
+    };
+
+    const releaseMine = markCompacting("busy-session", tempDir);
+    const releaseOther = markCompacting("other-session", otherDir);
+    try {
+      expect(await status()).toEqual(["busy-session"]);
+    } finally {
+      releaseMine();
+      releaseOther();
+    }
+    expect(await status()).toEqual([]);
   });
 
   it("returns zeros for empty project", async () => {

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -896,6 +896,53 @@ describe("importSessions replay resume", () => {
     expect(ledger.n).toBe(1);
   });
 
+  it("restart is refused when /status answers with an HTTP error, but not when the daemon is unreachable", async () => {
+    const cwd = "/test/resume-restart-status-error";
+    const { claudeProjectsDir, lcmDir } = setup(cwd, ["s1"]);
+
+    const first = makeMockClient(async (path: string) => {
+      if (path === "/ingest") return { ingested: 1, totalTokens: 100 };
+      if (path === "/compact") return { summary: "ok", replayOutcome: "compacted", latestSummaryContent: "s", latestSummaryId: "sum-s1" };
+    });
+    await importSessions(first, { replay: true, cwd, _claudeProjectsDir: claudeProjectsDir, _lcmDir: lcmDir });
+    persistSummary(lcmDir, cwd, "s1", "sum-s1", "summary-of-s1");
+    const dbPath = join(lcmDir, "projects", projectId(cwd), "db.sqlite");
+    const countSummaries = () => {
+      const db = new DatabaseSync(dbPath);
+      const row = db.prepare("SELECT COUNT(*) AS n FROM summaries").get() as { n: number };
+      db.close();
+      return row.n;
+    };
+
+    // Reachable daemon that rejects the token: the guard cannot confirm idleness, so it refuses.
+    const unauthorized = makeMockClient(async (path: string) => {
+      if (path === "/status") {
+        const e = new Error("unauthorized") as Error & { status?: number };
+        e.status = 401;
+        throw e;
+      }
+      if (path === "/ingest") return { ingested: 1, totalTokens: 100 };
+      if (path === "/compact") return { summary: "ok", replayOutcome: "compacted" };
+    });
+    await expect(importSessions(unauthorized, {
+      replay: true, restart: true, cwd,
+      _claudeProjectsDir: claudeProjectsDir, _lcmDir: lcmDir,
+    })).rejects.toThrow(/--restart refused: could not confirm.*HTTP 401/);
+    expect(countSummaries()).toBe(1);
+
+    // No daemon listening at all: nothing can be compacting, so the wipe proceeds.
+    const unreachable = makeMockClient(async (path: string) => {
+      if (path === "/status") throw new TypeError("fetch failed: ECONNREFUSED");
+      if (path === "/ingest") return { ingested: 1, totalTokens: 100 };
+      if (path === "/compact") return { summary: "ok", replayOutcome: "compacted" };
+    });
+    await importSessions(unreachable, {
+      replay: true, restart: true, cwd,
+      _claudeProjectsDir: claudeProjectsDir, _lcmDir: lcmDir,
+    });
+    expect(countSummaries()).toBe(0);
+  });
+
   it("dry-run replay does not write manifests or ledgers", async () => {
     const cwd = "/test/resume-dryrun";
     const { claudeProjectsDir, lcmDir } = setup(cwd, ["s1"]);

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -898,6 +898,76 @@ describe("importSessions replay resume", () => {
     expect(compacted).toEqual(["s1"]);
     expect(result.imported).toBe(1);
   });
+
+  function timeoutError(): Error {
+    const err = new Error("fetch failed");
+    err.name = "TimeoutError";
+    return err;
+  }
+
+  function persistSummary(lcmDir: string, cwd: string, sessionId: string, summaryId: string, content: string): void {
+    const db = new DatabaseSync(join(lcmDir, "projects", projectId(cwd), "db.sqlite"));
+    db.prepare("INSERT INTO conversations (session_id) VALUES (?)").run(sessionId);
+    const conv = db.prepare("SELECT conversation_id FROM conversations WHERE session_id = ?").get(sessionId) as { conversation_id: number };
+    db.prepare("INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, 'leaf', ?, 5)").run(summaryId, conv.conversation_id, content);
+    db.close();
+  }
+
+  it("a timed-out compact whose summary was stored keeps the chain and records the ledger row", async () => {
+    const cwd = "/test/timeout-stored";
+    const { claudeProjectsDir, lcmDir } = setup(cwd, ["s1", "s2", "s3"]);
+    const stderrLines: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: any[]) => { stderrLines.push(args.join(" ")); });
+
+    const compactBodies: { session_id: string; previous_summary?: string }[] = [];
+    const client = makeMockClient(async (path: string, body: any) => {
+      if (path === "/ingest") return { ingested: 1, totalTokens: 100 };
+      if (path === "/compact") {
+        compactBodies.push({ session_id: body.session_id, previous_summary: body.previous_summary });
+        if (body.session_id === "s2") {
+          // Daemon finished and stored the summary, but the client gave up waiting.
+          persistSummary(lcmDir, cwd, "s2", "sum-s2", "summary-of-s2");
+          throw timeoutError();
+        }
+        return { summary: "ok", replayOutcome: "compacted", latestSummaryContent: `summary-of-${body.session_id}`, latestSummaryId: `sum-${body.session_id}`, tokensBefore: 100, tokensAfter: 10 };
+      }
+    });
+    await importSessions(client, { replay: true, cwd, _claudeProjectsDir: claudeProjectsDir, _lcmDir: lcmDir });
+
+    expect(compactBodies.map((b) => b.previous_summary)).toEqual([undefined, "summary-of-s1", "summary-of-s2"]);
+    expect(stderrLines.some((l) => l.includes("s2") && l.includes("chain continues"))).toBe(true);
+
+    const db = new DatabaseSync(join(lcmDir, "projects", projectId(cwd), "db.sqlite"));
+    const row = db.prepare("SELECT summary_id FROM replay_ledger WHERE session_id = 's2'").get() as { summary_id: string } | undefined;
+    db.close();
+    expect(row?.summary_id).toBe("sum-s2");
+  });
+
+  it("a timed-out compact with no stored summary keeps the previous link instead of blanking it", async () => {
+    const cwd = "/test/timeout-missing";
+    const { claudeProjectsDir, lcmDir } = setup(cwd, ["s1", "s2", "s3"]);
+    const stderrLines: string[] = [];
+    vi.spyOn(console, "error").mockImplementation((...args: any[]) => { stderrLines.push(args.join(" ")); });
+
+    const compactBodies: { session_id: string; previous_summary?: string }[] = [];
+    const client = makeMockClient(async (path: string, body: any) => {
+      if (path === "/ingest") return { ingested: 1, totalTokens: 100 };
+      if (path === "/compact") {
+        compactBodies.push({ session_id: body.session_id, previous_summary: body.previous_summary });
+        if (body.session_id === "s2") throw timeoutError();
+        return { summary: "ok", replayOutcome: "compacted", latestSummaryContent: `summary-of-${body.session_id}`, latestSummaryId: `sum-${body.session_id}`, tokensBefore: 100, tokensAfter: 10 };
+      }
+    });
+    await importSessions(client, { replay: true, cwd, _claudeProjectsDir: claudeProjectsDir, _lcmDir: lcmDir });
+
+    expect(compactBodies.map((b) => b.previous_summary)).toEqual([undefined, "summary-of-s1", "summary-of-s1"]);
+    expect(stderrLines.some((l) => l.includes("s2") && l.includes("chain skips"))).toBe(true);
+
+    const db = new DatabaseSync(join(lcmDir, "projects", projectId(cwd), "db.sqlite"));
+    const row = db.prepare("SELECT COUNT(*) AS n FROM replay_ledger WHERE session_id = 's2'").get() as { n: number };
+    db.close();
+    expect(row.n).toBe(0);
+  });
 });
 
 // --- importSessions with provider: "codex" ---

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -688,6 +688,14 @@ describe("importSessions replay resume", () => {
     return { claudeProjectsDir, lcmDir, projDir };
   }
 
+  function persistSummary(lcmDir: string, cwd: string, sessionId: string, summaryId: string, content: string): void {
+    const db = new DatabaseSync(join(lcmDir, "projects", projectId(cwd), "db.sqlite"));
+    db.prepare("INSERT INTO conversations (session_id) VALUES (?)").run(sessionId);
+    const conv = db.prepare("SELECT conversation_id FROM conversations WHERE session_id = ?").get(sessionId) as { conversation_id: number };
+    db.prepare("INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, 'leaf', ?, 5)").run(summaryId, conv.conversation_id, content);
+    db.close();
+  }
+
   it("second run skips sessions already done in the first run", async () => {
     const cwd = "/test/resume-skip";
     const { claudeProjectsDir, lcmDir, projDir } = setup(cwd, ["s1", "s2", "s3"]);
@@ -856,6 +864,38 @@ describe("importSessions replay resume", () => {
     expect(r2.resumed).toBeUndefined();
   });
 
+  it("restart is refused while the daemon is compacting a session in the project", async () => {
+    const cwd = "/test/resume-restart-busy";
+    const { claudeProjectsDir, lcmDir } = setup(cwd, ["s1"]);
+
+    const first = makeMockClient(async (path: string) => {
+      if (path === "/ingest") return { ingested: 1, totalTokens: 100 };
+      if (path === "/compact") return { summary: "ok", replayOutcome: "compacted", latestSummaryContent: "s", latestSummaryId: "sum-s1" };
+    });
+    await importSessions(first, { replay: true, cwd, _claudeProjectsDir: claudeProjectsDir, _lcmDir: lcmDir });
+    persistSummary(lcmDir, cwd, "s1", "sum-s1", "summary-of-s1");
+
+    const compactCalls: string[] = [];
+    const busy = makeMockClient(async (path: string, body: any) => {
+      if (path === "/status") return { project: { compactingSessions: ["s1"] } };
+      if (path === "/ingest") return { ingested: 1, totalTokens: 100 };
+      if (path === "/compact") { compactCalls.push(body.session_id); return { summary: "ok", replayOutcome: "compacted" }; }
+    });
+    await expect(importSessions(busy, {
+      replay: true, restart: true, cwd,
+      _claudeProjectsDir: claudeProjectsDir, _lcmDir: lcmDir,
+    })).rejects.toThrow(/--restart refused.*s1/);
+
+    // Nothing was wiped or re-run.
+    expect(compactCalls).toEqual([]);
+    const db = new DatabaseSync(join(lcmDir, "projects", projectId(cwd), "db.sqlite"));
+    const summaries = db.prepare("SELECT COUNT(*) AS n FROM summaries").get() as { n: number };
+    const ledger = db.prepare("SELECT COUNT(*) AS n FROM replay_ledger").get() as { n: number };
+    db.close();
+    expect(summaries.n).toBe(1);
+    expect(ledger.n).toBe(1);
+  });
+
   it("dry-run replay does not write manifests or ledgers", async () => {
     const cwd = "/test/resume-dryrun";
     const { claudeProjectsDir, lcmDir } = setup(cwd, ["s1"]);
@@ -903,14 +943,6 @@ describe("importSessions replay resume", () => {
     const err = new Error("fetch failed");
     err.name = "TimeoutError";
     return err;
-  }
-
-  function persistSummary(lcmDir: string, cwd: string, sessionId: string, summaryId: string, content: string): void {
-    const db = new DatabaseSync(join(lcmDir, "projects", projectId(cwd), "db.sqlite"));
-    db.prepare("INSERT INTO conversations (session_id) VALUES (?)").run(sessionId);
-    const conv = db.prepare("SELECT conversation_id FROM conversations WHERE session_id = ?").get(sessionId) as { conversation_id: number };
-    db.prepare("INSERT INTO summaries (summary_id, conversation_id, kind, content, token_count) VALUES (?, ?, 'leaf', ?, 5)").run(summaryId, conv.conversation_id, content);
-    db.close();
   }
 
   it("a timed-out compact whose summary was stored keeps the chain and records the ledger row", async () => {


### PR DESCRIPTION
## Changes
- **Replay chain follows what was persisted (#308).** A `TimeoutError`/`AbortError` from `/compact` no longer clears the threaded context. The loop re-reads the session's latest summary from the project DB, threads it forward and records the ledger row; when nothing is stored yet it keeps the previous link instead of summarising the next session blind. Real daemon failures still break the chain.
- **`--restart` refused during a daemon compaction (#320).** The daemon tracks in-flight compactions per session and reports them per project in `/status` (`project.compactingSessions`). `lcm import --replay --restart` and `lcm compact --replay --restart` check every project before wiping anything and fail with a clear error. Unreachable or older daemon counts as idle. Detection only; the check-then-wipe is not atomic (documented).
- **Stats route test isolated (#307).** `homedir()` is mocked to a temp tree seeded with one small project, so the test no longer scans and migrates real user databases. 76s → 0.2s, 60s timeouts dropped.

## Files Touched
- `src/replay-resume.ts` — `isClientGaveUpError`, `loadLatestSessionSummary`, `refuseRestartDuringCompaction`
- `src/import.ts` — timeout-aware compact catch; restart pre-check
- `src/batch-compact.ts` — same for `lcm compact --replay`; client created before the restart block
- `src/daemon/routes/compact.ts` — `compactingNow` is a session→cwd map; `compactingSessionsFor`, `markCompacting`
- `src/daemon/routes/status.ts` — `project.compactingSessions`
- `docs/architecture.md` — restart guard wording
- `test/import.test.ts` — chain continues / chain skips / restart refused
- `test/daemon/routes/status.test.ts` — compactingSessions per project
- `test/daemon/routes/stats.test.ts` — isolated fixture

## Issue Reference

Closes #307
Closes #308
Closes #320

## Test Evidence
`npm run build` clean. `npx vitest run`: 119 files passed, 1 skipped; 1169 tests passed, 3 skipped. `test/daemon/routes/stats.test.ts` alone: 2 tests in 161ms.

## Risks & Follow-ups
- Restart guard is a check-then-wipe, not a lock; a compaction that starts after the check can still race.
- A timed-out compact whose summary lands after the CLI's DB lookup is treated as "no summary yet": chain keeps the previous link, ledger row not written, so resume retries that session.
- `test/daemon/routes/restore.test.ts` uses the real `tmpdir()` as a project cwd and is flaky when run in parallel with other route tests (pre-existing, not touched here).

## AR Status
[SKIP_AR: not requested in this session]

## Introspection Findings
Two Claude sessions sharing one checkout: a branch switch here made the other session commit onto this branch; commits were moved back with a scratch worktree and this branch rebuilt from main.

## Token Cost
~120k tokens (claude-fable-5-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJukdsNnRu1jsmCHmfJZz4