### PR TITLE
test(bench): summarizer model eval harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ sensitive-patterns-test.txt
 .env
 dist/
 
+
+# Summarizer eval bench (local only, never committed)
+test/bench/corpus/
+test/bench/results/

--- a/test/bench/export-eval-session.sh
+++ b/test/bench/export-eval-session.sh
@@ -16,4 +16,11 @@ mkdir -p "$(dirname "$out")"
 sqlite3 -json "file:${db}?immutable=1" \
   "select seq, role, content, token_count as tokenCount, created_at as createdAt
    from messages where conversation_id = ${cid} order by seq" > "$out"
-echo "$out: $(python3 -c "import json;m=json.load(open('$out'));print(len(m),'messages',sum(x['tokenCount'] for x in m),'tokens')")"
+# sqlite3 -json prints nothing (not []) for zero rows; leaving the empty file
+# behind would break loadCorpusDir later with an opaque JSON parse error.
+if ! [[ -s "$out" ]]; then
+  echo "no messages for conversation_id $cid" >&2
+  rm -f "$out"
+  exit 1
+fi
+echo "$out: $(python3 -c "import json,sys;m=json.load(open(sys.argv[1]));print(len(m),'messages',sum(x['tokenCount'] or 0 for x in m),'tokens')" "$out")"

--- a/test/bench/export-eval-session.sh
+++ b/test/bench/export-eval-session.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Export one conversation from a per-project lcm database as a bench corpus file.
+#
+#   test/bench/export-eval-session.sh <db.sqlite> <conversation_id> <out-dir/label.json>
+#
+# The database is opened read-only through the immutable URI, which is the only
+# form that opens these WAL databases without a lock.
+set -euo pipefail
+
+db="$1"; cid="$2"; out="$3"
+mkdir -p "$(dirname "$out")"
+sqlite3 -json "file:${db}?immutable=1" \
+  "select seq, role, content, token_count as tokenCount, created_at as createdAt
+   from messages where conversation_id = ${cid} order by seq" > "$out"
+echo "$out: $(python3 -c "import json;m=json.load(open('$out'));print(len(m),'messages',sum(x['tokenCount'] for x in m),'tokens')")"

--- a/test/bench/export-eval-session.sh
+++ b/test/bench/export-eval-session.sh
@@ -8,6 +8,10 @@
 set -euo pipefail
 
 db="$1"; cid="$2"; out="$3"
+if ! [[ "$cid" =~ ^[0-9]+$ ]]; then
+  echo "conversation_id must be a plain integer, got: $cid" >&2
+  exit 1
+fi
 mkdir -p "$(dirname "$out")"
 sqlite3 -json "file:${db}?immutable=1" \
   "select seq, role, content, token_count as tokenCount, created_at as createdAt

--- a/test/bench/summarizer-eval-harness.ts
+++ b/test/bench/summarizer-eval-harness.ts
@@ -15,7 +15,7 @@ import { runLcmMigrations } from "../../src/db/migration.js";
 import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "../../src/llm/types.js";
 import { ConversationStore } from "../../src/store/conversation-store.js";
 import { SummaryStore } from "../../src/store/summary-store.js";
-import { resolveTargetTokens } from "../../src/summarize.js";
+import { resolveMaxOutputTokens, resolveTargetTokens } from "../../src/summarize.js";
 
 // ── Corpus ─────────────────────────────────────────────────────────────────
 
@@ -281,12 +281,11 @@ export type EvalRunResult = {
     /** Format-passing calls over all calls that returned output. */
     formatPass: number;
     formatTotal: number;
-    /** Calls whose output hit the production max_tokens (1024): the summary was cut off. */
+    /** OpenRouter calls whose output reached the production output cap: the summary was cut off. */
     maxTokensHits: number;
   };
 };
 
-const PROD_MAX_OUTPUT_TOKENS = 1024;
 
 /** Exactly the engine config the daemon's /compact route uses. */
 function prodEngineConfig() {
@@ -384,7 +383,9 @@ export async function runEval(input: {
       costUsd: calls.reduce((n, c) => n + (c.usage?.costUsd ?? 0), 0),
       formatPass,
       formatTotal: scoredCalls.length,
-      maxTokensHits: calls.filter((c) => (c.usage?.outputTokens ?? 0) >= PROD_MAX_OUTPUT_TOKENS).length,
+      maxTokensHits: calls.filter(
+        (c) => c.usage?.provider === "openrouter" && (c.usage.outputTokens ?? 0) >= resolveMaxOutputTokens(c.targetTokens),
+      ).length,
     },
   };
 }

--- a/test/bench/summarizer-eval-harness.ts
+++ b/test/bench/summarizer-eval-harness.ts
@@ -152,6 +152,9 @@ export type SummarizerCall = {
   outputChars: number;
   outputTokensEstimate: number;
   latencyMs: number;
+  output?: string;
+  /** Format checks on this call's output; leaf summaries get condensed away and would otherwise go unscored. */
+  format?: SummaryScore;
   usage?: EvalUsage;
   /** openai.ts returns the input prefix when the model sends empty content. */
   emptyContentFallback: boolean;
@@ -197,6 +200,8 @@ export function instrumentSummarizer(inner: LcmSummarizeFn): InstrumentedSummari
       call.latencyMs = Date.now() - started;
       call.outputChars = out.length;
       call.outputTokensEstimate = Math.ceil(out.length / 4);
+      call.output = out;
+      call.format = scoreSummary(out, call.depth);
       call.emptyContentFallback = out === text.slice(0, 500);
       return out;
     } catch (err) {
@@ -269,6 +274,7 @@ export type EvalRunResult = {
     inputTokens: number;
     outputTokens: number;
     costUsd: number;
+    /** Format-passing calls over all calls that returned output. */
     formatPass: number;
     formatTotal: number;
     /** Calls whose output hit the production max_tokens (1024): the summary was cut off. */
@@ -345,8 +351,9 @@ export async function runEval(input: {
   const tokensAfter = await summaryStore.getContextTokenCount(cid);
   db.close();
 
-  const contextText = summaries.map((s) => s.content).join("\n\n");
-  const formatPass = summaries.filter((s) => s.hasExpandTrailer && s.hasFilesLine !== false).length;
+  const contextText = summaries.map((summary) => summary.content).join("\n\n");
+  const scoredCalls = calls.filter((c) => c.format);
+  const formatPass = scoredCalls.filter((c) => c.format!.hasExpandTrailer && c.format!.hasFilesLine !== false).length;
 
   return {
     label: session.label,
@@ -370,7 +377,7 @@ export async function runEval(input: {
       outputTokens: calls.reduce((n, c) => n + (c.usage?.outputTokens ?? 0), 0),
       costUsd: calls.reduce((n, c) => n + (c.usage?.costUsd ?? 0), 0),
       formatPass,
-      formatTotal: summaries.length,
+      formatTotal: scoredCalls.length,
       maxTokensHits: calls.filter((c) => (c.usage?.outputTokens ?? 0) >= PROD_MAX_OUTPUT_TOKENS).length,
     },
   };

--- a/test/bench/summarizer-eval-harness.ts
+++ b/test/bench/summarizer-eval-harness.ts
@@ -271,8 +271,12 @@ export type EvalRunResult = {
     costUsd: number;
     formatPass: number;
     formatTotal: number;
+    /** Calls whose output hit the production max_tokens (1024): the summary was cut off. */
+    maxTokensHits: number;
   };
 };
+
+const PROD_MAX_OUTPUT_TOKENS = 1024;
 
 /** Exactly the engine config the daemon's /compact route uses. */
 function prodEngineConfig() {
@@ -367,6 +371,7 @@ export async function runEval(input: {
       costUsd: calls.reduce((n, c) => n + (c.usage?.costUsd ?? 0), 0),
       formatPass,
       formatTotal: summaries.length,
+      maxTokensHits: calls.filter((c) => (c.usage?.outputTokens ?? 0) >= PROD_MAX_OUTPUT_TOKENS).length,
     },
   };
 }

--- a/test/bench/summarizer-eval-harness.ts
+++ b/test/bench/summarizer-eval-harness.ts
@@ -124,7 +124,7 @@ export function buildSyntheticSession(): CorpusSession {
       role,
       content,
       tokenCount: Math.ceil(content.length / CHARS_PER_TOKEN),
-      createdAt: new Date(base + seq * 60_000).toISOString(),
+      createdAt: new Date(base + (seq - 1) * 60_000).toISOString(),
     });
   };
 
@@ -206,7 +206,9 @@ export function instrumentSummarizer(inner: LcmSummarizeFn): InstrumentedSummari
       call.outputTokensEstimate = Math.ceil(out.length / CHARS_PER_TOKEN);
       call.output = out;
       call.format = scoreSummary(out, call.depth);
-      call.emptyContentFallback = out === text.slice(0, 500);
+      // Must match the empty-content fallback in src/llm/openai.ts; pinned by the
+    // "detects the production empty-content fallback" offline test.
+    call.emptyContentFallback = out === text.slice(0, 500);
       return out;
     } catch (err) {
       call.latencyMs = Date.now() - started;
@@ -260,6 +262,10 @@ export function checkPlantedFacts(
 export type EvalRunResult = {
   label: string;
   model: string;
+  /** Which bench provider produced this run — the same model scores differently per provider. */
+  provider: string;
+  /** Reasoning/thinking knobs in effect, if any; part of the result identity. */
+  variant?: string;
   run: number;
   startedAt: string;
   incomplete: boolean;
@@ -277,7 +283,8 @@ export type EvalRunResult = {
     latencyMs: number;
     inputTokens: number;
     outputTokens: number;
-    costUsd: number;
+    /** null when no call reported a cost — the provider does not price its calls. */
+    costUsd: number | null;
     /** Format-passing calls over all calls that returned output. */
     formatPass: number;
     formatTotal: number;
@@ -313,9 +320,11 @@ export async function runEval(input: {
   session: CorpusSession;
   summarizer: LcmSummarizeFn;
   model: string;
+  provider: string;
+  variant?: string;
   run: number;
 }): Promise<EvalRunResult> {
-  const { session, model, run } = input;
+  const { session, model, provider, variant, run } = input;
   const db = new DatabaseSync(":memory:");
   runLcmMigrations(db);
   const conversationStore = new ConversationStore(db);
@@ -367,6 +376,8 @@ export async function runEval(input: {
 
   return {
     label: session.label,
+    provider,
+    variant,
     model,
     run,
     startedAt,
@@ -378,14 +389,18 @@ export async function runEval(input: {
     tokensAfter,
     calls,
     summaries,
-    plantedFacts: session.plantedFacts ? checkPlantedFacts(contextText, session.plantedFacts) : undefined,
+    // An incomplete run leaves chunks un-summarized, so fact survival would be
+    // scored against a partial context — report nothing rather than a low score.
+    plantedFacts: session.plantedFacts && error === undefined ? checkPlantedFacts(contextText, session.plantedFacts) : undefined,
     totals: {
       calls: calls.length,
       failedCalls: calls.filter((c) => c.error).length,
       latencyMs: calls.reduce((n, c) => n + c.latencyMs, 0),
       inputTokens: calls.reduce((n, c) => n + (c.usage?.inputTokens ?? 0), 0),
       outputTokens: calls.reduce((n, c) => n + (c.usage?.outputTokens ?? 0), 0),
-      costUsd: calls.reduce((n, c) => n + (c.usage?.costUsd ?? 0), 0),
+      costUsd: calls.some((c) => typeof c.usage?.costUsd === "number")
+        ? calls.reduce((n, c) => n + (c.usage?.costUsd ?? 0), 0)
+        : null,
       formatPass,
       formatTotal: scoredCalls.length,
       maxTokensHits: calls.filter(
@@ -397,8 +412,12 @@ export async function runEval(input: {
 
 export function writeResult(dir: string, result: EvalRunResult): string {
   mkdirSync(dir, { recursive: true });
-  const safeModel = result.model.replace(/[^a-z0-9.-]+/gi, "_");
-  const file = join(dir, `${safeModel}__${result.label}__run${result.run}.json`);
+  const safe = (v: string) => v.replace(/[^a-z0-9.-]+/gi, "_");
+  // provider and variant are part of the run's identity: the same model scores
+  // differently under a different provider or reasoning setting, and leaving
+  // them out of the path made those runs overwrite each other.
+  const variant = result.variant ? `__${safe(result.variant)}` : "";
+  const file = join(dir, `${safe(result.model)}__${safe(result.provider)}${variant}__${result.label}__run${result.run}.json`);
   writeFileSync(file, JSON.stringify(result, null, 2));
   return file;
 }

--- a/test/bench/summarizer-eval-harness.ts
+++ b/test/bench/summarizer-eval-harness.ts
@@ -281,7 +281,7 @@ export type EvalRunResult = {
     /** Format-passing calls over all calls that returned output. */
     formatPass: number;
     formatTotal: number;
-    /** OpenRouter calls whose output reached the production output cap: the summary was cut off. */
+    /** HTTP-provider calls whose output reached the production output cap: the summary was cut off. */
     maxTokensHits: number;
   };
 };
@@ -384,7 +384,7 @@ export async function runEval(input: {
       formatPass,
       formatTotal: scoredCalls.length,
       maxTokensHits: calls.filter(
-        (c) => c.usage?.provider === "openrouter" && (c.usage.outputTokens ?? 0) >= resolveMaxOutputTokens(c.targetTokens),
+        (c) => c.usage?.provider !== "claude-process" && (c.usage?.outputTokens ?? 0) >= resolveMaxOutputTokens(c.targetTokens),
       ).length,
     },
   };

--- a/test/bench/summarizer-eval-harness.ts
+++ b/test/bench/summarizer-eval-harness.ts
@@ -1,0 +1,380 @@
+/**
+ * Summarizer model eval harness.
+ *
+ * Runs the real CompactionEngine with the production configuration against a
+ * session loaded into an in-memory SQLite database, records every summarizer
+ * call, and scores the resulting summaries mechanically. No production state
+ * is touched: the candidate model comes from the caller, never from
+ * ~/.lossless-claude/config.json.
+ */
+import { readFileSync, readdirSync, mkdirSync, writeFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { CompactionEngine } from "../../src/compaction.js";
+import { runLcmMigrations } from "../../src/db/migration.js";
+import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "../../src/llm/types.js";
+import { ConversationStore } from "../../src/store/conversation-store.js";
+import { SummaryStore } from "../../src/store/summary-store.js";
+import { resolveTargetTokens } from "../../src/summarize.js";
+
+// ── Corpus ─────────────────────────────────────────────────────────────────
+
+export type CorpusMessage = {
+  seq: number;
+  role: "user" | "assistant" | "system";
+  content: string;
+  tokenCount: number;
+  createdAt: string;
+};
+
+export type PlantedFact = { name: string; pattern: string };
+
+export type CorpusSession = {
+  label: string;
+  messages: CorpusMessage[];
+  plantedFacts?: PlantedFact[];
+};
+
+/** Load every `<label>.json` in a directory; each file is a `CorpusMessage[]`. */
+export function loadCorpusDir(dir: string): CorpusSession[] {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith(".json"))
+    .sort()
+    .map((f) => ({
+      label: basename(f, ".json"),
+      messages: JSON.parse(readFileSync(join(dir, f), "utf-8")) as CorpusMessage[],
+    }));
+}
+
+// ── Synthetic session with planted facts ──────────────────────────────────
+
+const PLANTED_FACTS: PlantedFact[] = [
+  { name: "decision-with-rationale", pattern: "ristretto|allocator" },
+  { name: "renamed-file", pattern: "ledger-writer\\.ts" },
+  { name: "open-task", pattern: "backfill|verticality" },
+  { name: "numeric-constraint", pattern: "7331" },
+  { name: "user-correction", pattern: "ULID" },
+];
+
+const FILLER_TOPICS = [
+  "the retry policy for the ingest queue",
+  "the shape of the config loader",
+  "how the daemon reports health",
+  "the CLI help text layout",
+  "the migration ordering rules",
+  "the search index rebuild path",
+  "the log rotation cadence",
+  "the plugin manifest validation",
+];
+
+function fillerTurn(i: number): [string, string] {
+  const topic = FILLER_TOPICS[i % FILLER_TOPICS.length];
+  const user = `Let's look at ${topic}. Walk me through the current behaviour and any edge cases you see, turn ${i}.`;
+  const lines: string[] = [];
+  for (let j = 0; j < 40; j++) {
+    lines.push(
+      `Observation ${i}.${j}: ${topic} handles case ${j} by checking the input, ` +
+        `normalising it, and writing the outcome to the store before returning. ` +
+        `No branch here changes public behaviour; the code path is covered by unit tests.`,
+    );
+  }
+  return [user, lines.join("\n")];
+}
+
+/**
+ * A synthetic session large enough for three leaf chunks plus one depth-1
+ * condensation under production config. The five facts are planted in the
+ * first turns so they sit outside the protected fresh tail and must survive
+ * summarization to appear in the final context.
+ */
+export function buildSyntheticSession(): CorpusSession {
+  const planted: [string, string][] = [
+    [
+      "Which cache library should we use for the summary lookups?",
+      "Decision: use ristretto for the cache. Rationale: the allocator pressure of the LRU alternative was 3x higher in the profile.",
+    ],
+    [
+      "Rename the writer module so its name matches what it does.",
+      "Done. Renamed src/ledger/writer.ts to src/ledger/ledger-writer.ts and updated the three imports.",
+    ],
+    [
+      "What is still open after this?",
+      "Open task: backfill the verticality column for records imported before March. Not started.",
+    ],
+    [
+      "How many rows can one batch carry?",
+      "The numeric constraint is hard: a batch may carry at most 7331 rows, enforced by the schema check.",
+    ],
+    [
+      "You wrote UUID above. That is wrong, we use ULID for record ids.",
+      "Correct, my mistake. Record ids are ULID, not UUID. I updated the note.",
+    ],
+  ];
+
+  const messages: CorpusMessage[] = [];
+  const base = Date.parse("2026-01-01T00:00:00Z");
+  let seq = 0;
+  const push = (role: CorpusMessage["role"], content: string) => {
+    messages.push({
+      seq: seq++,
+      role,
+      content,
+      tokenCount: Math.ceil(content.length / 4),
+      createdAt: new Date(base + seq * 60_000).toISOString(),
+    });
+  };
+
+  for (const [u, a] of planted) {
+    push("user", u);
+    push("assistant", a);
+  }
+  // ~73k tokens of filler: three 20k leaf chunks outside the tail, then one condensation.
+  for (let i = 0; i < 30; i++) {
+    const [u, a] = fillerTurn(i);
+    push("user", u);
+    push("assistant", a);
+  }
+
+  return { label: "synthetic-planted", messages, plantedFacts: PLANTED_FACTS };
+}
+
+// ── Instrumented summarizer ────────────────────────────────────────────────
+
+/** Production usage shape with the provider label widened to bench providers. */
+export type EvalUsage = Omit<SummarizerUsage, "provider"> & { provider: string };
+
+export type SummarizerCall = {
+  pass: "leaf" | "condensed";
+  depth: number;
+  aggressive: boolean;
+  inputChars: number;
+  targetTokens: number;
+  outputChars: number;
+  outputTokensEstimate: number;
+  latencyMs: number;
+  usage?: EvalUsage;
+  /** openai.ts returns the input prefix when the model sends empty content. */
+  emptyContentFallback: boolean;
+  error?: string;
+};
+
+export type InstrumentedSummarizer = { summarize: LcmSummarizeFn; calls: SummarizerCall[] };
+
+/** Wrap a summarizer so every call is recorded with the same target the summarizer computed. */
+export function instrumentSummarizer(inner: LcmSummarizeFn): InstrumentedSummarizer {
+  const calls: SummarizerCall[] = [];
+  const summarize: LcmSummarizeFn = async (text, aggressive, ctx: SummarizeContext = {}) => {
+    const isCondensed = ctx.isCondensed ?? false;
+    const targetTokens =
+      ctx.targetTokens ??
+      resolveTargetTokens({
+        inputTokens: Math.ceil(text.length / 4),
+        mode: aggressive ? "aggressive" : "normal",
+        isCondensed,
+        condensedTargetTokens: 2000,
+      });
+    const call: SummarizerCall = {
+      pass: isCondensed ? "condensed" : "leaf",
+      depth: isCondensed ? (ctx.depth ?? 1) : 0,
+      aggressive: aggressive === true,
+      inputChars: text.length,
+      targetTokens,
+      outputChars: 0,
+      outputTokensEstimate: 0,
+      latencyMs: 0,
+      emptyContentFallback: false,
+    };
+    calls.push(call);
+    const started = Date.now();
+    try {
+      const out = await inner(text, aggressive, {
+        ...ctx,
+        onUsage: (usage) => {
+          call.usage = usage;
+          ctx.onUsage?.(usage);
+        },
+      });
+      call.latencyMs = Date.now() - started;
+      call.outputChars = out.length;
+      call.outputTokensEstimate = Math.ceil(out.length / 4);
+      call.emptyContentFallback = out === text.slice(0, 500);
+      return out;
+    } catch (err) {
+      call.latencyMs = Date.now() - started;
+      call.error = err instanceof Error ? err.message : String(err);
+      throw err;
+    }
+  };
+  return { summarize, calls };
+}
+
+// ── Scoring ────────────────────────────────────────────────────────────────
+
+export type SummaryScore = {
+  depth: number;
+  chars: number;
+  tokensEstimate: number;
+  hasFilesLine: boolean | null;
+  hasExpandTrailer: boolean;
+  isFallback: boolean;
+};
+
+const EXPAND_TRAILER = "Expand for details about:";
+
+/**
+ * Format checks mirror the prompt contracts: leaf prompts require a `Files:`
+ * line, every prompt requires the `Expand for details about:` trailer as the
+ * last line. Leaf `hasFilesLine` is null for condensed summaries.
+ */
+export function scoreSummary(content: string, depth: number): SummaryScore {
+  const trimmed = content.trim();
+  const lastLine = trimmed.split("\n").at(-1) ?? "";
+  return {
+    depth,
+    chars: trimmed.length,
+    tokensEstimate: Math.ceil(trimmed.length / 4),
+    hasFilesLine: depth === 0 ? /^Files:/m.test(trimmed) : null,
+    hasExpandTrailer: lastLine.startsWith(EXPAND_TRAILER),
+    isFallback: /\[Truncated from \d+ tokens\]$/.test(trimmed),
+  };
+}
+
+export function checkPlantedFacts(
+  contextText: string,
+  facts: PlantedFact[],
+): { name: string; survived: boolean }[] {
+  return facts.map((f) => ({ name: f.name, survived: new RegExp(f.pattern, "i").test(contextText) }));
+}
+
+// ── Run ────────────────────────────────────────────────────────────────────
+
+export type EvalRunResult = {
+  label: string;
+  model: string;
+  run: number;
+  startedAt: string;
+  incomplete: boolean;
+  error?: string;
+  inputMessages: number;
+  inputTokens: number;
+  tokensBefore: number;
+  tokensAfter: number;
+  calls: SummarizerCall[];
+  summaries: (SummaryScore & { summaryId: string; content: string })[];
+  plantedFacts?: { name: string; survived: boolean }[];
+  totals: {
+    calls: number;
+    failedCalls: number;
+    latencyMs: number;
+    inputTokens: number;
+    outputTokens: number;
+    costUsd: number;
+    formatPass: number;
+    formatTotal: number;
+  };
+};
+
+/** Exactly the engine config the daemon's /compact route uses. */
+function prodEngineConfig() {
+  return {
+    contextThreshold: 0.75,
+    freshTailCount: 8,
+    leafMinFanout: 3,
+    condensedMinFanout: 2,
+    condensedMinFanoutHard: 1,
+    incrementalMaxDepth: 0,
+    leafTargetTokens: 1000,
+    condensedTargetTokens: 900,
+    maxRounds: 10,
+    // No scrubber: stored messages were scrubbed at ingest, and the corpus
+    // export copies stored content verbatim.
+  };
+}
+
+export async function runEval(input: {
+  session: CorpusSession;
+  summarizer: LcmSummarizeFn;
+  model: string;
+  run: number;
+}): Promise<EvalRunResult> {
+  const { session, model, run } = input;
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db);
+  const conversationStore = new ConversationStore(db);
+  const summaryStore = new SummaryStore(db);
+  const conversation = await conversationStore.createConversation({ sessionId: `eval-${session.label}` });
+  const cid = conversation.conversationId;
+
+  const records = await conversationStore.createMessagesBulk(
+    session.messages.map((m) => ({
+      conversationId: cid,
+      seq: m.seq,
+      role: m.role,
+      content: m.content,
+      tokenCount: m.tokenCount,
+    })),
+  );
+  // Keep original timestamps so the prompt's time headers match production.
+  const setCreated = db.prepare("UPDATE messages SET created_at = ? WHERE message_id = ?");
+  records.forEach((r, i) => setCreated.run(session.messages[i].createdAt, r.messageId));
+  await summaryStore.appendContextMessages(cid, records.map((r) => r.messageId));
+
+  const { summarize, calls } = instrumentSummarizer(input.summarizer);
+  const engine = new CompactionEngine(conversationStore, summaryStore, prodEngineConfig());
+  const tokensBefore = await summaryStore.getContextTokenCount(cid);
+  const startedAt = new Date().toISOString();
+
+  let error: string | undefined;
+  try {
+    await engine.compact({ conversationId: cid, tokenBudget: 200_000, summarize, force: true });
+  } catch (err) {
+    error = err instanceof Error ? err.message : String(err);
+  }
+
+  const items = await summaryStore.getContextItems(cid);
+  const summaries: EvalRunResult["summaries"] = [];
+  for (const item of items) {
+    if (item.itemType !== "summary" || !item.summaryId) continue;
+    const s = await summaryStore.getSummary(item.summaryId);
+    if (s) summaries.push({ summaryId: s.summaryId, content: s.content, ...scoreSummary(s.content, s.depth) });
+  }
+  const tokensAfter = await summaryStore.getContextTokenCount(cid);
+  db.close();
+
+  const contextText = summaries.map((s) => s.content).join("\n\n");
+  const formatPass = summaries.filter((s) => s.hasExpandTrailer && s.hasFilesLine !== false).length;
+
+  return {
+    label: session.label,
+    model,
+    run,
+    startedAt,
+    incomplete: error !== undefined,
+    error,
+    inputMessages: session.messages.length,
+    inputTokens: session.messages.reduce((n, m) => n + m.tokenCount, 0),
+    tokensBefore,
+    tokensAfter,
+    calls,
+    summaries,
+    plantedFacts: session.plantedFacts ? checkPlantedFacts(contextText, session.plantedFacts) : undefined,
+    totals: {
+      calls: calls.length,
+      failedCalls: calls.filter((c) => c.error).length,
+      latencyMs: calls.reduce((n, c) => n + c.latencyMs, 0),
+      inputTokens: calls.reduce((n, c) => n + (c.usage?.inputTokens ?? 0), 0),
+      outputTokens: calls.reduce((n, c) => n + (c.usage?.outputTokens ?? 0), 0),
+      costUsd: calls.reduce((n, c) => n + (c.usage?.costUsd ?? 0), 0),
+      formatPass,
+      formatTotal: summaries.length,
+    },
+  };
+}
+
+export function writeResult(dir: string, result: EvalRunResult): string {
+  mkdirSync(dir, { recursive: true });
+  const safeModel = result.model.replace(/[^a-z0-9.-]+/gi, "_");
+  const file = join(dir, `${safeModel}__${result.label}__run${result.run}.json`);
+  writeFileSync(file, JSON.stringify(result, null, 2));
+  return file;
+}

--- a/test/bench/summarizer-eval-harness.ts
+++ b/test/bench/summarizer-eval-harness.ts
@@ -287,7 +287,14 @@ export type EvalRunResult = {
 };
 
 
-/** Exactly the engine config the daemon's /compact route uses. */
+/**
+ * The daemon's /compact engine config, with two deliberate deviations:
+ *  - leafTargetTokens is the hardcoded default (1000) rather than the live
+ *    `config.compaction.leafTokens`, so a bench run is reproducible across
+ *    machines regardless of the operator's local config.json.
+ *  - no scrubber: stored messages were scrubbed at ingest, and the corpus
+ *    export copies stored content verbatim, so there is nothing left to scrub.
+ */
 function prodEngineConfig() {
   return {
     contextThreshold: 0.75,
@@ -299,8 +306,6 @@ function prodEngineConfig() {
     leafTargetTokens: 1000,
     condensedTargetTokens: 900,
     maxRounds: 10,
-    // No scrubber: stored messages were scrubbed at ingest, and the corpus
-    // export copies stored content verbatim.
   };
 }
 

--- a/test/bench/summarizer-eval-harness.ts
+++ b/test/bench/summarizer-eval-harness.ts
@@ -19,6 +19,9 @@ import { resolveTargetTokens } from "../../src/summarize.js";
 
 // ── Corpus ─────────────────────────────────────────────────────────────────
 
+/** Same estimate production uses for prompt sizing. */
+const CHARS_PER_TOKEN = 4;
+
 export type CorpusMessage = {
   seq: number;
   role: "user" | "assistant" | "system";
@@ -82,10 +85,11 @@ function fillerTurn(i: number): [string, string] {
 }
 
 /**
- * A synthetic session large enough for three leaf chunks plus one depth-1
- * condensation under production config. The five facts are planted in the
- * first turns so they sit outside the protected fresh tail and must survive
- * summarization to appear in the final context.
+ * A synthetic session large enough for three leaf chunks under production
+ * config; a depth-1 condensation follows only when the leaf summaries are
+ * verbose enough to reach the condensed minimum. The five facts are planted in
+ * the first turns so they sit outside the protected fresh tail and must
+ * survive summarization to appear in the final context.
  */
 export function buildSyntheticSession(): CorpusSession {
   const planted: [string, string][] = [
@@ -119,7 +123,7 @@ export function buildSyntheticSession(): CorpusSession {
       seq: seq++,
       role,
       content,
-      tokenCount: Math.ceil(content.length / 4),
+      tokenCount: Math.ceil(content.length / CHARS_PER_TOKEN),
       createdAt: new Date(base + seq * 60_000).toISOString(),
     });
   };
@@ -171,7 +175,7 @@ export function instrumentSummarizer(inner: LcmSummarizeFn): InstrumentedSummari
     const targetTokens =
       ctx.targetTokens ??
       resolveTargetTokens({
-        inputTokens: Math.ceil(text.length / 4),
+        inputTokens: Math.ceil(text.length / CHARS_PER_TOKEN),
         mode: aggressive ? "aggressive" : "normal",
         isCondensed,
         condensedTargetTokens: 2000,
@@ -199,7 +203,7 @@ export function instrumentSummarizer(inner: LcmSummarizeFn): InstrumentedSummari
       });
       call.latencyMs = Date.now() - started;
       call.outputChars = out.length;
-      call.outputTokensEstimate = Math.ceil(out.length / 4);
+      call.outputTokensEstimate = Math.ceil(out.length / CHARS_PER_TOKEN);
       call.output = out;
       call.format = scoreSummary(out, call.depth);
       call.emptyContentFallback = out === text.slice(0, 500);
@@ -237,7 +241,7 @@ export function scoreSummary(content: string, depth: number): SummaryScore {
   return {
     depth,
     chars: trimmed.length,
-    tokensEstimate: Math.ceil(trimmed.length / 4),
+    tokensEstimate: Math.ceil(trimmed.length / CHARS_PER_TOKEN),
     hasFilesLine: depth === 0 ? /^Files:/m.test(trimmed) : null,
     hasExpandTrailer: lastLine.startsWith(EXPAND_TRAILER),
     isFallback: /\[Truncated from \d+ tokens\]$/.test(trimmed),
@@ -345,8 +349,10 @@ export async function runEval(input: {
   const summaries: EvalRunResult["summaries"] = [];
   for (const item of items) {
     if (item.itemType !== "summary" || !item.summaryId) continue;
-    const s = await summaryStore.getSummary(item.summaryId);
-    if (s) summaries.push({ summaryId: s.summaryId, content: s.content, ...scoreSummary(s.content, s.depth) });
+    const record = await summaryStore.getSummary(item.summaryId);
+    if (record) {
+      summaries.push({ summaryId: record.summaryId, content: record.content, ...scoreSummary(record.content, record.depth) });
+    }
   }
   const tokensAfter = await summaryStore.getContextTokenCount(cid);
   db.close();

--- a/test/bench/summarizer-eval-providers.ts
+++ b/test/bench/summarizer-eval-providers.ts
@@ -19,14 +19,18 @@ function createHttpSummarizer(label: string, baseURL: string, apiKey: string, mo
   // explicit bench knob (LCM_EVAL_REASONING_EFFORT, e.g. "minimal"), not a
   // prod mirror.
   const reasoningEffort = process.env.LCM_EVAL_REASONING_EFFORT;
+  // Qwen-style servers (vLLM, MLX) take enable_thinking through chat_template_kwargs.
+  const disableThinking = process.env.LCM_EVAL_DISABLE_THINKING === "1";
 
   let pendingCtx: SummarizeContext | undefined;
   const capturing = {
     chat: {
       completions: {
         create: async (params: Parameters<typeof client.chat.completions.create>[0]) => {
-          const reasoning = reasoningEffort ? { reasoning: { effort: reasoningEffort } } : {};
-          const response = await client.chat.completions.create({ ...params, ...reasoning, stream: false });
+          const extra: Record<string, unknown> = {};
+          if (reasoningEffort) extra.reasoning = { effort: reasoningEffort };
+          if (disableThinking) extra.chat_template_kwargs = { enable_thinking: false };
+          const response = await client.chat.completions.create({ ...params, ...extra, stream: false });
           const usage = response.usage;
           if (usage && pendingCtx?.onUsage) {
             const cached = (usage.prompt_tokens_details as { cached_tokens?: number } | undefined)?.cached_tokens;

--- a/test/bench/summarizer-eval-providers.ts
+++ b/test/bench/summarizer-eval-providers.ts
@@ -16,9 +16,14 @@ function createHttpSummarizer(label: string, baseURL: string, apiKey: string, mo
   const client = new OpenAI({ baseURL, apiKey });
   // Reasoning models spend the whole max_tokens budget thinking and return
   // empty content; production sends no reasoning parameter, so this is an
-  // explicit bench knob (LCM_EVAL_REASONING_EFFORT, e.g. "minimal"), not a
-  // prod mirror.
-  const reasoningEffort = process.env.LCM_EVAL_REASONING_EFFORT;
+  // explicit bench knob, not a prod mirror. LCM_EVAL_REASONING is the JSON
+  // object sent as `reasoning` (e.g. {"effort":"minimal"} or {"enabled":false});
+  // LCM_EVAL_REASONING_EFFORT is the shorthand for the effort form.
+  const reasoning: Record<string, unknown> | undefined = process.env.LCM_EVAL_REASONING
+    ? (JSON.parse(process.env.LCM_EVAL_REASONING) as Record<string, unknown>)
+    : process.env.LCM_EVAL_REASONING_EFFORT
+      ? { effort: process.env.LCM_EVAL_REASONING_EFFORT }
+      : undefined;
   // Qwen-style servers (vLLM, MLX) take enable_thinking through chat_template_kwargs.
   const disableThinking = process.env.LCM_EVAL_DISABLE_THINKING === "1";
 
@@ -28,7 +33,7 @@ function createHttpSummarizer(label: string, baseURL: string, apiKey: string, mo
       completions: {
         create: async (params: Parameters<typeof client.chat.completions.create>[0]) => {
           const extra: Record<string, unknown> = {};
-          if (reasoningEffort) extra.reasoning = { effort: reasoningEffort };
+          if (reasoning) extra.reasoning = reasoning;
           if (disableThinking) extra.chat_template_kwargs = { enable_thinking: false };
           const response = await client.chat.completions.create({ ...params, ...extra, stream: false });
           const usage = response.usage;

--- a/test/bench/summarizer-eval-providers.ts
+++ b/test/bench/summarizer-eval-providers.ts
@@ -33,6 +33,8 @@ function createHttpSummarizer(label: string, baseURL: string, apiKey: string, mo
       completions: {
         create: async (params: Parameters<typeof client.chat.completions.create>[0]) => {
           const extra: Record<string, unknown> = {};
+          // OpenRouter only returns usage.cost when accounting is requested.
+          if (baseURL === OPENROUTER_BASE_URL) extra.usage = { include: true };
           if (reasoning) extra.reasoning = reasoning;
           if (disableThinking) extra.chat_template_kwargs = { enable_thinking: false };
           const response = await client.chat.completions.create({ ...params, ...extra, stream: false });
@@ -48,6 +50,11 @@ function createHttpSummarizer(label: string, baseURL: string, apiKey: string, mo
               cachedInputTokens: cached,
               outputTokens: usage.completion_tokens,
               tokensUsed: usage.total_tokens ?? usage.prompt_tokens + usage.completion_tokens,
+              // OpenRouter reports the real charged cost here; plain OpenAI-compatible
+              // servers report nothing, and the bench must say "unknown", not 0.
+              costUsd: typeof (usage as { cost?: unknown }).cost === "number"
+                ? (usage as { cost: number }).cost
+                : undefined,
             } as unknown as SummarizerUsage);
           }
           return response;

--- a/test/bench/summarizer-eval-providers.ts
+++ b/test/bench/summarizer-eval-providers.ts
@@ -3,19 +3,17 @@ import { createClaudeProcessSummarizer } from "../../src/llm/claude-process.js";
 import { createOpenAISummarizer } from "../../src/llm/openai.js";
 import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "../../src/llm/types.js";
 
-export type EvalProvider = "openrouter" | "claude-process";
+export type EvalProvider = "openrouter" | "openai" | "claude-process";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
 /**
- * The production OpenAI-compatible summarizer, pointed at OpenRouter, with the
+ * The production OpenAI-compatible summarizer against any endpoint, with the
  * response usage captured through the client override so the bench can report
  * tokens without changing production code.
  */
-function createOpenRouterSummarizer(model: string): LcmSummarizeFn {
-  const apiKey = process.env.OPENROUTER_API_KEY;
-  if (!apiKey) throw new Error("OPENROUTER_API_KEY is not set");
-  const client = new OpenAI({ baseURL: OPENROUTER_BASE_URL, apiKey });
+function createHttpSummarizer(label: string, baseURL: string, apiKey: string, model: string): LcmSummarizeFn {
+  const client = new OpenAI({ baseURL, apiKey });
   // Reasoning models spend the whole max_tokens budget thinking and return
   // empty content; production sends no reasoning parameter, so this is an
   // explicit bench knob (LCM_EVAL_REASONING_EFFORT, e.g. "minimal"), not a
@@ -35,7 +33,7 @@ function createOpenRouterSummarizer(model: string): LcmSummarizeFn {
             // Provider label is wider than the production union; the bench
             // only reads the numbers and the model.
             pendingCtx.onUsage({
-              provider: "openrouter",
+              provider: label,
               model: response.model ?? model,
               inputTokens: usage.prompt_tokens,
               cachedInputTokens: cached,
@@ -49,7 +47,7 @@ function createOpenRouterSummarizer(model: string): LcmSummarizeFn {
     },
   };
 
-  const inner = createOpenAISummarizer({ model, baseURL: OPENROUTER_BASE_URL, apiKey, _clientOverride: capturing });
+  const inner = createOpenAISummarizer({ model, baseURL, apiKey, _clientOverride: capturing });
   return async (text, aggressive, ctx = {}) => {
     pendingCtx = ctx;
     try {
@@ -60,7 +58,17 @@ function createOpenRouterSummarizer(model: string): LcmSummarizeFn {
   };
 }
 
+function requireEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is not set`);
+  return value;
+}
+
 export function createEvalSummarizer(provider: EvalProvider, model: string): LcmSummarizeFn {
   if (provider === "claude-process") return createClaudeProcessSummarizer({ model });
-  return createOpenRouterSummarizer(model);
+  if (provider === "openai") {
+    // Any OpenAI-compatible server, e.g. a local MLX box: LCM_EVAL_BASE_URL + LCM_EVAL_API_KEY.
+    return createHttpSummarizer("openai", requireEnv("LCM_EVAL_BASE_URL"), process.env.LCM_EVAL_API_KEY ?? "local", model);
+  }
+  return createHttpSummarizer("openrouter", OPENROUTER_BASE_URL, requireEnv("OPENROUTER_API_KEY"), model);
 }

--- a/test/bench/summarizer-eval-providers.ts
+++ b/test/bench/summarizer-eval-providers.ts
@@ -1,0 +1,60 @@
+import OpenAI from "openai";
+import { createClaudeProcessSummarizer } from "../../src/llm/claude-process.js";
+import { createOpenAISummarizer } from "../../src/llm/openai.js";
+import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "../../src/llm/types.js";
+
+export type EvalProvider = "openrouter" | "claude-process";
+
+const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+/**
+ * The production OpenAI-compatible summarizer, pointed at OpenRouter, with the
+ * response usage captured through the client override so the bench can report
+ * tokens without changing production code.
+ */
+function createOpenRouterSummarizer(model: string): LcmSummarizeFn {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) throw new Error("OPENROUTER_API_KEY is not set");
+  const client = new OpenAI({ baseURL: OPENROUTER_BASE_URL, apiKey });
+
+  let pendingCtx: SummarizeContext | undefined;
+  const capturing = {
+    chat: {
+      completions: {
+        create: async (params: Parameters<typeof client.chat.completions.create>[0]) => {
+          const response = await client.chat.completions.create({ ...params, stream: false });
+          const usage = response.usage;
+          if (usage && pendingCtx?.onUsage) {
+            const cached = (usage.prompt_tokens_details as { cached_tokens?: number } | undefined)?.cached_tokens;
+            // Provider label is wider than the production union; the bench
+            // only reads the numbers and the model.
+            pendingCtx.onUsage({
+              provider: "openrouter",
+              model: response.model ?? model,
+              inputTokens: usage.prompt_tokens,
+              cachedInputTokens: cached,
+              outputTokens: usage.completion_tokens,
+              tokensUsed: usage.total_tokens ?? usage.prompt_tokens + usage.completion_tokens,
+            } as unknown as SummarizerUsage);
+          }
+          return response;
+        },
+      },
+    },
+  };
+
+  const inner = createOpenAISummarizer({ model, baseURL: OPENROUTER_BASE_URL, apiKey, _clientOverride: capturing });
+  return async (text, aggressive, ctx = {}) => {
+    pendingCtx = ctx;
+    try {
+      return await inner(text, aggressive, ctx);
+    } finally {
+      pendingCtx = undefined;
+    }
+  };
+}
+
+export function createEvalSummarizer(provider: EvalProvider, model: string): LcmSummarizeFn {
+  if (provider === "claude-process") return createClaudeProcessSummarizer({ model });
+  return createOpenRouterSummarizer(model);
+}

--- a/test/bench/summarizer-eval-providers.ts
+++ b/test/bench/summarizer-eval-providers.ts
@@ -16,13 +16,19 @@ function createOpenRouterSummarizer(model: string): LcmSummarizeFn {
   const apiKey = process.env.OPENROUTER_API_KEY;
   if (!apiKey) throw new Error("OPENROUTER_API_KEY is not set");
   const client = new OpenAI({ baseURL: OPENROUTER_BASE_URL, apiKey });
+  // Reasoning models spend the whole max_tokens budget thinking and return
+  // empty content; production sends no reasoning parameter, so this is an
+  // explicit bench knob (LCM_EVAL_REASONING_EFFORT, e.g. "minimal"), not a
+  // prod mirror.
+  const reasoningEffort = process.env.LCM_EVAL_REASONING_EFFORT;
 
   let pendingCtx: SummarizeContext | undefined;
   const capturing = {
     chat: {
       completions: {
         create: async (params: Parameters<typeof client.chat.completions.create>[0]) => {
-          const response = await client.chat.completions.create({ ...params, stream: false });
+          const reasoning = reasoningEffort ? { reasoning: { effort: reasoningEffort } } : {};
+          const response = await client.chat.completions.create({ ...params, ...reasoning, stream: false });
           const usage = response.usage;
           if (usage && pendingCtx?.onUsage) {
             const cached = (usage.prompt_tokens_details as { cached_tokens?: number } | undefined)?.cached_tokens;

--- a/test/bench/summarizer-eval.test.ts
+++ b/test/bench/summarizer-eval.test.ts
@@ -64,7 +64,8 @@ describe("summarizer eval harness (offline)", () => {
 //   LCM_EVAL_BASE_URL    openai only: OpenAI-compatible endpoint; LCM_EVAL_API_KEY optional
 //   LCM_EVAL_RUNS        runs per session (default 1)
 //   LCM_EVAL_SESSIONS    comma-separated labels to run (default all)
-//   LCM_EVAL_REASONING_EFFORT  openrouter only: reasoning.effort sent with each request (default none)
+//   LCM_EVAL_REASONING_EFFORT  http providers: reasoning.effort sent with each request (default none)
+//   LCM_EVAL_DISABLE_THINKING  http providers: "1" sends chat_template_kwargs.enable_thinking=false (Qwen-style servers)
 
 const model = process.env.LCM_EVAL_MODEL;
 const corpusDir = process.env.LCM_EVAL_CORPUS_DIR;
@@ -72,7 +73,9 @@ const provider = (process.env.LCM_EVAL_PROVIDER ?? "openrouter") as EvalProvider
 const runs = Number(process.env.LCM_EVAL_RUNS ?? "1");
 const only = process.env.LCM_EVAL_SESSIONS?.split(",").map((s) => s.trim()).filter(Boolean);
 
-const reasoning = process.env.LCM_EVAL_REASONING_EFFORT ? ` reasoning=${process.env.LCM_EVAL_REASONING_EFFORT}` : "";
+const reasoning =
+  (process.env.LCM_EVAL_REASONING_EFFORT ? ` reasoning=${process.env.LCM_EVAL_REASONING_EFFORT}` : "") +
+  (process.env.LCM_EVAL_DISABLE_THINKING === "1" ? " thinking=off" : "");
 
 describe.skipIf(!model || !corpusDir)(`summarizer eval: ${model} via ${provider}${reasoning}`, () => {
   const sessions: CorpusSession[] = (corpusDir && existsSync(corpusDir)

--- a/test/bench/summarizer-eval.test.ts
+++ b/test/bench/summarizer-eval.test.ts
@@ -63,6 +63,7 @@ describe("summarizer eval harness (offline)", () => {
 //   LCM_EVAL_PROVIDER    openrouter (default) | claude-process
 //   LCM_EVAL_RUNS        runs per session (default 1)
 //   LCM_EVAL_SESSIONS    comma-separated labels to run (default all)
+//   LCM_EVAL_REASONING_EFFORT  openrouter only: reasoning.effort sent with each request (default none)
 
 const model = process.env.LCM_EVAL_MODEL;
 const corpusDir = process.env.LCM_EVAL_CORPUS_DIR;
@@ -70,7 +71,9 @@ const provider = (process.env.LCM_EVAL_PROVIDER ?? "openrouter") as EvalProvider
 const runs = Number(process.env.LCM_EVAL_RUNS ?? "1");
 const only = process.env.LCM_EVAL_SESSIONS?.split(",").map((s) => s.trim()).filter(Boolean);
 
-describe.skipIf(!model || !corpusDir)(`summarizer eval: ${model} via ${provider}`, () => {
+const reasoning = process.env.LCM_EVAL_REASONING_EFFORT ? ` reasoning=${process.env.LCM_EVAL_REASONING_EFFORT}` : "";
+
+describe.skipIf(!model || !corpusDir)(`summarizer eval: ${model} via ${provider}${reasoning}`, () => {
   const sessions: CorpusSession[] = (corpusDir && existsSync(corpusDir)
     ? [...loadCorpusDir(corpusDir), buildSyntheticSession()]
     : []

--- a/test/bench/summarizer-eval.test.ts
+++ b/test/bench/summarizer-eval.test.ts
@@ -1,0 +1,102 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import type { LcmSummarizeFn } from "../../src/llm/types.js";
+import {
+  buildSyntheticSession,
+  loadCorpusDir,
+  runEval,
+  scoreSummary,
+  writeResult,
+  type CorpusSession,
+} from "./summarizer-eval-harness.js";
+import { createEvalSummarizer, type EvalProvider } from "./summarizer-eval-providers.js";
+
+const RESULTS_DIR = join(import.meta.dirname, "results");
+
+/** Offline stand-in that obeys the prompt contract and echoes the input head. */
+const fakeSummarizer: LcmSummarizeFn = async (text, _aggressive, ctx = {}) => {
+  const head = text.replace(/\[[^\]]*\]\n/g, "").slice(0, 2400);
+  const files = ctx.isCondensed ? "" : "Files: none\n";
+  return `${files}${head}\nExpand for details about: filler observations`;
+};
+
+describe("summarizer eval harness (offline)", () => {
+  it("runs leaf and depth-1 passes under production config and scores them", async () => {
+    const session = buildSyntheticSession();
+    const result = await runEval({ session, summarizer: fakeSummarizer, model: "fake", run: 1 });
+
+    expect(result.incomplete).toBe(false);
+    expect(result.calls.filter((c) => c.pass === "leaf").length).toBeGreaterThanOrEqual(3);
+    expect(result.calls.filter((c) => c.pass === "condensed" && c.depth === 1).length).toBeGreaterThanOrEqual(1);
+    expect(result.summaries.some((s) => s.depth === 1)).toBe(true);
+    expect(result.totals.formatPass).toBe(result.totals.formatTotal);
+    expect(result.plantedFacts?.map((f) => f.name)).toHaveLength(5);
+    expect(result.tokensAfter).toBeLessThan(result.tokensBefore);
+  }, 30_000);
+
+  it("scores format per pass type", () => {
+    const leaf = scoreSummary("Did things.\nFiles: none\nExpand for details about: x", 0);
+    expect(leaf).toMatchObject({ hasFilesLine: true, hasExpandTrailer: true, isFallback: false });
+    const condensed = scoreSummary("Did things.\nExpand for details about: x", 1);
+    expect(condensed).toMatchObject({ hasFilesLine: null, hasExpandTrailer: true });
+    expect(scoreSummary("Did things.", 0)).toMatchObject({ hasFilesLine: false, hasExpandTrailer: false });
+    expect(scoreSummary("raw text\n[Truncated from 900 tokens]", 0).isFallback).toBe(true);
+  });
+
+  it("marks a run incomplete when the summarizer keeps failing", async () => {
+    const failing: LcmSummarizeFn = async () => {
+      throw new Error("429 rate limited");
+    };
+    const result = await runEval({ session: buildSyntheticSession(), summarizer: failing, model: "fake", run: 1 });
+    expect(result.incomplete).toBe(true);
+    expect(result.error).toContain("429");
+    expect(result.totals.failedCalls).toBe(1);
+  }, 30_000);
+});
+
+// ── Live eval, gated by env ────────────────────────────────────────────────
+//
+//   LCM_EVAL_MODEL       candidate model id (required)
+//   LCM_EVAL_CORPUS_DIR  directory of <label>.json exports (required)
+//   LCM_EVAL_PROVIDER    openrouter (default) | claude-process
+//   LCM_EVAL_RUNS        runs per session (default 1)
+//   LCM_EVAL_SESSIONS    comma-separated labels to run (default all)
+
+const model = process.env.LCM_EVAL_MODEL;
+const corpusDir = process.env.LCM_EVAL_CORPUS_DIR;
+const provider = (process.env.LCM_EVAL_PROVIDER ?? "openrouter") as EvalProvider;
+const runs = Number(process.env.LCM_EVAL_RUNS ?? "1");
+const only = process.env.LCM_EVAL_SESSIONS?.split(",").map((s) => s.trim()).filter(Boolean);
+
+describe.skipIf(!model || !corpusDir)(`summarizer eval: ${model} via ${provider}`, () => {
+  const sessions: CorpusSession[] = (corpusDir && existsSync(corpusDir)
+    ? [...loadCorpusDir(corpusDir), buildSyntheticSession()]
+    : []
+  ).filter((s) => !only || only.includes(s.label));
+
+  it("has a corpus to run", () => {
+    expect(sessions.length).toBeGreaterThan(0);
+  });
+
+  for (const session of sessions) {
+    for (let run = 1; run <= runs; run++) {
+      it(`${session.label} run ${run}`, async () => {
+        const summarizer = createEvalSummarizer(provider, model!);
+        const result = await runEval({ session, summarizer, model: model!, run });
+        const file = writeResult(RESULTS_DIR, result);
+        const facts = result.plantedFacts
+          ? ` facts=${result.plantedFacts.filter((f) => f.survived).length}/${result.plantedFacts.length}`
+          : "";
+        console.log(
+          `${session.label} run ${run}: calls=${result.totals.calls} failed=${result.totals.failedCalls}` +
+            ` format=${result.totals.formatPass}/${result.totals.formatTotal}` +
+            ` tokens=${result.tokensBefore}->${result.tokensAfter} latency=${result.totals.latencyMs}ms` +
+            `${facts}${result.incomplete ? " INCOMPLETE" : ""} -> ${file}`,
+        );
+        // A 429 after retries is recorded as partial, not a test failure.
+        expect(result.summaries.length).toBeGreaterThan(0);
+      }, 0);
+    }
+  }
+});

--- a/test/bench/summarizer-eval.test.ts
+++ b/test/bench/summarizer-eval.test.ts
@@ -60,7 +60,8 @@ describe("summarizer eval harness (offline)", () => {
 //
 //   LCM_EVAL_MODEL       candidate model id (required)
 //   LCM_EVAL_CORPUS_DIR  directory of <label>.json exports (required)
-//   LCM_EVAL_PROVIDER    openrouter (default) | claude-process
+//   LCM_EVAL_PROVIDER    openrouter (default) | openai | claude-process
+//   LCM_EVAL_BASE_URL    openai only: OpenAI-compatible endpoint; LCM_EVAL_API_KEY optional
 //   LCM_EVAL_RUNS        runs per session (default 1)
 //   LCM_EVAL_SESSIONS    comma-separated labels to run (default all)
 //   LCM_EVAL_REASONING_EFFORT  openrouter only: reasoning.effort sent with each request (default none)

--- a/test/bench/summarizer-eval.test.ts
+++ b/test/bench/summarizer-eval.test.ts
@@ -64,7 +64,8 @@ describe("summarizer eval harness (offline)", () => {
 //   LCM_EVAL_BASE_URL    openai only: OpenAI-compatible endpoint; LCM_EVAL_API_KEY optional
 //   LCM_EVAL_RUNS        runs per session (default 1)
 //   LCM_EVAL_SESSIONS    comma-separated labels to run (default all)
-//   LCM_EVAL_REASONING_EFFORT  http providers: reasoning.effort sent with each request (default none)
+//   LCM_EVAL_REASONING         http providers: JSON sent as `reasoning`, e.g. {"enabled":false} (default none)
+//   LCM_EVAL_REASONING_EFFORT  shorthand for LCM_EVAL_REASONING={"effort":"<value>"}
 //   LCM_EVAL_DISABLE_THINKING  http providers: "1" sends chat_template_kwargs.enable_thinking=false (Qwen-style servers)
 
 const model = process.env.LCM_EVAL_MODEL;
@@ -74,6 +75,7 @@ const runs = Number(process.env.LCM_EVAL_RUNS ?? "1");
 const only = process.env.LCM_EVAL_SESSIONS?.split(",").map((s) => s.trim()).filter(Boolean);
 
 const reasoning =
+  (process.env.LCM_EVAL_REASONING ? ` reasoning=${process.env.LCM_EVAL_REASONING}` : "") +
   (process.env.LCM_EVAL_REASONING_EFFORT ? ` reasoning=${process.env.LCM_EVAL_REASONING_EFFORT}` : "") +
   (process.env.LCM_EVAL_DISABLE_THINKING === "1" ? " thinking=off" : "");
 

--- a/test/bench/summarizer-eval.test.ts
+++ b/test/bench/summarizer-eval.test.ts
@@ -24,7 +24,7 @@ const fakeSummarizer: LcmSummarizeFn = async (text, _aggressive, ctx = {}) => {
 describe("summarizer eval harness (offline)", () => {
   it("runs leaf and depth-1 passes under production config and scores them", async () => {
     const session = buildSyntheticSession();
-    const result = await runEval({ session, summarizer: fakeSummarizer, model: "fake", run: 1 });
+    const result = await runEval({ session, summarizer: fakeSummarizer, model: "fake", provider: "fake", run: 1 });
 
     expect(result.incomplete).toBe(false);
     expect(result.calls.filter((c) => c.pass === "leaf").length).toBeGreaterThanOrEqual(3);
@@ -45,11 +45,21 @@ describe("summarizer eval harness (offline)", () => {
     expect(scoreSummary("raw text\n[Truncated from 900 tokens]", 0).isFallback).toBe(true);
   });
 
+  it("detects the production empty-content fallback", async () => {
+    // openai.ts returns text.slice(0, 500) when the model sends empty content.
+    const echoing: LcmSummarizeFn = async (text) => text.slice(0, 500);
+    const result = await runEval({
+      session: buildSyntheticSession(), summarizer: echoing, model: "fake", provider: "fake", run: 1,
+    });
+    expect(result.calls.length).toBeGreaterThan(0);
+    expect(result.calls.every((c) => c.emptyContentFallback)).toBe(true);
+  }, 30_000);
+
   it("marks a run incomplete when the summarizer keeps failing", async () => {
     const failing: LcmSummarizeFn = async () => {
       throw new Error("429 rate limited");
     };
-    const result = await runEval({ session: buildSyntheticSession(), summarizer: failing, model: "fake", run: 1 });
+    const result = await runEval({ session: buildSyntheticSession(), summarizer: failing, model: "fake", provider: "fake", run: 1 });
     expect(result.incomplete).toBe(true);
     expect(result.error).toContain("429");
     expect(result.totals.failedCalls).toBe(1);
@@ -96,8 +106,14 @@ const reasoning =
   (process.env.LCM_EVAL_REASONING_EFFORT ? ` reasoning=${process.env.LCM_EVAL_REASONING_EFFORT}` : "") +
   (process.env.LCM_EVAL_DISABLE_THINKING === "1" ? " thinking=off" : "");
 
+/** The reasoning/thinking knobs, as a filename-safe run identity. */
+const variant = reasoning.trim().replace(/\s+/g, "_") || undefined;
+
 describe.skipIf(!model || !corpusDir)(`summarizer eval: ${model} via ${provider}${reasoning}`, () => {
-  const sessions: CorpusSession[] = (corpusDir && existsSync(corpusDir)
+  if (corpusDir && !existsSync(corpusDir)) {
+    throw new Error(`LCM_EVAL_CORPUS_DIR does not exist: ${corpusDir}`);
+  }
+  const sessions: CorpusSession[] = (corpusDir
     ? [...loadCorpusDir(corpusDir), buildSyntheticSession()]
     : []
   ).filter((s) => !only || only.includes(s.label));
@@ -110,7 +126,7 @@ describe.skipIf(!model || !corpusDir)(`summarizer eval: ${model} via ${provider}
     for (let run = 1; run <= runs; run++) {
       it(`${session.label} run ${run}`, async () => {
         const summarizer = createEvalSummarizer(provider, model!);
-        const result = await runEval({ session, summarizer, model: model!, run });
+        const result = await runEval({ session, summarizer, model: model!, provider, variant, run });
         const file = writeResult(RESULTS_DIR, result);
         const facts = result.plantedFacts
           ? ` facts=${result.plantedFacts.filter((f) => f.survived).length}/${result.plantedFacts.length}`

--- a/test/bench/summarizer-eval.test.ts
+++ b/test/bench/summarizer-eval.test.ts
@@ -90,7 +90,7 @@ describe.skipIf(!model || !corpusDir)(`summarizer eval: ${model} via ${provider}
           : "";
         console.log(
           `${session.label} run ${run}: calls=${result.totals.calls} failed=${result.totals.failedCalls}` +
-            ` format=${result.totals.formatPass}/${result.totals.formatTotal}` +
+            ` format=${result.totals.formatPass}/${result.totals.formatTotal} maxTokensHits=${result.totals.maxTokensHits}` +
             ` tokens=${result.tokensBefore}->${result.tokensAfter} latency=${result.totals.latencyMs}ms` +
             `${facts}${result.incomplete ? " INCOMPLETE" : ""} -> ${file}`,
         );

--- a/test/bench/summarizer-eval.test.ts
+++ b/test/bench/summarizer-eval.test.ts
@@ -68,10 +68,27 @@ describe("summarizer eval harness (offline)", () => {
 //   LCM_EVAL_REASONING_EFFORT  shorthand for LCM_EVAL_REASONING={"effort":"<value>"}
 //   LCM_EVAL_DISABLE_THINKING  http providers: "1" sends chat_template_kwargs.enable_thinking=false (Qwen-style servers)
 
+const EVAL_PROVIDERS: readonly EvalProvider[] = ["openrouter", "openai", "claude-process"];
+
+function parseProvider(value: string | undefined): EvalProvider {
+  if (value === undefined) return "openrouter";
+  if ((EVAL_PROVIDERS as readonly string[]).includes(value)) return value as EvalProvider;
+  throw new Error(`LCM_EVAL_PROVIDER must be one of ${EVAL_PROVIDERS.join(", ")}, got: ${value}`);
+}
+
+function parseRuns(value: string | undefined): number {
+  if (value === undefined) return 1;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 1) {
+    throw new Error(`LCM_EVAL_RUNS must be a positive integer, got: ${value}`);
+  }
+  return n;
+}
+
 const model = process.env.LCM_EVAL_MODEL;
 const corpusDir = process.env.LCM_EVAL_CORPUS_DIR;
-const provider = (process.env.LCM_EVAL_PROVIDER ?? "openrouter") as EvalProvider;
-const runs = Number(process.env.LCM_EVAL_RUNS ?? "1");
+const provider = parseProvider(process.env.LCM_EVAL_PROVIDER);
+const runs = parseRuns(process.env.LCM_EVAL_RUNS);
 const only = process.env.LCM_EVAL_SESSIONS?.split(",").map((s) => s.trim()).filter(Boolean);
 
 const reasoning =

--- a/test/bench/summarizer-eval.test.ts
+++ b/test/bench/summarizer-eval.test.ts
@@ -30,6 +30,7 @@ describe("summarizer eval harness (offline)", () => {
     expect(result.calls.filter((c) => c.pass === "leaf").length).toBeGreaterThanOrEqual(3);
     expect(result.calls.filter((c) => c.pass === "condensed" && c.depth === 1).length).toBeGreaterThanOrEqual(1);
     expect(result.summaries.some((s) => s.depth === 1)).toBe(true);
+    expect(result.totals.formatTotal).toBe(result.calls.length);
     expect(result.totals.formatPass).toBe(result.totals.formatTotal);
     expect(result.plantedFacts?.map((f) => f.name)).toHaveLength(5);
     expect(result.tokensAfter).toBeLessThan(result.tokensBefore);
@@ -94,8 +95,8 @@ describe.skipIf(!model || !corpusDir)(`summarizer eval: ${model} via ${provider}
             ` tokens=${result.tokensBefore}->${result.tokensAfter} latency=${result.totals.latencyMs}ms` +
             `${facts}${result.incomplete ? " INCOMPLETE" : ""} -> ${file}`,
         );
-        // A 429 after retries is recorded as partial, not a test failure.
-        expect(result.summaries.length).toBeGreaterThan(0);
+        // A failed or partial run is recorded, not asserted: the JSON is the deliverable.
+        expect(existsSync(file)).toBe(true);
       }, 0);
     }
   }


### PR DESCRIPTION
## Changes
- New vitest bench that runs the real `CompactionEngine` with the production `/compact` configuration against a session loaded into in-memory SQLite (real stores, real migrations), records every summarizer call, and scores it: `Files:` line and `Expand for details about:` trailer per prompt contract, output-cap hits, empty-content echo, latency, tokens, cost, and planted-fact survival on a synthetic session.
- Providers: OpenRouter and any OpenAI-compatible endpoint through the production `createOpenAISummarizer` (usage captured via `_clientOverride`, no production change), and `createClaudeProcessSummarizer` for subscription baselines.
- Bench-only knobs for reasoning models: `LCM_EVAL_REASONING` (JSON `reasoning` object), `LCM_EVAL_REASONING_EFFORT`, `LCM_EVAL_DISABLE_THINKING`. Production sends none of these; the bench measures what a model does with them so that decision can be made with data.
- Offline tests run in CI with a fake summarizer (leaf and depth-1 passes, format scoring, incomplete-run recording). The live eval is skipped unless `LCM_EVAL_MODEL` and `LCM_EVAL_CORPUS_DIR` are set.
- Corpus (`test/bench/corpus/`) and results (`test/bench/results/`) are gitignored; `export-eval-session.sh` exports a conversation from a per-project database read-only.

## Files Touched
- `test/bench/summarizer-eval-harness.ts` — corpus loading, synthetic session, instrumentation, scoring, run, result writing
- `test/bench/summarizer-eval-providers.ts` — OpenRouter / OpenAI-compatible / claude-process summarizers for the bench
- `test/bench/summarizer-eval.test.ts` — offline tests and the env-gated live eval
- `test/bench/export-eval-session.sh` — read-only session export via the immutable SQLite URI
- `.gitignore` — corpus and results directories

## Issue Reference

Closes #337

## Test Evidence
```
npx vitest run test/bench/summarizer-eval.test.ts test/llm → Test Files 10 passed, Tests 63 passed | 1 skipped
tsc --noEmit on the three bench files                       → OK
```
Live runs on 2026-09-07 (5 sessions, 3 runs per candidate, cap following target): GLM 5.3 Flash 92% format-valid, 0% cut, 9.7 s/call, planted facts 15/15, ~0.014 USD/session; Haiku 4.5 via claude-process 91%, 22 s/call; Sonnet 5 80%, 35 s/call. These runs surfaced and drove #328 (subprocess isolation) and #336 (output cap).

## Risks & Follow-ups
- Format scoring is mechanical; nobody grades prose quality. Planted facts only cover the synthetic session.
- Follow-up: production `openai.ts`/`anthropic.ts` echo the first 500 input characters when a model returns empty content, storing a fake summary without an error; the bench flags this as `emptyContentFallback`.
- Follow-up: production sends no `reasoning` parameter, so reasoning-on-by-default models return empty content; a config option is needed before adopting one.

## AR Status
[SKIP_AR: waived by the maintainer; test and bench tooling only, no production code]

## Introspection Findings
- `createMessagesBulk` alone gives the engine nothing; `appendContextMessages` is what makes messages compactable.
- Leaf summaries are consumed by condensation before the final context is read, so format must be scored per call, not on the final context.
- The bench must run from a dedicated worktree: another session switching branches in the shared checkout reset the branch once.

## Token Cost
~400k tokens (Fable 5.1) across the harness, provider probes and eval orchestration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192LTrLjpB8AsWf2QjSTawh