### PR TITLE
feat(llm): configurable reasoning parameter for the openai summarizer

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -173,6 +173,21 @@ Valid provider values are:
 - `openai`
 - `disabled`
 
+### Reasoning parameter
+
+The `openai` provider sends `llm.reasoning` verbatim with each chat completion
+request, for models that reason by default and would otherwise spend the whole
+output budget thinking:
+
+```json
+{ "llm": { "provider": "openai", "reasoning": { "effort": "minimal" } } }
+```
+
+The accepted shape depends on the provider: GLM 5.3 Flash honours
+`{"effort":"minimal"}` and rejects `{"enabled":false}`; Qwen3.7 Flash honours only
+`{"enabled":false}`; Mercury 2.5 honours `effort`. When unset, no `reasoning` key
+is sent.
+
 ### Token cost reporting
 
 Every process-backed provider reports its usage in a normalized shape, stored in

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -42,7 +42,7 @@ export type DaemonConfig = {
     stalePenalty: number;
     allowStaleOnStrongMatch: boolean;
   };
-  llm: { provider: "auto" | "claude-process" | "codex-process" | "copilot-process" | "anthropic" | "openai" | "disabled"; model: string; apiKey?: string; baseURL: string };
+  llm: { provider: "auto" | "claude-process" | "codex-process" | "copilot-process" | "anthropic" | "openai" | "disabled"; model: string; apiKey?: string; baseURL: string; reasoning?: Record<string, unknown> };
   summarizer: { mock: boolean };
   security: SecurityConfig;
   hooks: { snapshotIntervalSec: number; disableAutoCompact: boolean };

--- a/src/daemon/summarizer.ts
+++ b/src/daemon/summarizer.ts
@@ -39,6 +39,7 @@ export async function createSummarizer(
       model: config.llm.model,
       baseURL: config.llm.baseURL,
       apiKey: config.llm.apiKey,
+      reasoning: config.llm.reasoning,
     });
   }
   // anthropic

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -12,6 +12,7 @@ type OpenAISummarizerOptions = {
   model: string;
   baseURL: string;
   apiKey?: string;
+  reasoning?: Record<string, unknown>;
   _clientOverride?: any;
   _retryDelayMs?: number;
 };
