### PR TITLE
fix(search): stop session fusion from starving summaries

### DIFF
--- a/.changeset/summary-starvation-in-search.md
+++ b/.changeset/summary-starvation-in-search.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Stop search from hiding summaries. Session fusion emitted one message per matching session before reaching any summary, so whenever the number of matching sessions reached the result limit no summary could surface at all — however well it scored. Summaries now draw first against a reserved third of the limit, messages take the rest, and whichever side underfills hands its leftover to the other.

--- a/src/search/native-history.ts
+++ b/src/search/native-history.ts
@@ -78,10 +78,48 @@ function sourceContext(content: string, anchor: { start: number; length: number 
 }
 
 /**
+ * Share of the limit held for summaries before messages may take a slot.
+ *
+ * Message and summary ranks come from different FTS5 tables, so their bm25
+ * scores are not comparable and the two sources cannot be merged by score.
+ * Without a reserved share the round-robin below emits one message per
+ * matching session and exhausts the limit on its first pass, which makes a
+ * summary unreachable whenever the session count reaches the limit — however
+ * well it scores. Reserving is skipped at limit 1, where a single slot is
+ * better spent on the source the caller already expects.
+ */
+const SUMMARY_LIMIT_SHARE = 1 / 3;
+
+/** Round-robin over sessions in RRF order, one hit per session per pass. */
+function drawBySession(
+  hits: RankedHistoryHit[],
+  groups: string[],
+  groupOf: (hit: RankedHistoryHit) => string,
+  budget: number,
+): RankedHistoryHit[] {
+  const hitsOf = new Map<string, RankedHistoryHit[]>(groups.map(group => [group, []]));
+  for (const hit of hits) hitsOf.get(groupOf(hit))?.push(hit);
+  const drawn: RankedHistoryHit[] = [];
+  for (let pass = 0; drawn.length < budget; pass++) {
+    let emitted = false;
+    for (const group of groups) {
+      const hit = hitsOf.get(group)![pass];
+      if (!hit || drawn.length >= budget) continue;
+      drawn.push(hit);
+      emitted = true;
+    }
+    if (!emitted) break;
+  }
+  return drawn;
+}
+
+/**
  * Fuse message and summary candidates by session: a session scores the sum of
  * reciprocal ranks of its best message and best summary, so evidence present
- * in both sources rises. Emission is round-robin, one hit per session per
- * pass (messages before summaries), so a small limit spans several sessions.
+ * in both sources rises. Summaries draw first against a reserved share of the
+ * limit, messages take the rest, and whichever side underfills hands its
+ * leftover to the other. Emission stays round-robin, one hit per session per
+ * pass, so a small limit still spans several sessions.
  */
 export function fuseHistoryBySession(
   messages: RankedHistoryHit[],
@@ -100,20 +138,20 @@ export function fuseHistoryBySession(
     });
   }
   const groups = [...score.entries()].sort((a, b) => b[1] - a[1]).map(([group]) => group);
-  const hitsOf = new Map<string, RankedHistoryHit[]>(groups.map(group => [group, []]));
-  for (const hit of [...messages, ...summaries]) hitsOf.get(groupOf(hit))!.push(hit);
-  const fused: RankedHistoryHit[] = [];
-  for (let pass = 0; fused.length < limit; pass++) {
-    let emitted = false;
-    for (const group of groups) {
-      const hit = hitsOf.get(group)![pass];
-      if (!hit || fused.length >= limit) continue;
-      fused.push(hit);
-      emitted = true;
-    }
-    if (!emitted) break;
-  }
-  return fused;
+
+  const reserved = limit >= 2 ? Math.ceil(limit * SUMMARY_LIMIT_SHARE) : 0;
+  const drawnSummaries = drawBySession(summaries, groups, groupOf, reserved);
+  const drawnMessages = drawBySession(messages, groups, groupOf, limit - drawnSummaries.length);
+  // Messages that underfill hand the remainder back rather than shrinking the result.
+  const extraSummaries = drawnMessages.length + drawnSummaries.length < limit
+    ? drawBySession(summaries, groups, groupOf, limit - drawnMessages.length).slice(drawnSummaries.length)
+    : [];
+
+  const selected = new Set([...drawnSummaries, ...extraSummaries, ...drawnMessages]);
+  // Re-emit in session order, a session's messages ahead of its summaries, so
+  // the distilled hit sits next to the raw evidence it came from.
+  const ordered = [...messages, ...summaries].filter(hit => selected.has(hit));
+  return drawBySession(ordered, groups, groupOf, limit);
 }
 
 /** Rank one request's history candidates without loading source context. */

