### PR TITLE
docs: document the summarizer eval bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,8 @@ npx vitest
 npx tsc --noEmit
 ```
 
+To score a candidate summarizer model against the real compaction engine, see [docs/summarizer-bench.md](docs/summarizer-bench.md). The bench is opt-in — it is skipped unless `LCM_EVAL_MODEL` and `LCM_EVAL_CORPUS_DIR` are set, so `npx vitest` never calls a paid API.
+
 ### Repository layout
 
 ```text
@@ -305,6 +307,7 @@ installer/
   install.ts                  setup wizard
   uninstall.ts                cleanup
 test/
+  bench/                      summarizer eval bench (opt-in, see docs/summarizer-bench.md)
   ...                         Vitest suites
 ```
 

--- a/docs/summarizer-bench.md
+++ b/docs/summarizer-bench.md
@@ -42,7 +42,7 @@ test/bench/export-eval-session.sh \
 `<project-id>` is the sha256 of the project's canonicalized working directory (`projectId` in `src/daemon/project.ts`). To find the one for a given project:
 
 ```bash
-node -e 'import("./dist/src/daemon/project.js").then(p => console.log(p.projectDbPath(process.argv[1])))' /path/to/project
+npm run build && node -e 'import("./dist/src/daemon/project.js").then(p => console.log(p.projectDbPath(process.argv[1])))' /path/to/project
 ```
 
 The database is opened read-only through the immutable URI — the only form that opens these WAL databases without taking a lock, so it is safe to run against a live install. A conversation id that matches no messages fails rather than leaving an empty file behind.

--- a/docs/summarizer-bench.md
+++ b/docs/summarizer-bench.md
@@ -1,0 +1,70 @@
+# Summarizer eval bench
+
+Scores a candidate summarizer model on the work lcm actually asks of it. The bench runs the real `CompactionEngine` with the production `/compact` configuration against a real session loaded into an in-memory SQLite database — real stores, real migrations — and records every summarizer call.
+
+It is opt-in. With no `LCM_EVAL_*` variables set, only the offline tests run and no API is called.
+
+## Running it
+
+```bash
+LCM_EVAL_MODEL=openai/gpt-oss-120b \
+LCM_EVAL_CORPUS_DIR=test/bench/corpus \
+npx vitest run --dir test test/bench/summarizer-eval.test.ts
+```
+
+Results land in `test/bench/results/` as one JSON per model, provider, variant, session and run. Both `test/bench/corpus/` and `test/bench/results/` are gitignored — they hold real conversation content and must never be committed.
+
+## Environment
+
+| Variable | Meaning |
+|---|---|
+| `LCM_EVAL_MODEL` | Candidate model id. **Required** — without it the live block is skipped. |
+| `LCM_EVAL_CORPUS_DIR` | Directory of `<label>.json` exports. **Required**. A set-but-missing path is an error, not a skip. |
+| `LCM_EVAL_PROVIDER` | `openrouter` (default), `openai`, or `claude-process`. An unrecognised value is rejected. |
+| `LCM_EVAL_BASE_URL` | `openai` provider only: the OpenAI-compatible endpoint. `LCM_EVAL_API_KEY` is optional. |
+| `LCM_EVAL_RUNS` | Runs per session, default `1`. Must be a positive integer. |
+| `LCM_EVAL_SESSIONS` | Comma-separated labels to run; default is every session in the corpus. |
+| `LCM_EVAL_REASONING` | HTTP providers: the JSON sent as `reasoning`, e.g. `{"enabled":false}`. |
+| `LCM_EVAL_REASONING_EFFORT` | Shorthand for `LCM_EVAL_REASONING={"effort":"<value>"}`. |
+| `LCM_EVAL_DISABLE_THINKING` | HTTP providers: `1` sends `chat_template_kwargs.enable_thinking=false`, for Qwen-style servers. |
+
+`openrouter` needs `OPENROUTER_API_KEY`. The provider and the reasoning knobs are part of a run's identity and appear in the result filename, so the same model measured under different settings does not overwrite itself.
+
+## Building a corpus
+
+Every corpus session is one JSON file named for its label. Export one from a per-project lcm database:
+
+```bash
+test/bench/export-eval-session.sh \
+  ~/.lossless-claude/projects/<project-id>/db.sqlite 42 test/bench/corpus/long-refactor.json
+```
+
+`<project-id>` is the sha256 of the project's canonicalized working directory (`projectId` in `src/daemon/project.ts`). To find the one for a given project:
+
+```bash
+node -e 'import("./dist/src/daemon/project.js").then(p => console.log(p.projectDbPath(process.argv[1])))' /path/to/project
+```
+
+The database is opened read-only through the immutable URI — the only form that opens these WAL databases without taking a lock, so it is safe to run against a live install. A conversation id that matches no messages fails rather than leaving an empty file behind.
+
+A synthetic session carrying planted facts is always appended to the corpus, so fact-survival is scored even on a corpus of one.
+
+## What it scores
+
+Per run, in `totals`:
+
+- **`formatPass` / `formatTotal`** — calls whose summary honoured the prompt contract: a `Files:` line on leaf summaries, an `Expand for details about:` trailer on all of them.
+- **`maxTokensHits`** — calls whose output reached the production output cap, meaning the summary was cut off.
+- **`inputTokens` / `outputTokens` / `latencyMs`** — totals across every call.
+- **`costUsd`** — the real charged cost, or `null` when the provider prices nothing. `null` means *unknown*, never *free*; only OpenRouter and the Claude CLI report a cost today (see #345).
+- **`failedCalls`** and the top-level `incomplete`, set when the engine itself errored. An incomplete run reports no fact survival, because chunks were left un-summarized and the score would be meaningless.
+- **`plantedFacts`** — which of the synthetic session's planted facts survived into the post-compaction context.
+
+## Parity with production
+
+`prodEngineConfig()` in `test/bench/summarizer-eval-harness.ts` mirrors the daemon's `/compact` engine configuration, with two deliberate deviations, both documented at that function:
+
+- `leafTargetTokens` uses the compiled-in default rather than the operator's live `config.json`, so a run is reproducible across machines.
+- No scrubber: stored messages were already scrubbed at ingest, and the export copies stored content verbatim.
+
+Everything else — thresholds, fan-outs, depth limits, round cap, token budget — matches. When the `/compact` route changes, that function has to change with it.


### PR DESCRIPTION
The summarizer eval bench landed in #338 with its usage documented only in inline comments in `test/bench/summarizer-eval.test.ts` and the header of `export-eval-session.sh`. Nothing in the README or `docs/` pointed at it, so there was no way to find it without already knowing it existed. A Tier B self-review at #338's merge gate flagged this as the one open gap.

## Changes

- **`docs/summarizer-bench.md`** (new) — how to run the bench, every `LCM_EVAL_*` variable and what rejects a bad value, how to export a corpus session from a live per-project database, what each scored metric means, and the two deliberate deviations from the production `/compact` engine config.
- **`README.md`** — a pointer from the Development section, and `test/bench/` in the repository layout.

## Notes

`totals.costUsd` is documented as `null` meaning *unknown*, never *free* — that distinction is what #338 fixed, and #345 tracks the production half.

## Verification

Every command and claim in the doc was exercised against this repo's own database, not just read:

- the export script on a real conversation (472 messages, 96773 tokens)
- its non-integer `conversation_id` rejection
- its empty-result guard — fails and leaves no zero-byte file behind
- the offline run with no environment set: 4 passed, 1 skipped, no network
- `LCM_EVAL_CORPUS_DIR` pointing at a missing path: fails naming the path
- the `projectDbPath` one-liner for locating a project's database

Docs only — no source or test changes.

---

**Follow-up:** the doc's parity section warns that `prodEngineConfig()` copies the `/compact` route's engine config and has to be kept in step by hand. #348 removes that hazard instead: both callers now build from one shared `compactEngineConfig()`, and the doc section is rewritten accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJukdsNnRu1jsmCHmfJZz4
