### PR TITLE
fix(daemon): content-hash build fingerprint; sync installed copy after build

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "postbuild": "mkdir -p dist/src/prompts && cp -r src/prompts/*.yaml dist/src/prompts/ && mkdir -p dist/src/connectors/templates && cp -r src/connectors/templates/. dist/src/connectors/templates/ && cp installer/setup.sh dist/installer/setup.sh && sh scripts/sync-plugin-cache.sh",
+    "postbuild": "mkdir -p dist/src/prompts && cp -r src/prompts/*.yaml dist/src/prompts/ && mkdir -p dist/src/connectors/templates && cp -r src/connectors/templates/. dist/src/connectors/templates/ && cp installer/setup.sh dist/installer/setup.sh && node scripts/write-build-id.mjs && sh scripts/sync-plugin-cache.sh",
     "prepublishOnly": "npm run build",
     "changeset": "changeset",
     "release:verify": "npm test && npm pack --dry-run",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "postbuild": "mkdir -p dist/src/prompts && cp -r src/prompts/*.yaml dist/src/prompts/ && mkdir -p dist/src/connectors/templates && cp -r src/connectors/templates/. dist/src/connectors/templates/ && cp installer/setup.sh dist/installer/setup.sh",
+    "postbuild": "mkdir -p dist/src/prompts && cp -r src/prompts/*.yaml dist/src/prompts/ && mkdir -p dist/src/connectors/templates && cp -r src/connectors/templates/. dist/src/connectors/templates/ && cp installer/setup.sh dist/installer/setup.sh && sh scripts/sync-plugin-cache.sh",
     "prepublishOnly": "npm run build",
     "changeset": "changeset",
     "release:verify": "npm test && npm pack --dry-run",

--- a/scripts/sync-plugin-cache.sh
+++ b/scripts/sync-plugin-cache.sh
@@ -11,7 +11,11 @@ set -e
 
 if [ "$LCM_SKIP_CACHE_SYNC" = "1" ]; then exit 0; fi
 
-cd "$(dirname "$0")/.."
+# Best-effort: never fail the build.
+[ -n "${HOME:-}" ] || exit 0
+command -v rsync >/dev/null 2>&1 || exit 0
+
+cd "$(dirname "$0")/.." || exit 0
 
 version=$(node -p "require('./package.json').version" 2>/dev/null) || exit 0
 [ -n "$version" ] || exit 0
@@ -20,5 +24,5 @@ target="$HOME/.claude/plugins/cache/lossless-claude/lcm/$version/dist"
 [ -d "$target" ] || exit 0
 [ -d dist ] || exit 0
 
-rsync -a --delete dist/ "$target/"
+rsync -a --delete dist/ "$target/" || { echo "sync-plugin-cache: rsync failed (ignored)" >&2; exit 0; }
 echo "synced dist/ -> $target"

--- a/scripts/sync-plugin-cache.sh
+++ b/scripts/sync-plugin-cache.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+# Mirror the freshly built dist/ into the installed plugin cache, when present.
+#
+# The cache is a copy of dist/ made at install time and is never refreshed on
+# rebuild, so the installed copy silently drifts from the checkout. Syncing it
+# after every build keeps both reporting the same build fingerprint.
+#
+# Never fails the build: a missing cache directory is a no-op.
+# Set LCM_SKIP_CACHE_SYNC=1 to skip.
+set -e
+
+if [ "$LCM_SKIP_CACHE_SYNC" = "1" ]; then exit 0; fi
+
+cd "$(dirname "$0")/.."
+
+version=$(node -p "require('./package.json').version" 2>/dev/null) || exit 0
+[ -n "$version" ] || exit 0
+
+target="$HOME/.claude/plugins/cache/lossless-claude/lcm/$version/dist"
+[ -d "$target" ] || exit 0
+[ -d dist ] || exit 0
+
+rsync -a --delete dist/ "$target/"
+echo "synced dist/ -> $target"