--- a/test/search/fusion.test.ts
+++ b/test/search/fusion.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { fuseHistoryBySession, type RankedHistoryHit } from "../../src/search/native-history.js";
+
+// Summaries are given a far better rank than any message, so a summary that
+// fails to surface has been hidden by the fusion structure, not outscored.
+const message = (session: string, i: number): RankedHistoryHit =>
+  ({ messageId: i, conversationId: i, sessionId: session, rank: -50 + i }) as RankedHistoryHit;
+const summary = (session: string, i: number): RankedHistoryHit =>
+  ({ summaryId: `s${i}`, conversationId: i, sessionId: session, rank: -99 }) as RankedHistoryHit;
+
+const sessions = (n: number) => Array.from({ length: n }, (_, i) => `sess-${i}`);
+const oneEach = (n: number) => {
+  const names = sessions(n);
+  return {
+    messages: names.map((s, i) => message(s, i)),
+    summaries: names.map((s, i) => summary(s, i)),
+  };
+};
+const countSummaries = (hits: RankedHistoryHit[]) => hits.filter((h) => "summaryId" in h).length;
+
+describe("fuseHistoryBySession", () => {
+  it.each([
+    [10, 10, 4],
+    [5, 5, 2],
+    [9, 10, 4],
+    [3, 10, 3],
+    [1, 10, 1],
+  ])("surfaces summaries with %i sessions at limit %i", (n, limit, expected) => {
+    const { messages, summaries } = oneEach(n);
+    // Before the reserved share, every case where sessions >= limit returned zero.
+    expect(countSummaries(fuseHistoryBySession(messages, summaries, limit))).toBe(expected);
+  });
+
+  it("spends a single slot on the message, as callers already expect", () => {
+    const { messages, summaries } = oneEach(3);
+    const hits = fuseHistoryBySession(messages, summaries, 1);
+    expect(hits).toHaveLength(1);
+    expect("messageId" in hits[0]).toBe(true);
+  });
+
+  it("gives the reserved share back to messages when no summary matched", () => {
+    const { messages } = oneEach(4);
+    const hits = fuseHistoryBySession(messages, [], 4);
+    expect(hits).toHaveLength(4);
+    expect(countSummaries(hits)).toBe(0);
+  });
+
+  it("lets summaries take the remainder when messages underfill", () => {
+    const summaries = sessions(5).map((s, i) => summary(s, i));
+    const hits = fuseHistoryBySession([message("sess-0", 0)], summaries, 5);
+    // One message exists; the other four slots must not be left empty.
+    expect(hits).toHaveLength(5);
+    expect(countSummaries(hits)).toBe(4);
+  });
+
+  it("returns only summaries when no message matched", () => {
+    const summaries = sessions(3).map((s, i) => summary(s, i));
+    expect(fuseHistoryBySession([], summaries, 5)).toHaveLength(3);
+  });
+
+  it("keeps a session's message ahead of its own summary", () => {
+    const hits = fuseHistoryBySession([message("a", 1)], [summary("a", 1)], 5);
+    expect(hits.map((h) => ("messageId" in h ? "message" : "summary"))).toEqual(["message", "summary"]);
+  });
+
+  it("still spreads a small limit across sessions before taking second hits", () => {
+    const messages = [message("a", 1), message("a", 2), message("b", 3)];
+    const hits = fuseHistoryBySession(messages, [], 2);
+    expect(new Set(hits.map((h) => h.sessionId))).toEqual(new Set(["a", "b"]));
+  });
+
+  it("never exceeds the limit and returns nothing at limit 0", () => {
+    const { messages, summaries } = oneEach(6);
+    expect(fuseHistoryBySession(messages, summaries, 0)).toEqual([]);
+    expect(fuseHistoryBySession(messages, summaries, 3)).toHaveLength(3);
+  });
+});


### PR DESCRIPTION
Closes #353

## The bug

`fuseHistoryBySession` appended every message ahead of every summary inside each session group, then emitted round-robin — one hit per session per pass. Pass 0 alone emits one hit per matching session, so once the session count reached the limit the budget was spent and no summary could be emitted, regardless of score. The default limit is 5.

Message and summary ranks come from different FTS5 tables and are not comparable, which is why the original code sidestepped merging them by score. That part of the reasoning was right; making the concession unconditional was the bug.

## The fix

Summaries draw first against a reserved third of the limit, messages take the rest, and whichever side underfills hands its leftover to the other. Emission stays round-robin over sessions in RRF order, and the session-level scoring is untouched — it was already sound.

Reserving is skipped at `limit === 1`, so the existing "message-before-summary ordering" guarantee at a single slot is preserved (`test/search/native-history.test.ts`).

`5 → 2` summary slots, `4 → 2`, `3 → 1`, `2 → 1`, `1 → 0`.

## Proof

`test/search/fusion.test.ts` (new, 12 cases) gives every summary rank -99 and every message -50 or worse, so any hiding is structural rather than a scoring artifact:

| sessions | limit | summaries before | after |
|---|---|---|---|
| 10 | 10 | 0 | 4 |
| 5 | 5 | 0 | 2 |
| 9 | 10 | 1 | 4 |
| 3 | 10 | 3 | 3 |

Plus: limit 1 stays a message, no-summaries hands the share back to messages, messages underfilling lets summaries take the remainder, summaries-only works, and the limit is never exceeded.

## End-to-end verification

Against this repo's own memory (94 imported sessions), the query from the issue at the default limit:

> porque é que decidimos não integrar o QMD e seguir com busca nativa

Before: 5 raw messages, zero summaries. After: `sum_3294ad67d34cb14e` — the condensed node that actually answers it — at position 4.

That summary's own text records the same diagnosis from an earlier session ("messages always ranked above summaries, hiding the relevant summary from top-5"), so the symptom was known; it was still present on `main`.

The recall gate (`test/search/recall-fixtures.test.ts`) passes unchanged. Full suite: 1270 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU