### PR TITLE
fix(llm): isolate the claude summarizer subprocess from user plugins, MCP and settings

### DIFF
--- a/src/llm/claude-process.ts
+++ b/src/llm/claude-process.ts
@@ -15,7 +15,7 @@ let cachedEmptyPluginDir: string | undefined;
 
 /**
  * An existing empty directory: `--plugin-dir` rejects a missing path. It is
- * private to this process (mkdtemp, mode 0700) so no other local user can
+ * private to this process (mkdtemp; on POSIX, mode 0700) so no other local user can
  * pre-create a same-named path and plant plugins in it. The cache is assigned
  * only after creation succeeds.
  */

--- a/src/llm/claude-process.ts
+++ b/src/llm/claude-process.ts
@@ -1,5 +1,5 @@
 import { spawn as defaultSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "./types.js";
@@ -9,18 +9,20 @@ import { buildSummaryPrompt } from "./prompt.js";
 const HAIKU_MODEL = "claude-haiku-4-5-20251001";
 const TIMEOUT_MS = 120_000;
 const EMPTY_MCP_CONFIG = '{"mcpServers":{}}';
+const STDERR_ERROR_MAX_CHARS = 2_000;
 
 let cachedEmptyPluginDir: string | undefined;
 
-/** An existing empty directory: `--plugin-dir` rejects a missing path. */
+/**
+ * An existing empty directory: `--plugin-dir` rejects a missing path. It is
+ * private to this process (mkdtemp, mode 0700) so no other local user can
+ * pre-create a same-named path and plant plugins in it. The cache is assigned
+ * only after creation succeeds.
+ */
 export function emptyPluginDir(): string {
-  if (!cachedEmptyPluginDir) {
-    cachedEmptyPluginDir = join(tmpdir(), "lcm-claude-empty-plugins");
-    mkdirSync(cachedEmptyPluginDir, { recursive: true });
-  }
+  cachedEmptyPluginDir ??= mkdtempSync(join(tmpdir(), "lcm-claude-empty-plugins-"));
   return cachedEmptyPluginDir;
 }
-const STDERR_ERROR_MAX_CHARS = 2_000;
 
 type ClaudeModelUsage = {
   inputTokens?: number;
@@ -126,7 +128,11 @@ function normalizeSpawnError(error: unknown): Error {
  * several seconds per call). `--bare` is not used because it disables OAuth,
  * which would move the cost off the subscription.
  */
-export function buildClaudeArgs(model: string, systemPrompt = LCM_SUMMARIZER_SYSTEM_PROMPT): string[] {
+export function buildClaudeArgs(
+  model: string,
+  systemPrompt = LCM_SUMMARIZER_SYSTEM_PROMPT,
+  pluginDir = emptyPluginDir(),
+): string[] {
   return [
     "--print",
     "--output-format", "json",
@@ -135,7 +141,7 @@ export function buildClaudeArgs(model: string, systemPrompt = LCM_SUMMARIZER_SYS
     "--system-prompt", systemPrompt,
     "--tools", "",
     "--disable-slash-commands",
-    "--plugin-dir", emptyPluginDir(),
+    "--plugin-dir", pluginDir,
     "--strict-mcp-config",
     "--mcp-config", EMPTY_MCP_CONFIG,
     "--setting-sources", "",
@@ -161,7 +167,8 @@ export function createClaudeProcessSummarizer(opts: ClaudeProcessDeps = {}): Lcm
     return new Promise((resolve, reject) => {
       let proc: ChildProcessWithoutNullStreams;
       try {
-        proc = deps.spawn("claude", buildClaudeArgs(deps.model, ctx.taskPrompt), { stdio: ["pipe", "pipe", "pipe"] });
+        // Directory creation happens here, inside the spawn error path.
+        proc = deps.spawn("claude", buildClaudeArgs(deps.model, ctx.taskPrompt, emptyPluginDir()), { stdio: ["pipe", "pipe", "pipe"] });
       } catch (error) {
         reject(normalizeSpawnError(error));
         return;

--- a/src/llm/claude-process.ts
+++ b/src/llm/claude-process.ts
@@ -1,10 +1,25 @@
 import { spawn as defaultSpawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "./types.js";
 import { LCM_SUMMARIZER_SYSTEM_PROMPT } from "../summarize.js";
 import { buildSummaryPrompt } from "./prompt.js";
 
 const HAIKU_MODEL = "claude-haiku-4-5-20251001";
 const TIMEOUT_MS = 120_000;
+const EMPTY_MCP_CONFIG = '{"mcpServers":{}}';
+
+let cachedEmptyPluginDir: string | undefined;
+
+/** An existing empty directory: `--plugin-dir` rejects a missing path. */
+export function emptyPluginDir(): string {
+  if (!cachedEmptyPluginDir) {
+    cachedEmptyPluginDir = join(tmpdir(), "lcm-claude-empty-plugins");
+    mkdirSync(cachedEmptyPluginDir, { recursive: true });
+  }
+  return cachedEmptyPluginDir;
+}
 const STDERR_ERROR_MAX_CHARS = 2_000;
 
 type ClaudeModelUsage = {
@@ -104,6 +119,13 @@ function normalizeSpawnError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
 }
 
+/**
+ * The summarizer needs a bare model call, not a Claude Code session. Without
+ * the isolation flags the CLI loads the user's plugins, MCP servers, settings
+ * and CLAUDE.md files into every prompt (tens of thousands of tokens and
+ * several seconds per call). `--bare` is not used because it disables OAuth,
+ * which would move the cost off the subscription.
+ */
 export function buildClaudeArgs(model: string, systemPrompt = LCM_SUMMARIZER_SYSTEM_PROMPT): string[] {
   return [
     "--print",
@@ -113,6 +135,10 @@ export function buildClaudeArgs(model: string, systemPrompt = LCM_SUMMARIZER_SYS
     "--system-prompt", systemPrompt,
     "--tools", "",
     "--disable-slash-commands",
+    "--plugin-dir", emptyPluginDir(),
+    "--strict-mcp-config",
+    "--mcp-config", EMPTY_MCP_CONFIG,
+    "--setting-sources", "",
   ];
 }
 

--- a/test/llm/claude-process-args.test.ts
+++ b/test/llm/claude-process-args.test.ts
@@ -1,0 +1,15 @@
+import { existsSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { buildClaudeArgs, emptyPluginDir } from "../../src/llm/claude-process.js";
+
+describe("buildClaudeArgs", () => {
+  it("isolates the subprocess from the user's plugins, MCP servers and settings", () => {
+    const args = buildClaudeArgs("test-model");
+    expect(args[args.indexOf("--plugin-dir") + 1]).toBe(emptyPluginDir());
+    expect(existsSync(emptyPluginDir())).toBe(true);
+    expect(args).toContain("--strict-mcp-config");
+    expect(args[args.indexOf("--mcp-config") + 1]).toBe('{"mcpServers":{}}');
+    expect(args[args.indexOf("--setting-sources") + 1]).toBe("");
+    expect(args).not.toContain("--bare");
+  });
+});

--- a/test/llm/claude-process-args.test.ts
+++ b/test/llm/claude-process-args.test.ts
@@ -1,15 +1,23 @@
-import { existsSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { describe, expect, it } from "vitest";
 import { buildClaudeArgs, emptyPluginDir } from "../../src/llm/claude-process.js";
 
 describe("buildClaudeArgs", () => {
   it("isolates the subprocess from the user's plugins, MCP servers and settings", () => {
     const args = buildClaudeArgs("test-model");
+    for (const flag of ["--plugin-dir", "--mcp-config", "--setting-sources"]) expect(args).toContain(flag);
     expect(args[args.indexOf("--plugin-dir") + 1]).toBe(emptyPluginDir());
     expect(existsSync(emptyPluginDir())).toBe(true);
     expect(args).toContain("--strict-mcp-config");
     expect(args[args.indexOf("--mcp-config") + 1]).toBe('{"mcpServers":{}}');
     expect(args[args.indexOf("--setting-sources") + 1]).toBe("");
     expect(args).not.toContain("--bare");
+  });
+
+  it("uses a per-process private directory and caches it", () => {
+    expect(emptyPluginDir()).toBe(emptyPluginDir());
+    expect(emptyPluginDir().startsWith(tmpdir())).toBe(true);
+    expect((statSync(emptyPluginDir()).mode & 0o777) === 0o700 || process.platform === "win32").toBe(true);
   });
 });


### PR DESCRIPTION
## Changes
- `buildClaudeArgs` now passes `--plugin-dir <empty dir>`, `--strict-mcp-config --mcp-config '{"mcpServers":{}}'` and `--setting-sources ""`. Without them every summarizer call loads the user's plugins, MCP servers, settings and CLAUDE.md files into the prompt.
- Measured on Claude Code 2.1.263 with a one-word prompt to Haiku: 35,905 prompt tokens and 15 s per call before, 243 tokens and 4 s after. On a 20k-token leaf summary the reported input dropped from ~53k to ~18.7k tokens, matching what an OpenAI-compatible endpoint counts for the same prompt.
- `--bare` was rejected because it disables OAuth and would bill the API key instead of the subscription. OAuth was verified to keep working with `ANTHROPIC_API_KEY` unset.
- The empty plugin directory is created with `mkdtemp` (mode 0700, per process) so no other local user can pre-create a same-named path and plant plugins in it. Creation happens in the spawn path where errors are already normalized.

## Files Touched
- `src/llm/claude-process.ts` — isolation flags in `buildClaudeArgs`; `emptyPluginDir()` helper
- `test/llm/claude-process-args.test.ts` — asserts each flag, the directory's existence and privacy, and the absence of `--bare`

## Issue Reference

Closes #327

## Test Evidence
```
npx vitest run --project unit   → Test Files 108 passed | 1 skipped, Tests 1122 passed | 1 skipped
npx vitest run test/llm         → 58 passed
npx tsc --noEmit                → OK
```
Live check: Haiku via claude-process on a 73k-token synthetic session, 4 leaf calls, format 4/4, planted facts 5/5, cost 0.23 → 0.14 USD list price.

## Risks & Follow-ups
- Revives closed PR #258 (never merged, no recorded reason) and adds `--setting-sources ""` on top.
- The flags are a contract with the installed `claude` CLI; the project already requires 2.1.x and inline `--mcp-config` JSON is documented. An unknown-flag exit is surfaced with stderr by `buildClaudeExitError`.
- Follow-up: the summarizer model eval bench on `feat/summarizer-eval-bench` is stacked on this branch so `claude-process` baselines are measured with the isolated subprocess.

## AR Status
PASSED — adversarial review, 2 rounds, converged at round 2 (zero novel findings at the opus ceiling, judge fable). 5 confirmed (1 medium: predictable tmp path hijackable via symlink; 4 low: cache assigned before creation, filesystem I/O in the arg builder, constants block split, indexOf without guard), all fixed in f03719c. 2 debunked (tmp dir persistence by design; CLI version gate unwarranted). Run: `~/.autoimprove/runs/20260907-181305-origin-main--fix-claude-process-isolatio`.

## Introspection Findings
- `--bare` looks like the obvious isolation switch, but it forces API-key auth. The subscription-preserving recipe is plugin-dir + strict MCP + empty setting sources.
- `--setting-sources ""` is honored as "none", not "unset": measured 5.4k → 243 tokens.

## Token Cost
~120k tokens (Fable 5.1 orchestration) + ~85k tokens (opus/fable review agents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192LTrLjpB8AsWf2QjSTawh