--- a/scripts/write-build-id.mjs
+++ b/scripts/write-build-id.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+// Compute a build fingerprint over the emitted JavaScript and write it to
+// <dist>/BUILD_ID (plain text, no trailing newline).
+//
+// The id is the first 16 hex chars of a sha256 over every *.js file under the
+// directory, walked in sorted relative-path order, hashing the path alongside
+// the bytes so that a rename changes the id. Because the file travels with a
+// copy of the build, an installed copy reports the same id as its source,
+// while any rebuild that changes any emitted file changes it.
+//
+// Usage: node scripts/write-build-id.mjs [distDir]   (default: ./dist)
+
+import { createHash } from "node:crypto";
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { join, relative, sep } from "node:path";
+
+function collectJsFiles(dir, root, out) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) collectJsFiles(full, root, out);
+    else if (entry.isFile() && entry.name.endsWith(".js")) out.push(relative(root, full));
+  }
+  return out;
+}
+
+function computeBuildId(distDir) {
+  const files = collectJsFiles(distDir, distDir, []).sort();
+  const hash = createHash("sha256");
+  for (const rel of files) {
+    hash.update(rel.split(sep).join("/"));
+    hash.update("\0");
+    hash.update(readFileSync(join(distDir, rel)));
+    hash.update("\0");
+  }
+  return hash.digest("hex").slice(0, 16);
+}
+
+const distDir = process.argv[2] ?? "dist";
+const buildId = computeBuildId(distDir);
+writeFileSync(join(distDir, "BUILD_ID"), buildId);
+process.stdout.write(buildId + "\n");

--- a/src/daemon/version.ts
+++ b/src/daemon/version.ts
@@ -1,4 +1,5 @@
-import { readFileSync, statSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -30,14 +31,29 @@ export const PKG_VERSION: string | undefined = (() => {
 })();
 
 /**
- * Fingerprint of the running build: the mtime of this module file.
- * Two daemons with the same PKG_VERSION but different builds (a rebuilt dist,
- * a dev checkout) report different BUILD_IDs, so callers can tell a stale
- * daemon apart from a current one. `undefined` when the file cannot be stat'd.
+ * Content fingerprint of a file: the first 16 hex chars of its sha256.
+ * Throws when the file cannot be read; callers decide how to fail.
+ */
+export function fingerprintFile(path: string): string {
+  return createHash("sha256").update(readFileSync(path)).digest("hex").slice(0, 16);
+}
+
+/**
+ * Fingerprint of the running build: a content hash of this module file.
+ *
+ * The fingerprint must depend on file *content*, not on filesystem metadata:
+ * an installed copy of a build is byte-identical to its source but does not
+ * carry its mtime (copy tools such as `rsync -a` truncate mtimes to whole
+ * seconds), so an mtime-based id makes two identical builds compare unequal
+ * and sends callers into an endless "stale daemon" restart loop.
+ *
+ * Two daemons with the same PKG_VERSION but different builds report different
+ * BUILD_IDs, so callers can tell a stale daemon apart from a current one.
+ * `undefined` when the file cannot be read.
  */
 export const BUILD_ID: string | undefined = (() => {
   try {
-    return new Date(statSync(fileURLToPath(import.meta.url)).mtimeMs).toISOString();
+    return fingerprintFile(fileURLToPath(import.meta.url));
   } catch {
     return undefined;
   }

--- a/src/daemon/version.ts
+++ b/src/daemon/version.ts
@@ -39,19 +39,42 @@ export function fingerprintFile(path: string): string {
 }
 
 /**
- * Fingerprint of the running build: a content hash of this module file.
+ * Reads a build id written next to the emitted JavaScript, trying each
+ * candidate directory in order. Returns `undefined` when no readable,
+ * well-formed id is found.
+ */
+export function readBuildIdFile(dirs: string[]): string | undefined {
+  for (const dir of dirs) {
+    try {
+      const id = readFileSync(join(dir, "BUILD_ID"), "utf-8").trim();
+      if (/^[0-9a-f]{16}$/.test(id)) return id;
+    } catch { /* try next candidate */ }
+  }
+  return undefined;
+}
+
+/**
+ * Fingerprint of the running build.
  *
- * The fingerprint must depend on file *content*, not on filesystem metadata:
+ * The primary source is `dist/BUILD_ID`, written at build time as a hash over
+ * every emitted JavaScript file, so that *any* rebuild changes the id. The
+ * fallback, used in a checkout that has not run the build step, is a content
+ * hash of this module file alone.
+ *
+ * The fingerprint must depend on file *content*, never on filesystem metadata:
  * an installed copy of a build is byte-identical to its source but does not
- * carry its mtime (copy tools such as `rsync -a` truncate mtimes to whole
+ * carry its mtimes (copy tools such as `rsync -a` truncate them to whole
  * seconds), so an mtime-based id makes two identical builds compare unequal
  * and sends callers into an endless "stale daemon" restart loop.
  *
  * Two daemons with the same PKG_VERSION but different builds report different
  * BUILD_IDs, so callers can tell a stale daemon apart from a current one.
- * `undefined` when the file cannot be read.
+ * `undefined` when nothing can be read.
  */
 export const BUILD_ID: string | undefined = (() => {
+  // Production / installed: dist/src/daemon → 2 levels up = dist root
+  const fromFile = readBuildIdFile([join(__dirname, "..", "..")]);
+  if (fromFile) return fromFile;
   try {
     return fingerprintFile(fileURLToPath(import.meta.url));
   } catch {

--- a/test/daemon/server.test.ts
+++ b/test/daemon/server.test.ts
@@ -41,7 +41,7 @@ describe("daemon server", () => {
     const body = await res.json() as { build?: string; pid?: number };
     expect(body.pid).toBe(process.pid);
     expect(typeof body.build).toBe("string");
-    expect(Number.isNaN(Date.parse(body.build!))).toBe(false);
+    expect(body.build).toMatch(/^[0-9a-f]{16}$/);
   });
 
   it("rejects with EADDRINUSE when the port is taken instead of crashing the process", async () => {

--- a/test/daemon/version.test.ts
+++ b/test/daemon/version.test.ts
@@ -1,11 +1,26 @@
 import { describe, it, expect, afterEach } from "vitest";
-import { copyFileSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { copyFileSync, mkdirSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 
-import { BUILD_ID, fingerprintFile } from "../../src/daemon/version.js";
+import { BUILD_ID, fingerprintFile, readBuildIdFile } from "../../src/daemon/version.js";
+
+const HEX16 = /^[0-9a-f]{16}$/;
+const scriptPath = fileURLToPath(new URL("../../scripts/write-build-id.mjs", import.meta.url));
 
 const tempDirs: string[] = [];
+
+function newTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "lossless-buildid-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function runBuildIdScript(distDir: string): string {
+  return execFileSync(process.execPath, [scriptPath, distDir], { encoding: "utf-8" }).trim();
+}
 
 afterEach(() => {
   while (tempDirs.length) {
@@ -17,13 +32,13 @@ afterEach(() => {
 describe("BUILD_ID", () => {
   it("is a 16-char lowercase hex fingerprint", () => {
     expect(BUILD_ID).toBeDefined();
-    expect(BUILD_ID).toMatch(/^[0-9a-f]{16}$/);
+    expect(BUILD_ID).toMatch(HEX16);
   });
+});
 
+describe("fingerprintFile", () => {
   it("is identical for byte-identical copies with different mtimes", () => {
-    const dir = mkdtempSync(join(tmpdir(), "lossless-buildid-"));
-    tempDirs.push(dir);
-
+    const dir = newTempDir();
     const original = join(dir, "module.js");
     const copy = join(dir, "module-copy.js");
     writeFileSync(original, "export const answer = 42;\n");
@@ -38,14 +53,70 @@ describe("BUILD_ID", () => {
   });
 
   it("differs when content differs", () => {
-    const dir = mkdtempSync(join(tmpdir(), "lossless-buildid-"));
-    tempDirs.push(dir);
-
+    const dir = newTempDir();
     const a = join(dir, "a.js");
     const b = join(dir, "b.js");
     writeFileSync(a, "export const answer = 42;\n");
     writeFileSync(b, "export const answer = 43;\n");
 
     expect(fingerprintFile(a)).not.toBe(fingerprintFile(b));
+  });
+});
+
+describe("readBuildIdFile", () => {
+  it("reads a well-formed id from the first candidate that has one", () => {
+    const empty = newTempDir();
+    const dir = newTempDir();
+    writeFileSync(join(dir, "BUILD_ID"), "0123456789abcdef");
+
+    expect(readBuildIdFile([empty, dir])).toBe("0123456789abcdef");
+  });
+
+  it("tolerates a trailing newline", () => {
+    const dir = newTempDir();
+    writeFileSync(join(dir, "BUILD_ID"), "0123456789abcdef\n");
+    expect(readBuildIdFile([dir])).toBe("0123456789abcdef");
+  });
+
+  it("returns undefined when no file exists or the content is malformed", () => {
+    const missing = newTempDir();
+    const bad = newTempDir();
+    writeFileSync(join(bad, "BUILD_ID"), "not-a-fingerprint");
+
+    expect(readBuildIdFile([missing])).toBeUndefined();
+    expect(readBuildIdFile([bad])).toBeUndefined();
+    expect(readBuildIdFile([])).toBeUndefined();
+  });
+});
+
+describe("write-build-id script", () => {
+  it("writes a 16-char hex id that covers every emitted js file", () => {
+    const dist = newTempDir();
+    mkdirSync(join(dist, "src", "daemon"), { recursive: true });
+    writeFileSync(join(dist, "src", "daemon", "server.js"), "export const a = 1;\n");
+    writeFileSync(join(dist, "src", "daemon", "version.js"), "export const b = 2;\n");
+
+    const first = runBuildIdScript(dist);
+    expect(first).toMatch(HEX16);
+    expect(readBuildIdFile([dist])).toBe(first);
+
+    // Stable when nothing changed.
+    expect(runBuildIdScript(dist)).toBe(first);
+
+    // Changes when an unrelated emitted file changes.
+    writeFileSync(join(dist, "src", "daemon", "server.js"), "export const a = 99;\n");
+    const second = runBuildIdScript(dist);
+    expect(second).toMatch(HEX16);
+    expect(second).not.toBe(first);
+  });
+
+  it("changes when a file is renamed but its bytes are not", () => {
+    const dist = newTempDir();
+    writeFileSync(join(dist, "one.js"), "export const a = 1;\n");
+    const before = runBuildIdScript(dist);
+
+    rmSync(join(dist, "one.js"));
+    writeFileSync(join(dist, "two.js"), "export const a = 1;\n");
+    expect(runBuildIdScript(dist)).not.toBe(before);
   });
 });

--- a/test/daemon/version.test.ts
+++ b/test/daemon/version.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { copyFileSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { BUILD_ID, fingerprintFile } from "../../src/daemon/version.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  while (tempDirs.length) {
+    const dir = tempDirs.pop()!;
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
+
+describe("BUILD_ID", () => {
+  it("is a 16-char lowercase hex fingerprint", () => {
+    expect(BUILD_ID).toBeDefined();
+    expect(BUILD_ID).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("is identical for byte-identical copies with different mtimes", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lossless-buildid-"));
+    tempDirs.push(dir);
+
+    const original = join(dir, "module.js");
+    const copy = join(dir, "module-copy.js");
+    writeFileSync(original, "export const answer = 42;\n");
+    copyFileSync(original, copy);
+
+    // Simulate a copy tool that does not preserve mtimes exactly.
+    const shifted = new Date(Date.now() - 60_000);
+    utimesSync(copy, shifted, shifted);
+    expect(statSync(copy).mtimeMs).not.toBe(statSync(original).mtimeMs);
+
+    expect(fingerprintFile(copy)).toBe(fingerprintFile(original));
+  });
+
+  it("differs when content differs", () => {
+    const dir = mkdtempSync(join(tmpdir(), "lossless-buildid-"));
+    tempDirs.push(dir);
+
+    const a = join(dir, "a.js");
+    const b = join(dir, "b.js");
+    writeFileSync(a, "export const answer = 42;\n");
+    writeFileSync(b, "export const answer = 43;\n");
+
+    expect(fingerprintFile(a)).not.toBe(fingerprintFile(b));
+  });
+});


### PR DESCRIPTION
## Bug

`BUILD_ID` (src/daemon/version.ts) was the mtime of the version module, formatted as an ISO date. `lcm doctor` compares the running daemon's reported `build` against the local `BUILD_ID` and restarts the daemon on mismatch.

The installed copy of the package under `~/.claude/plugins/cache/lossless-claude/lcm/<version>/dist` is a byte-identical copy of `dist/`, but a copy does not carry the original mtimes (`rsync -a` truncates them to whole seconds on macOS). So the same build reported two different fingerprints depending on which path it was launched from, and running `doctor` from the checkout and then from the installed copy restarted the daemon on every single run — an endless ping-pong. Any metadata-based fingerprint has this flaw.

A second, independent problem: the installed copy is made once at install time and is never refreshed, so it silently drifts from the checkout after a rebuild.

## Fix

**A build fingerprint over the whole emitted build.** `scripts/write-build-id.mjs` walks `dist/` in sorted relative-path order and hashes each `*.js` file's path and bytes into one sha256, writing the first 16 hex chars to `dist/BUILD_ID`. Because it is derived from content it survives copying unchanged, and because it covers every emitted file, any rebuild that changes anything changes it. The file has no `.js` extension, so it never hashes itself.

`BUILD_ID` reads `dist/BUILD_ID` relative to the module location and falls back to a content hash of the module file alone when it is absent, so a checkout that has not run the build step still works. The `string | undefined` contract and the fail-open behavior are unchanged; a malformed id is ignored rather than propagated.

**Keeping the installed copy fresh.** `scripts/sync-plugin-cache.sh`, also in `postbuild`, mirrors `dist/` into the installed copy when that directory exists, no-ops silently otherwise, and never fails the build. `LCM_SKIP_CACHE_SYNC=1` skips it.

`postbuild` order is `tsc` → asset copies → `write-build-id.mjs` → `sync-plugin-cache.sh`, so the id is always rewritten before it is copied and can never go stale.

`test/daemon/server.test.ts` asserted the health endpoint's `build` parsed as a date; it now asserts the hex fingerprint shape.

## Verification

- `npm run build` passes (and is still green with the target directory absent — the sync script exits 0).
- Full suite: **1173 passed, 3 skipped, 0 failed** (121 files).
- `test/daemon/version.test.ts` covers: `BUILD_ID` matches `/^[0-9a-f]{16}$/`; two byte-identical files with deliberately different mtimes hash the same; different content hashes differently; the reader picks the first well-formed id, tolerates a trailing newline, and returns `undefined` for missing or malformed files; the build-id script emits 16 hex chars, is stable when nothing changed, changes when any emitted file's content changes, and changes on a rename with identical bytes.
- `lcm doctor` from the checkout twice and once from the installed copy: `up`, `up`, `up` — no restarts, ping-pong gone.
- Appending a comment to an unrelated source file and rebuilding flipped `dist/BUILD_ID` from `29700382f7aa3244` to `40e8620fe7251e0a`; reverting and rebuilding restored `29700382f7aa3244`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5EHTa3whx4xnRxsQtUZCL