@@ -51,6 +52,9 @@ export function createOpenAISummarizer(opts: OpenAISummarizerOptions): LcmSummar
       try {
         const response = await client.chat.completions.create({
           model: opts.model,
+          // `reasoning` is provider-specific and absent from the OpenAI SDK types;
+          // omitted entirely when unset so servers rejecting unknown fields keep working.
+          ...(opts.reasoning ? { reasoning: opts.reasoning } : {}),
           max_tokens: resolveMaxOutputTokens(targetTokens),
           // Merge system content into user message for compatibility with local
           // servers (e.g. MLX/llama.cpp) that don't support role:"system".

--- a/test/daemon/config.test.ts
+++ b/test/daemon/config.test.ts
@@ -44,6 +44,14 @@ describe("loadDaemonConfig", () => {
     expect(c.llm.model).toBe("qwen2.5:14b");
   });
 
+  it("defaults llm.reasoning to undefined and merges it from file config", () => {
+    expect(loadDaemonConfig("/nonexistent/config.json").llm.reasoning).toBeUndefined();
+    const c = loadDaemonConfig("/nonexistent/config.json", {
+      llm: { provider: "openai", reasoning: { effort: "minimal" } }
+    });
+    expect(c.llm.reasoning).toEqual({ effort: "minimal" });
+  });
+
   it("accepts codex-process as a provider from file config", () => {
     const c = loadDaemonConfig("/nonexistent/config.json", {
       llm: { provider: "codex-process" }

--- a/test/daemon/config.test.ts
+++ b/test/daemon/config.test.ts
@@ -44,7 +44,7 @@ describe("loadDaemonConfig", () => {
     expect(c.llm.model).toBe("qwen2.5:14b");
   });
 
-  it("defaults llm.reasoning to undefined and merges it from file config", () => {
+  it("defaults llm.reasoning to undefined and merges it from overrides", () => {
     expect(loadDaemonConfig("/nonexistent/config.json").llm.reasoning).toBeUndefined();
     const c = loadDaemonConfig("/nonexistent/config.json", {
       llm: { provider: "openai", reasoning: { effort: "minimal" } }

--- a/test/daemon/routes/compact.test.ts
+++ b/test/daemon/routes/compact.test.ts
@@ -204,6 +204,18 @@ describe("createCompactHandler — summarizer branching", () => {
     expect(createAnthropicSummarizer).not.toHaveBeenCalled();
   });
 
+  it("passes llm.reasoning through to createOpenAISummarizer", async () => {
+    vi.clearAllMocks();
+    const config = makeConfig("openai");
+    (config.llm as any).reasoning = { effort: "minimal" };
+    const handler = createCompactHandler(config);
+    const { res } = mockRes();
+    await handler({} as any, res, JSON.stringify({ session_id: "s1", cwd: testCwd }));
+    expect(createOpenAISummarizer).toHaveBeenCalledWith(
+      expect.objectContaining({ reasoning: { effort: "minimal" } })
+    );
+  });
+
   it("returns no-op when provider is 'disabled' — no summarizer created", async () => {
     vi.clearAllMocks();
     const handler = createCompactHandler(makeConfig("disabled"));

--- a/test/daemon/routes/compact.test.ts
+++ b/test/daemon/routes/compact.test.ts
@@ -207,7 +207,7 @@ describe("createCompactHandler — summarizer branching", () => {
   it("passes llm.reasoning through to createOpenAISummarizer", async () => {
     vi.clearAllMocks();
     const config = makeConfig("openai");
-    (config.llm as any).reasoning = { effort: "minimal" };
+    config.llm.reasoning = { effort: "minimal" };
     const handler = createCompactHandler(config);
     const { res } = mockRes();
     await handler({} as any, res, JSON.stringify({ session_id: "s1", cwd: testCwd }));

--- a/test/llm/openai.test.ts
+++ b/test/llm/openai.test.ts
@@ -33,6 +33,25 @@ describe("createOpenAISummarizer", () => {
     expect(args.messages[0].content).toContain("context-compaction summarization engine");
   });
 
+  it("sends reasoning verbatim when configured and omits the key otherwise", async () => {
+    const withReasoning = makeClient("Summary.");
+    await createOpenAISummarizer({
+      model: "m",
+      baseURL: "http://x/v1",
+      reasoning: { effort: "minimal" },
+      _clientOverride: withReasoning as any,
+    })("Conversation text", false, {});
+    expect(withReasoning.chat.completions.create.mock.calls[0][0].reasoning).toEqual({ effort: "minimal" });
+
+    const without = makeClient("Summary.");
+    await createOpenAISummarizer({ model: "m", baseURL: "http://x/v1", _clientOverride: without as any })(
+      "Conversation text",
+      false,
+      {},
+    );
+    expect(without.chat.completions.create.mock.calls[0][0]).not.toHaveProperty("reasoning");
+  });
+
   it("raises max_tokens with the condensed target", async () => {
     const mockClient = makeClient("Summary.");
     const summarizer = createOpenAISummarizer({ model: "m", baseURL: "http://x/v1", _clientOverride: mockClient as any });


### PR DESCRIPTION
## Changes
- `llm.reasoning` (free-form object) in `config.json` is sent verbatim as `reasoning` with each chat completion request of the `openai` provider, and the key is omitted entirely when unset so servers that reject unknown fields keep working.
- Motivation: reasoning-on-by-default models spend the whole output budget thinking and return empty content on 20k-token leaf prompts. With `{"effort":"minimal"}`, GLM 5.3 Flash produced 92% format-valid summaries in the eval bench versus none without it.
- Free-form rather than an enum because providers differ: GLM honours `effort` and rejects `enabled:false`; Qwen3.7 Flash honours only `enabled:false`; Mercury honours `effort`.

## Files Touched
- `src/daemon/config.ts` — `reasoning?: Record<string, unknown>` on `llm`
- `src/daemon/summarizer.ts` — passes it to `createOpenAISummarizer`
- `src/llm/openai.ts` — spreads it into the request when set
- `docs/configuration.md` — "Reasoning parameter" subsection with example and provider notes
- `test/llm/openai.test.ts` — key sent when configured, absent otherwise
- `test/daemon/config.test.ts` — default undefined, merged from file config
- `test/daemon/routes/compact.test.ts` — flows from config to the summarizer

## Issue Reference

Closes #340

## Test Evidence
```
npx vitest run --project unit → Test Files 109 passed | 1 skipped, Tests 1142 passed | 1 skipped
npx tsc --noEmit              → OK
```

## Risks & Follow-ups
- Only the `openai` provider reads it; `anthropic` and the process-backed providers ignore it by design.
- Implemented by a delegated opus agent from a pre-#341 main; rebuilt here on the current main so the empty-content fix stays intact.

## AR Status
[SKIP_AR: waived by the maintainer; small config plumbing with tests at each hop]

## Introspection Findings
- A delegated agent's `git add -A` swept its `node_modules` symlink into the commit; the branch was rebuilt from the diff rather than rebased.

## Token Cost
~65k tokens (opus agent) + ~20k tokens (Fable 5.1 review and rebuild)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0192LTrLjpB8AsWf2QjSTawh