### PR TITLE
refactor(compaction): one engine config for /compact and the bench

### DIFF
--- a/docs/summarizer-bench.md
+++ b/docs/summarizer-bench.md
@@ -62,9 +62,11 @@ Per run, in `totals`:
 
 ## Parity with production
 
-`prodEngineConfig()` in `test/bench/summarizer-eval-harness.ts` mirrors the daemon's `/compact` engine configuration, with two deliberate deviations, both documented at that function:
+The bench does not copy the production engine configuration — it calls the same function. `compactEngineConfig()` in `src/compaction.ts` is the single source of truth, used by both the daemon's `/compact` route and the bench, and both compact against the same `COMPACT_TOKEN_BUDGET`. A change to the engine's thresholds, fan-outs, depth limits or round cap reaches the bench automatically; it cannot drift into measuring an engine production does not run.
 
-- `leafTargetTokens` uses the compiled-in default rather than the operator's live `config.json`, so a run is reproducible across machines.
-- No scrubber: stored messages were already scrubbed at ingest, and the export copies stored content verbatim.
+Only two values are per-caller arguments, and the bench differs on both deliberately:
 
-Everything else — thresholds, fan-outs, depth limits, round cap, token budget — matches. When the `/compact` route changes, that function has to change with it.
+- `leafTargetTokens` — the bench passes the compiled-in `DEFAULT_LEAF_TOKENS`, not the operator's live `config.json`, so a run is reproducible across machines.
+- `scrubber` — none: stored messages were already scrubbed at ingest, and the export copies stored content verbatim.
+
+`test/compaction.test.ts` pins this: it asserts that every field except those two comes out identical for both callers.

--- a/src/compaction.ts
+++ b/src/compaction.ts
@@ -56,6 +56,37 @@ export interface CompactionConfig {
   scrubber?: ScrubEngine;
 }
 
+/** Token budget the `/compact` route compacts against. */
+export const COMPACT_TOKEN_BUDGET = 200_000;
+
+/**
+ * The engine configuration the daemon's `/compact` route runs.
+ *
+ * Single source of truth: the summarizer eval bench builds its engine from this
+ * same function, so the bench cannot silently drift into measuring a different
+ * engine than production runs. Only the two genuinely per-caller values are
+ * arguments — the bench passes the compiled-in `DEFAULT_LEAF_TOKENS` (a run must
+ * be reproducible across machines, not follow the operator's config.json) and no
+ * scrubber (its corpus was scrubbed at ingest).
+ */
+export function compactEngineConfig(opts: {
+  leafTargetTokens: number;
+  scrubber?: ScrubEngine;
+}): CompactionConfig {
+  return {
+    contextThreshold: 0.75,
+    freshTailCount: 8,
+    leafMinFanout: 3,
+    condensedMinFanout: 2,
+    condensedMinFanoutHard: 1,
+    incrementalMaxDepth: 0,
+    leafTargetTokens: opts.leafTargetTokens,
+    condensedTargetTokens: 900,
+    maxRounds: 10,
+    scrubber: opts.scrubber,
+  };
+}
+
 type CompactionLevel = "normal" | "aggressive" | "fallback";
 type CompactionPass = "leaf" | "condensed";
 type CompactionSummarizeOptions = {

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -48,11 +48,18 @@ export type DaemonConfig = {
   hooks: { snapshotIntervalSec: number; disableAutoCompact: boolean };
 };
 
+/**
+ * Default target tokens for a leaf summary. Exported because the summarizer
+ * bench builds the production engine config without an operator's config.json:
+ * it needs this value by name, not as a copied literal that can drift.
+ */
+export const DEFAULT_LEAF_TOKENS = 1000;
+
 const DEFAULTS: DaemonConfig = {
   version: 1,
   daemon: { port: 3737, socketPath: join(homedir(), ".lossless-claude", "daemon.sock"), logLevel: "info", logMaxSizeMB: 10, logRetentionDays: 7, idleTimeoutMs: 1800000 },
   compaction: {
-    leafTokens: 1000, maxDepth: 5, autoCompactMinTokens: 10000,
+    leafTokens: DEFAULT_LEAF_TOKENS, maxDepth: 5, autoCompactMinTokens: 10000,
     promotionThresholds: {
       minDepth: 2, compressionRatio: 0.3,
       keywords: { decision: ["decided", "agreed", "will use", "going with", "chosen"], fix: ["fixed", "root cause", "workaround", "resolved"] },

--- a/src/daemon/routes/compact.ts
+++ b/src/daemon/routes/compact.ts
@@ -10,7 +10,7 @@ import { runLcmMigrations } from "../../db/migration.js";
 import { upsertRedactionCounts } from "../../db/redaction-stats.js";
 import { ConversationStore } from "../../store/conversation-store.js";
 import { SummaryStore } from "../../store/summary-store.js";
-import { CompactionEngine } from "../../compaction.js";
+import { CompactionEngine, compactEngineConfig, COMPACT_TOKEN_BUDGET } from "../../compaction.js";
 import { parseTranscript } from "../../transcript.js";
 import type { LcmSummarizeFn } from "../../llm/types.js";
 import { ScrubEngine } from "../../scrub.js";
@@ -316,22 +316,14 @@ export function createCompactHandler(config: DaemonConfig): RouteHandler {
             }
           };
 
-          const engine = new CompactionEngine(conversationStore, summaryStore, {
-            contextThreshold: 0.75,
-            freshTailCount: 8,
-            leafMinFanout: 3,
-            condensedMinFanout: 2,
-            condensedMinFanoutHard: 1,
-            incrementalMaxDepth: 0,
+          const engine = new CompactionEngine(conversationStore, summaryStore, compactEngineConfig({
             leafTargetTokens: config.compaction.leafTokens,
-            condensedTargetTokens: 900,
-            maxRounds: 10,
             scrubber,
-          });
+          }));
 
           const compactResult = await engine.compact({
             conversationId: conversation.conversationId,
-            tokenBudget: 200_000,
+            tokenBudget: COMPACT_TOKEN_BUDGET,
             summarize: summarizeWithUsage,
             force: true,
             previousSummaryContent: validatedPreviousSummary,

--- a/test/bench/summarizer-eval-harness.ts
+++ b/test/bench/summarizer-eval-harness.ts
@@ -10,7 +10,8 @@
 import { readFileSync, readdirSync, mkdirSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { CompactionEngine } from "../../src/compaction.js";
+import { CompactionEngine, compactEngineConfig, COMPACT_TOKEN_BUDGET } from "../../src/compaction.js";
+import { DEFAULT_LEAF_TOKENS } from "../../src/daemon/config.js";
 import { runLcmMigrations } from "../../src/db/migration.js";
 import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "../../src/llm/types.js";
 import { ConversationStore } from "../../src/store/conversation-store.js";
@@ -294,27 +295,6 @@ export type EvalRunResult = {
 };
 
 
-/**
- * The daemon's /compact engine config, with two deliberate deviations:
- *  - leafTargetTokens is the hardcoded default (1000) rather than the live
- *    `config.compaction.leafTokens`, so a bench run is reproducible across
- *    machines regardless of the operator's local config.json.
- *  - no scrubber: stored messages were scrubbed at ingest, and the corpus
- *    export copies stored content verbatim, so there is nothing left to scrub.
- */
-function prodEngineConfig() {
-  return {
-    contextThreshold: 0.75,
-    freshTailCount: 8,
-    leafMinFanout: 3,
-    condensedMinFanout: 2,
-    condensedMinFanoutHard: 1,
-    incrementalMaxDepth: 0,
-    leafTargetTokens: 1000,
-    condensedTargetTokens: 900,
-    maxRounds: 10,
-  };
-}
 
 export async function runEval(input: {
   session: CorpusSession;
@@ -347,13 +327,18 @@ export async function runEval(input: {
   await summaryStore.appendContextMessages(cid, records.map((r) => r.messageId));
 
   const { summarize, calls } = instrumentSummarizer(input.summarizer);
-  const engine = new CompactionEngine(conversationStore, summaryStore, prodEngineConfig());
+  const engine = new CompactionEngine(conversationStore, summaryStore, compactEngineConfig({
+    // The compiled-in default, not the operator's config.json: a bench run must
+    // be reproducible across machines. No scrubber — corpus content was already
+    // scrubbed at ingest and the export copies stored content verbatim.
+    leafTargetTokens: DEFAULT_LEAF_TOKENS,
+  }));
   const tokensBefore = await summaryStore.getContextTokenCount(cid);
   const startedAt = new Date().toISOString();
 
   let error: string | undefined;
   try {
-    await engine.compact({ conversationId: cid, tokenBudget: 200_000, summarize, force: true });
+    await engine.compact({ conversationId: cid, tokenBudget: COMPACT_TOKEN_BUDGET, summarize, force: true });
   } catch (err) {
     error = err instanceof Error ? err.message : String(err);
   }

--- a/test/compaction.test.ts
+++ b/test/compaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { CompactionEngine, type CompactionSummarizeFn } from "../src/compaction.js";
+import { CompactionEngine, compactEngineConfig, type CompactionSummarizeFn } from "../src/compaction.js";
 import type { ConversationStore } from "../src/store/conversation-store.js";
 import type { SummaryStore } from "../src/store/summary-store.js";
 
@@ -64,5 +64,27 @@ describe("CompactionEngine.compact — previousSummaryContent seeding", () => {
 
     expect(summarizeCalls.length).toBeGreaterThan(0);
     expect(summarizeCalls[0].previousSummary).toBe("prior context");
+  });
+});
+
+describe("compactEngineConfig", () => {
+  it("threads through the only two per-caller values", () => {
+    const scrubber = {} as never;
+    const withScrubber = compactEngineConfig({ leafTargetTokens: 2500, scrubber });
+    expect(withScrubber.leafTargetTokens).toBe(2500);
+    expect(withScrubber.scrubber).toBe(scrubber);
+
+    const without = compactEngineConfig({ leafTargetTokens: 1000 });
+    expect(without.scrubber).toBeUndefined();
+  });
+
+  it("is the same engine for every caller, so the bench cannot drift from /compact", () => {
+    // Only leafTargetTokens and scrubber may differ between the daemon route
+    // and the summarizer bench; everything else must come out identical.
+    const route = compactEngineConfig({ leafTargetTokens: 4000, scrubber: {} as never });
+    const bench = compactEngineConfig({ leafTargetTokens: 1000 });
+    const { leafTargetTokens: _a, scrubber: _b, ...routeRest } = route;
+    const { leafTargetTokens: _c, scrubber: _d, ...benchRest } = bench;
+    expect(benchRest).toEqual(routeRest);
   });
 });


### PR DESCRIPTION
Follow-up to #346. That PR documented the summarizer bench, including a warning that `prodEngineConfig()` copies the `/compact` route's engine configuration and has to be kept in step by hand. This removes the hazard instead of describing it.

## The problem

The bench harness copied the route's engine config literal by literal — thresholds, fan-outs, depth limits, round cap, token budget. Nothing tied them together. Change the route and the bench keeps happily reporting scores for an engine production no longer runs: no test fails, nothing surfaces, and the numbers stay plausible.

## Changes

**`compactEngineConfig()` in `src/compaction.ts` is now the single source of truth**, called by both the daemon route and the bench, along with a shared `COMPACT_TOKEN_BUDGET`. Only the two values that genuinely differ per caller are arguments:

- `leafTargetTokens` — the bench passes the newly exported `DEFAULT_LEAF_TOKENS` rather than the operator's `config.json`, so a run stays reproducible across machines.
- `scrubber` — none in the bench: corpus content was already scrubbed at ingest.

`test/compaction.test.ts` asserts every other field comes out identical for both callers, so a field added to only one path fails rather than drifting.

`docs/summarizer-bench.md`'s parity section is rewritten to match — it now describes one shared function rather than a copy to maintain.

## Verification

Full suite green: 1237 passed, 4 skipped. The `/compact` route tests and the bench's offline tests both exercise the new factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJukdsNnRu1jsmCHmfJZz4