### PR TITLE
fix(llm): fail on empty summarizer output instead of echoing the input

### DIFF
--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -51,19 +51,10 @@ export function createAnthropicSummarizer(opts: SummarizerOptions): LcmSummarize
         });
 
         const textContent = response.content.find((c: any) => c.type === "text")?.text ?? "";
-
-        if (!textContent && attempt === 0) {
-          // Single retry on empty response
-          const retry = await client.messages.create({
-            model: opts.model,
-            max_tokens: resolveMaxOutputTokens(targetTokens),
-            system: ctx.taskPrompt ?? LCM_SUMMARIZER_SYSTEM_PROMPT,
-            messages: [{ role: "user", content: prompt }],
-          });
-          return retry.content.find((c: any) => c.type === "text")?.text ?? text.slice(0, 500);
-        }
-
-        return textContent || text.slice(0, 500);
+        // Empty content is a failure, not a summary: falling back to a slice of
+        // the input would persist raw conversation text as a fake summary.
+        if (!textContent) throw new Error("summarizer returned empty content");
+        return textContent;
       } catch (err: any) {
         if (err?.status === 401) throw err; // auth error: no retry
         lastError = err;

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -60,7 +60,10 @@ export function createOpenAISummarizer(opts: OpenAISummarizerOptions): LcmSummar
         });
 
         const textContent = response.choices[0]?.message?.content ?? "";
-        return textContent || text.slice(0, 500);
+        // Empty content is a failure, not a summary: falling back to a slice of
+        // the input would persist raw conversation text as a fake summary.
+        if (!textContent) throw new Error("summarizer returned empty content");
+        return textContent;
       } catch (err: any) {
         if (err?.status === 401) throw err; // auth error: no retry
         lastError = err;

--- a/test/llm/anthropic.test.ts
+++ b/test/llm/anthropic.test.ts
@@ -19,16 +19,28 @@ describe("createAnthropicSummarizer", () => {
     expect(args.system).toBeDefined();
   });
 
-  it("retries once on empty content, then returns", async () => {
+  it("retries on empty content, then returns", async () => {
     const mockCreate = vi.fn()
       .mockResolvedValueOnce({ content: [] })
       .mockResolvedValueOnce({ content: [{ type: "text", text: "Retry." }] });
     const summarizer = createAnthropicSummarizer({
       model: "claude-haiku-4-5-20251001", apiKey: "sk-test",
       _clientOverride: { messages: { create: mockCreate } } as any,
+      _retryDelayMs: 0,
     });
     expect(await summarizer("text", false)).toBe("Retry.");
     expect(mockCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("throws after retries when content stays empty instead of echoing the input", async () => {
+    const mockCreate = vi.fn().mockResolvedValue({ content: [] });
+    const summarizer = createAnthropicSummarizer({
+      model: "claude-haiku-4-5-20251001", apiKey: "sk-test",
+      _clientOverride: { messages: { create: mockCreate } } as any,
+      _retryDelayMs: 0,
+    });
+    await expect(summarizer("x".repeat(600), false)).rejects.toThrow("empty content");
+    expect(mockCreate).toHaveBeenCalledTimes(3);
   });
 
   it("throws immediately on 401 auth error", async () => {

--- a/test/llm/openai.test.ts
+++ b/test/llm/openai.test.ts
@@ -80,17 +80,15 @@ describe("createOpenAISummarizer", () => {
     expect(result).toBe("Summary.");
   });
 
-  it("falls back to truncated text if response is empty", async () => {
-    const mockClient = {
-      chat: { completions: { create: vi.fn().mockResolvedValue({ choices: [{ message: { content: "" } }] }) } },
-    };
-    const longText = "x".repeat(600);
+  it("retries on empty content and then throws instead of echoing the input", async () => {
+    const create = vi.fn().mockResolvedValue({ choices: [{ message: { content: "" } }] });
     const summarizer = createOpenAISummarizer({
       model: "test-model",
       baseURL: "http://localhost:11435/v1",
-      _clientOverride: mockClient as any,
+      _clientOverride: { chat: { completions: { create } } } as any,
+      _retryDelayMs: 0,
     });
-    const result = await summarizer(longText, false);
-    expect(result).toBe(longText.slice(0, 500));
+    await expect(summarizer("x".repeat(600), false)).rejects.toThrow("empty content");
+    expect(create).toHaveBeenCalledTimes(3);
   });
 });


### PR DESCRIPTION
## Changes
- `openai.ts` and `anthropic.ts` returned `text.slice(0, 500)` when the model sent empty content, and `CompactionEngine` stored that slice of raw conversation as a normal leaf summary with no error and no expansion trailer. Empty content is now thrown inside the existing retry loop (3 attempts with backoff), then propagated, so the engine's error path runs instead of persisting a fake summary.
- `anthropic.ts` loses its ad-hoc single retry; the shared loop covers it.

## Files Touched
- `src/llm/openai.ts` — throw on empty content
- `src/llm/anthropic.ts` — throw on empty content, drop the ad-hoc retry
- `test/llm/openai.test.ts` — empty content retries then throws; the input-echo test is gone
- `test/llm/anthropic.test.ts` — same, plus the existing retry-then-return case

## Issue Reference

Closes #339

## Test Evidence
```
npx vitest run --project unit → Test Files 109 passed | 1 skipped, Tests 1139 passed | 1 skipped
npx tsc --noEmit              → OK
```

## Risks & Follow-ups
- A model that keeps returning empty content now fails the compaction instead of silently degrading it. That is the intended behaviour; the surfaced error names the cause.
- Reasoning-on-by-default models are the common trigger; making them usable is #340 (configurable `reasoning` parameter).

## AR Status
[SKIP_AR: waived by the maintainer; two call sites, same three-line change]

## Introspection Findings
- The engine accepts any summary shorter than its input, so a summarizer must never return a "safe" placeholder: it becomes stored memory.

## Token Cost
~25k tokens (Fable 5.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192LTrLjpB8AsWf2QjSTawh
