### PR TITLE
feat(llm): report token usage from the HTTP summarizer providers

### DIFF
--- a/.changeset/http-provider-usage.md
+++ b/.changeset/http-provider-usage.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Report token usage from the HTTP summarizer providers. `openai` and `anthropic` now emit the same normalized accounting the process-backed providers do, so `llm_usage_stats` and `lcm import --replay` stop showing a summarizer that appears to consume nothing. Against an OpenRouter base URL the `openai` provider asks for cost accounting and records the real charge; every other server leaves `costUsd` absent, meaning unknown, never free.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -206,9 +206,10 @@ Every provider reports its usage in a normalized shape, stored in
 | `openai` | yes | when the server reports it | yes | real charged cost, OpenRouter only |
 | `anthropic` | yes | yes | yes | — |
 
-A missing cost means *unknown*, never *free*: only the Claude CLI and OpenRouter
-price a call. Against an OpenRouter base URL the `openai` provider asks for cost
-accounting explicitly, because OpenRouter omits the charge otherwise.
+Every provider charges; only the Claude CLI and OpenRouter report the charge
+back as a number. A missing cost therefore means *unknown*, never *free*.
+Against an OpenRouter base URL the `openai` provider asks for cost accounting
+explicitly, because OpenRouter omits the figure otherwise.
 
 `inputTokens` always counts the full prompt, with `cachedInputTokens` as a subset
 of it, so totals are comparable across providers. The Copilot CLI only exposes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -195,7 +195,7 @@ an array, `null` or a number is rejected at config load, not at request time.
 
 ### Token cost reporting
 
-Every process-backed provider reports its usage in a normalized shape, stored in
+Every provider reports its usage in a normalized shape, stored in
 `llm_usage_stats` and shown by `lcm import --replay`:
 
 | Provider | Input | Cached | Output | Extra |
@@ -203,6 +203,12 @@ Every process-backed provider reports its usage in a normalized shape, stored in
 | `claude-process` | yes | yes | yes | list-price cost in USD |
 | `codex-process` | yes | yes | yes | — |
 | `copilot-process` | no | no | yes | premium requests |
+| `openai` | yes | when the server reports it | yes | real charged cost, OpenRouter only |
+| `anthropic` | yes | yes | yes | — |
+
+A missing cost means *unknown*, never *free*: only the Claude CLI and OpenRouter
+price a call. Against an OpenRouter base URL the `openai` provider asks for cost
+accounting explicitly, because OpenRouter omits the charge otherwise.
 
 `inputTokens` always counts the full prompt, with `cachedInputTokens` as a subset
 of it, so totals are comparable across providers. The Copilot CLI only exposes

--- a/docs/summarizer-bench.md
+++ b/docs/summarizer-bench.md
@@ -56,7 +56,7 @@ Per run, in `totals`:
 - **`formatPass` / `formatTotal`** — calls whose summary honoured the prompt contract: a `Files:` line on leaf summaries, an `Expand for details about:` trailer on all of them.
 - **`maxTokensHits`** — calls whose output reached the production output cap, meaning the summary was cut off.
 - **`inputTokens` / `outputTokens` / `latencyMs`** — totals across every call.
-- **`costUsd`** — the real charged cost, or `null` when the provider prices nothing. `null` means *unknown*, never *free*; only OpenRouter and the Claude CLI report a cost today (see #345).
+- **`costUsd`** — the real charged cost, or `null` when the provider prices nothing. `null` means *unknown*, never *free*; only OpenRouter and the Claude CLI report a cost today.
 - **`failedCalls`** and the top-level `incomplete`, set when the engine itself errored. An incomplete run reports no fact survival, because chunks were left un-summarized and the score would be meaningless.
 - **`plantedFacts`** — which of the synthetic session's planted facts survived into the post-compaction context.
 

--- a/docs/summarizer-bench.md
+++ b/docs/summarizer-bench.md
@@ -56,7 +56,7 @@ Per run, in `totals`:
 - **`formatPass` / `formatTotal`** — calls whose summary honoured the prompt contract: a `Files:` line on leaf summaries, an `Expand for details about:` trailer on all of them.
 - **`maxTokensHits`** — calls whose output reached the production output cap, meaning the summary was cut off.
 - **`inputTokens` / `outputTokens` / `latencyMs`** — totals across every call.
-- **`costUsd`** — the real charged cost, or `null` when the provider prices nothing. `null` means *unknown*, never *free*; only OpenRouter and the Claude CLI report a cost today.
+- **`costUsd`** — the real charged cost, or `null` when the provider reports no cost figure. `null` means *unknown*, never *free* — the call was still charged; only OpenRouter and the Claude CLI report the number today.
 - **`failedCalls`** and the top-level `incomplete`, set when the engine itself errored. An incomplete run reports no fact survival, because chunks were left un-summarized and the score would be meaningless.
 - **`plantedFacts`** — which of the synthetic session's planted facts survived into the post-compaction context.
 

--- a/src/daemon/routes/compact.ts
+++ b/src/daemon/routes/compact.ts
@@ -285,8 +285,8 @@ export function createCompactHandler(config: DaemonConfig): RouteHandler {
               const summary = await summarize(text, aggressive, {
                 ...ctx,
                 onUsage: (usage) => {
-                  // Every process-backed provider reports normalized usage;
-                  // only providers that report call onUsage at all.
+                  // Every provider reports normalized usage; only providers
+                  // whose response carries it call onUsage at all.
                   sawUsage = true;
                   callTokensSpent.tokens += usage.tokensUsed;
                   callTokensSpent.input += usage.inputTokens ?? 0;

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -6,7 +6,7 @@ import {
   resolveTargetTokens,
   resolveMaxOutputTokens,
 } from "../summarize.js";
-import type { LcmSummarizeFn, SummarizeContext } from "./types.js";
+import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "./types.js";
 
 export type { LcmSummarizeFn } from "./types.js";
 
@@ -19,6 +19,30 @@ type SummarizerOptions = {
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Anthropic reports `input_tokens` as the UNCACHED portion only, with cache
+ * reads and writes counted separately. The normalized `inputTokens` is the
+ * full prompt, so the three are summed and `cache_read` is the cached subset.
+ * The API prices nothing, so `costUsd` stays absent — meaning unknown.
+ */
+function toUsage(response: any, fallbackModel: string): SummarizerUsage | undefined {
+  const usage = response?.usage;
+  if (!usage) return undefined;
+  const inputTokens =
+    (usage.input_tokens ?? 0) +
+    (usage.cache_read_input_tokens ?? 0) +
+    (usage.cache_creation_input_tokens ?? 0);
+  const outputTokens = usage.output_tokens ?? 0;
+  return {
+    provider: "anthropic",
+    model: response.model || fallbackModel,
+    inputTokens,
+    cachedInputTokens: usage.cache_read_input_tokens,
+    outputTokens,
+    tokensUsed: inputTokens + outputTokens,
+  };
 }
 
 export function createAnthropicSummarizer(opts: SummarizerOptions): LcmSummarizeFn {
@@ -49,6 +73,11 @@ export function createAnthropicSummarizer(opts: SummarizerOptions): LcmSummarize
           system: ctx.taskPrompt ?? LCM_SUMMARIZER_SYSTEM_PROMPT,
           messages: [{ role: "user", content: prompt }],
         });
+
+        // Reported before the empty-content check: those tokens were charged
+        // even when the model returned nothing usable.
+        const usage = toUsage(response, opts.model);
+        if (usage) ctx.onUsage?.(usage);
 
         const textContent = response.content.find((c: any) => c.type === "text")?.text ?? "";
         // Empty content is a failure, not a summary: falling back to a slice of

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -25,7 +25,8 @@ function sleep(ms: number): Promise<void> {
  * Anthropic reports `input_tokens` as the UNCACHED portion only, with cache
  * reads and writes counted separately. The normalized `inputTokens` is the
  * full prompt, so the three are summed and `cache_read` is the cached subset.
- * The API prices nothing, so `costUsd` stays absent — meaning unknown.
+ * The API returns no cost figure, so `costUsd` stays absent — meaning
+ * unknown, not free: the call is still charged.
  */
 function toUsage(response: any, fallbackModel: string): SummarizerUsage | undefined {
   const usage = response?.usage;

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import type { LcmSummarizeFn, SummarizeContext } from "./types.js";
+import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "./types.js";
 import {
   LCM_SUMMARIZER_SYSTEM_PROMPT,
   buildLeafSummaryPrompt,
@@ -21,6 +21,40 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
+/**
+ * OpenRouter is the only OpenAI-compatible endpoint that prices a call and
+ * reports the real charge, and only when the request asks for accounting.
+ * Plain servers reject unknown top-level fields, so the flag is host-scoped.
+ */
+function isOpenRouter(baseURL: string): boolean {
+  try {
+    return new URL(baseURL).hostname.endsWith("openrouter.ai");
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * OpenAI reports `cached_tokens` as a SUBSET of `prompt_tokens`, which is
+ * already the normalized convention: no re-basing needed, unlike Anthropic.
+ */
+function toUsage(response: any, fallbackModel: string): SummarizerUsage | undefined {
+  const usage = response?.usage;
+  if (!usage) return undefined;
+  const inputTokens = usage.prompt_tokens;
+  const outputTokens = usage.completion_tokens;
+  return {
+    provider: "openai",
+    model: response.model || fallbackModel,
+    inputTokens,
+    cachedInputTokens: usage.prompt_tokens_details?.cached_tokens,
+    outputTokens,
+    tokensUsed: usage.total_tokens ?? (inputTokens ?? 0) + (outputTokens ?? 0),
+    // Absent stays absent: a consumer must read it as "unknown", not "free".
+    costUsd: typeof usage.cost === "number" ? usage.cost : undefined,
+  };
+}
+
 export function createOpenAISummarizer(opts: OpenAISummarizerOptions): LcmSummarizeFn {
   const client =
     opts._clientOverride ??
@@ -30,6 +64,7 @@ export function createOpenAISummarizer(opts: OpenAISummarizerOptions): LcmSummar
     });
   const retryDelayMs = opts._retryDelayMs ?? 1000;
   const MAX_RETRIES = 3;
+  const askForCostAccounting = isOpenRouter(opts.baseURL);
 
   return async function summarize(text, aggressive, ctx: SummarizeContext = {}): Promise<string> {
     const estimatedInputTokens = Math.ceil(text.length / 4);
@@ -55,6 +90,7 @@ export function createOpenAISummarizer(opts: OpenAISummarizerOptions): LcmSummar
           // `reasoning` is provider-specific and absent from the OpenAI SDK types;
           // omitted entirely when unset so servers rejecting unknown fields keep working.
           ...(opts.reasoning !== undefined ? { reasoning: opts.reasoning } : {}),
+          ...(askForCostAccounting ? { usage: { include: true } } : {}),
           max_tokens: resolveMaxOutputTokens(targetTokens),
           // Merge system content into user message for compatibility with local
           // servers (e.g. MLX/llama.cpp) that don't support role:"system".
@@ -62,6 +98,11 @@ export function createOpenAISummarizer(opts: OpenAISummarizerOptions): LcmSummar
             { role: "user", content: `${ctx.taskPrompt ?? LCM_SUMMARIZER_SYSTEM_PROMPT}\n\n${prompt}` },
           ],
         });
+
+        // Reported before the empty-content check: a reasoning model that
+        // spends the whole budget thinking still charged for those tokens.
+        const usage = toUsage(response, opts.model);
+        if (usage) ctx.onUsage?.(usage);
 
         const textContent = response.choices[0]?.message?.content ?? "";
         // Empty content is a failure, not a summary: falling back to a slice of

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -22,9 +22,9 @@ function sleep(ms: number): Promise<void> {
 }
 
 /**
- * OpenRouter is the only OpenAI-compatible endpoint that prices a call and
- * reports the real charge, and only when the request asks for accounting.
- * Plain servers reject unknown top-level fields, so the flag is host-scoped.
+ * Every provider charges; OpenRouter is the only OpenAI-compatible endpoint
+ * that REPORTS the charge back (`usage.cost`), and only when the request opts
+ * in. Plain servers reject unknown top-level fields, so the flag is host-scoped.
  */
 function isOpenRouter(baseURL: string): boolean {
   try {

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,7 +1,12 @@
-export type SummarizerProvider = "claude-process" | "codex-process" | "copilot-process";
+export type SummarizerProvider =
+  | "claude-process"
+  | "codex-process"
+  | "copilot-process"
+  | "openai"
+  | "anthropic";
 
 /**
- * Normalized token accounting, shared by every process-backed summarizer.
+ * Normalized token accounting, shared by every summarizer that reports it.
  *
  * Conventions (pinned so numbers stay comparable across providers):
  * - `inputTokens` is the FULL prompt cost, cached portion included.
@@ -19,7 +24,11 @@ export type SummarizerUsage = {
   cachedInputTokens?: number;
   outputTokens?: number;
   tokensUsed: number;
-  /** Claude CLI only — list-price cost of the call. */
+  /**
+   * Charged cost of the call, when the provider prices it: the Claude CLI
+   * reports list price, OpenRouter the real charge. Absent means UNKNOWN,
+   * never free — a consumer must not read a missing cost as zero.
+   */
   costUsd?: number;
   /** Copilot CLI only — GitHub's billing unit, not a token count. */
   premiumRequests?: number;

--- a/test/bench/summarizer-eval-providers.ts
+++ b/test/bench/summarizer-eval-providers.ts
@@ -1,77 +1,50 @@
 import OpenAI from "openai";
 import { createClaudeProcessSummarizer } from "../../src/llm/claude-process.js";
 import { createOpenAISummarizer } from "../../src/llm/openai.js";
-import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "../../src/llm/types.js";
+import type { LcmSummarizeFn } from "../../src/llm/types.js";
 
 export type EvalProvider = "openrouter" | "openai" | "claude-process";
 
 const OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
 
 /**
- * The production OpenAI-compatible summarizer against any endpoint, with the
- * response usage captured through the client override so the bench can report
- * tokens without changing production code.
+ * The production OpenAI-compatible summarizer against any endpoint. Token and
+ * cost accounting lives in production now, so the bench adds nothing but the
+ * knobs production has no reason to send.
  */
-function createHttpSummarizer(label: string, baseURL: string, apiKey: string, model: string): LcmSummarizeFn {
-  const client = new OpenAI({ baseURL, apiKey });
+function createHttpSummarizer(baseURL: string, apiKey: string, model: string): LcmSummarizeFn {
   // Reasoning models spend the whole max_tokens budget thinking and return
-  // empty content; production sends no reasoning parameter, so this is an
-  // explicit bench knob, not a prod mirror. LCM_EVAL_REASONING is the JSON
-  // object sent as `reasoning` (e.g. {"effort":"minimal"} or {"enabled":false});
+  // empty content; production sends no reasoning parameter unless configured,
+  // so this is an explicit bench knob. LCM_EVAL_REASONING is the JSON object
+  // sent as `reasoning` (e.g. {"effort":"minimal"} or {"enabled":false});
   // LCM_EVAL_REASONING_EFFORT is the shorthand for the effort form.
   const reasoning: Record<string, unknown> | undefined = process.env.LCM_EVAL_REASONING
     ? (JSON.parse(process.env.LCM_EVAL_REASONING) as Record<string, unknown>)
     : process.env.LCM_EVAL_REASONING_EFFORT
       ? { effort: process.env.LCM_EVAL_REASONING_EFFORT }
       : undefined;
-  // Qwen-style servers (vLLM, MLX) take enable_thinking through chat_template_kwargs.
-  const disableThinking = process.env.LCM_EVAL_DISABLE_THINKING === "1";
 
-  let pendingCtx: SummarizeContext | undefined;
-  const capturing = {
-    chat: {
-      completions: {
-        create: async (params: Parameters<typeof client.chat.completions.create>[0]) => {
-          const extra: Record<string, unknown> = {};
-          // OpenRouter only returns usage.cost when accounting is requested.
-          if (baseURL === OPENROUTER_BASE_URL) extra.usage = { include: true };
-          if (reasoning) extra.reasoning = reasoning;
-          if (disableThinking) extra.chat_template_kwargs = { enable_thinking: false };
-          const response = await client.chat.completions.create({ ...params, ...extra, stream: false });
-          const usage = response.usage;
-          if (usage && pendingCtx?.onUsage) {
-            const cached = (usage.prompt_tokens_details as { cached_tokens?: number } | undefined)?.cached_tokens;
-            // Provider label is wider than the production union; the bench
-            // only reads the numbers and the model.
-            pendingCtx.onUsage({
-              provider: label,
-              model: response.model ?? model,
-              inputTokens: usage.prompt_tokens,
-              cachedInputTokens: cached,
-              outputTokens: usage.completion_tokens,
-              tokensUsed: usage.total_tokens ?? usage.prompt_tokens + usage.completion_tokens,
-              // OpenRouter reports the real charged cost here; plain OpenAI-compatible
-              // servers report nothing, and the bench must say "unknown", not 0.
-              costUsd: typeof (usage as { cost?: unknown }).cost === "number"
-                ? (usage as { cost: number }).cost
-                : undefined,
-            } as unknown as SummarizerUsage);
-          }
-          return response;
+  // Qwen-style servers (vLLM, MLX) take enable_thinking through
+  // chat_template_kwargs, the one parameter with no production path: a client
+  // override is the only place to inject it.
+  let clientOverride: unknown;
+  if (process.env.LCM_EVAL_DISABLE_THINKING === "1") {
+    const client = new OpenAI({ baseURL, apiKey });
+    clientOverride = {
+      chat: {
+        completions: {
+          create: (params: Parameters<typeof client.chat.completions.create>[0]) =>
+            client.chat.completions.create({
+              ...params,
+              chat_template_kwargs: { enable_thinking: false },
+              stream: false,
+            } as typeof params),
         },
       },
-    },
-  };
+    };
+  }
 
-  const inner = createOpenAISummarizer({ model, baseURL, apiKey, _clientOverride: capturing });
-  return async (text, aggressive, ctx = {}) => {
-    pendingCtx = ctx;
-    try {
-      return await inner(text, aggressive, ctx);
-    } finally {
-      pendingCtx = undefined;
-    }
-  };
+  return createOpenAISummarizer({ model, baseURL, apiKey, reasoning, _clientOverride: clientOverride });
 }
 
 function requireEnv(name: string): string {
@@ -84,7 +57,7 @@ export function createEvalSummarizer(provider: EvalProvider, model: string): Lcm
   if (provider === "claude-process") return createClaudeProcessSummarizer({ model });
   if (provider === "openai") {
     // Any OpenAI-compatible server, e.g. a local MLX box: LCM_EVAL_BASE_URL + LCM_EVAL_API_KEY.
-    return createHttpSummarizer("openai", requireEnv("LCM_EVAL_BASE_URL"), process.env.LCM_EVAL_API_KEY ?? "local", model);
+    return createHttpSummarizer(requireEnv("LCM_EVAL_BASE_URL"), process.env.LCM_EVAL_API_KEY ?? "local", model);
   }
-  return createHttpSummarizer("openrouter", OPENROUTER_BASE_URL, requireEnv("OPENROUTER_API_KEY"), model);
+  return createHttpSummarizer(OPENROUTER_BASE_URL, requireEnv("OPENROUTER_API_KEY"), model);
 }

--- a/test/llm/anthropic.test.ts
+++ b/test/llm/anthropic.test.ts
@@ -65,4 +65,40 @@ describe("createAnthropicSummarizer", () => {
     await expect(summarizer("text", false)).rejects.toThrow("rate limited");
     expect(mockCreate).toHaveBeenCalledTimes(3);
   });
+
+  it("reports usage with cache tokens folded into the full input", async () => {
+    const mockCreate = vi.fn().mockResolvedValue({
+      content: [{ type: "text", text: "Summary." }],
+      model: "served-model",
+      usage: {
+        input_tokens: 100,
+        cache_read_input_tokens: 800,
+        cache_creation_input_tokens: 50,
+        output_tokens: 200,
+      },
+    });
+    const onUsage = vi.fn();
+    await createAnthropicSummarizer({
+      model: "claude-haiku-4-5-20251001", apiKey: "sk-test",
+      _clientOverride: { messages: { create: mockCreate } } as any,
+    })("Conversation text", false, { onUsage });
+    expect(onUsage).toHaveBeenCalledWith({
+      provider: "anthropic",
+      model: "served-model",
+      inputTokens: 950,
+      cachedInputTokens: 800,
+      outputTokens: 200,
+      tokensUsed: 1150,
+    });
+  });
+
+  it("stays silent when the response carries no usage", async () => {
+    const mockCreate = vi.fn().mockResolvedValue({ content: [{ type: "text", text: "Summary." }] });
+    const onUsage = vi.fn();
+    await createAnthropicSummarizer({
+      model: "claude-haiku-4-5-20251001", apiKey: "sk-test",
+      _clientOverride: { messages: { create: mockCreate } } as any,
+    })("text", false, { onUsage });
+    expect(onUsage).not.toHaveBeenCalled();
+  });
 });

--- a/test/llm/openai.test.ts
+++ b/test/llm/openai.test.ts
@@ -110,4 +110,80 @@ describe("createOpenAISummarizer", () => {
     await expect(summarizer("x".repeat(600), false)).rejects.toThrow("empty content");
     expect(create).toHaveBeenCalledTimes(3);
   });
+
+  it("reports normalized usage, with cached tokens as a subset of the input", async () => {
+    const create = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: "Summary." } }],
+      model: "served-model",
+      usage: {
+        prompt_tokens: 1200,
+        completion_tokens: 300,
+        total_tokens: 1500,
+        prompt_tokens_details: { cached_tokens: 800 },
+        cost: 0.0042,
+      },
+    });
+    const onUsage = vi.fn();
+    await createOpenAISummarizer({
+      model: "requested-model",
+      baseURL: "https://openrouter.ai/api/v1",
+      _clientOverride: { chat: { completions: { create } } } as any,
+    })("Conversation text", false, { onUsage });
+    expect(onUsage).toHaveBeenCalledWith({
+      provider: "openai",
+      model: "served-model",
+      inputTokens: 1200,
+      cachedInputTokens: 800,
+      outputTokens: 300,
+      tokensUsed: 1500,
+      costUsd: 0.0042,
+    });
+  });
+
+  it("leaves costUsd absent when the server prices nothing, and stays silent without usage", async () => {
+    const priced = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: "Summary." } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+    const onPriced = vi.fn();
+    await createOpenAISummarizer({
+      model: "m", baseURL: "http://localhost:11435/v1",
+      _clientOverride: { chat: { completions: { create: priced } } } as any,
+    })("text", false, { onUsage: onPriced });
+    expect(onPriced.mock.calls[0][0].costUsd).toBeUndefined();
+    expect(onPriced.mock.calls[0][0].tokensUsed).toBe(15);
+
+    const silent = makeClient("Summary.");
+    const onSilent = vi.fn();
+    await createOpenAISummarizer({
+      model: "m", baseURL: "http://localhost:11435/v1", _clientOverride: silent as any,
+    })("text", false, { onUsage: onSilent });
+    expect(onSilent).not.toHaveBeenCalled();
+  });
+
+  it("reports usage for an empty completion, whose tokens were still charged", async () => {
+    const create = vi.fn().mockResolvedValue({
+      choices: [{ message: { content: "" } }],
+      usage: { prompt_tokens: 10, completion_tokens: 900, total_tokens: 910 },
+    });
+    const onUsage = vi.fn();
+    await expect(
+      createOpenAISummarizer({
+        model: "m", baseURL: "http://x/v1",
+        _clientOverride: { chat: { completions: { create } } } as any,
+        _retryDelayMs: 0,
+      })("x".repeat(600), false, { onUsage }),
+    ).rejects.toThrow("empty content");
+    expect(onUsage).toHaveBeenCalledTimes(3);
+  });
+
+  it("requests cost accounting only from OpenRouter", async () => {
+    const router = makeClient("Summary.");
+    await createOpenAISummarizer({ model: "m", baseURL: "https://openrouter.ai/api/v1", _clientOverride: router as any })("text", false);
+    expect(router.chat.completions.create.mock.calls[0][0].usage).toEqual({ include: true });
+
+    const plain = makeClient("Summary.");
+    await createOpenAISummarizer({ model: "m", baseURL: "http://localhost:11435/v1", _clientOverride: plain as any })("text", false);
+    expect(plain.chat.completions.create.mock.calls[0][0]).not.toHaveProperty("usage");
+  });
 });


### PR DESCRIPTION
Closes #345

Rebased onto `main` now that #349 has merged; it is a single commit.

`ctx.onUsage` was called only by `claude-process`, so for every HTTP provider — the default path for anyone off the Claude CLI — lcm recorded no tokens and no cost for its own summarization calls.

- `src/llm/openai.ts` — forward `prompt_tokens` / `completion_tokens` / `total_tokens` and `prompt_tokens_details.cached_tokens`. OpenAI reports cached tokens as a subset of the prompt, which is already the normalized convention.
- `src/llm/anthropic.ts` — same, re-based: Anthropic's `input_tokens` is the *uncached* portion, so cache reads and creations are summed back into the full prompt and `cache_read` is the cached subset.
- Usage is reported **before** the empty-content check: a reasoning model that spends the whole budget thinking still charged for those tokens, and `compact.ts` already handles that via `sawUsage` in its catch.
- Cost stays provider-specific. Against an OpenRouter base URL the request asks for accounting (`usage: { include: true }`, host-scoped because plain servers reject unknown fields) and records the real charge; everywhere else `costUsd` is absent, which means *unknown*, never zero — the exact bug this came from.
- `test/bench/summarizer-eval-providers.ts` — the client override that captured usage is removed. Keeping it would fire `onUsage` twice per call and double the harness totals. The override now survives only for `chat_template_kwargs`, the one knob with no production path.
- Stale comments and docs updated: `types.ts` "Claude CLI only", `configuration.md` "Every process-backed provider", `summarizer-bench.md` "(see #345)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU