### PR TITLE
feat(stats): show summarizer usage in `lcm stats`

### DIFF
--- a/.changeset/stats-summarizer-section.md
+++ b/.changeset/stats-summarizer-section.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Show summarizer usage in `lcm stats`. The figures were already collected and stored but never rendered; a Summarizer section now reports calls, the token breakdown and the cost, appearing only once a call has been recorded. Cost follows the same rule as the replay receipt: `unknown` rather than `$0.00` when nothing reported a price, six decimals below a dollar, and "N of M calls priced" so a partial total cannot pass for a complete one.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -196,7 +196,7 @@ an array, `null` or a number is rejected at config load, not at request time.
 ### Token cost reporting
 
 Every provider reports its usage in a normalized shape, stored in
-`llm_usage_stats` and shown by `lcm import --replay`:
+`llm_usage_stats` and shown by `lcm import --replay` and `lcm stats`:
 
 | Provider | Input | Cached | Output | Extra |
 |---|---|---|---|---|

--- a/src/import-summary.ts
+++ b/src/import-summary.ts
@@ -1,14 +1,5 @@
 import type { ImportResult } from "./import.js";
-import { formatNumber, formatRatio } from "./stats.js";
-
-/**
- * Summarizer calls cost fractions of a cent, so two decimals would print a real
- * charge as "$0.00" — the same "absent reads as free" bug this figure exists to
- * kill. Sub-dollar amounts keep six decimals.
- */
-function formatUsd(n: number): string {
-  return n >= 1 ? `$${n.toFixed(2)}` : `$${n.toFixed(6)}`;
-}
+import { formatNumber, formatRatio, formatUsd } from "./stats.js";
 
 export function printImportSummary(
   result: ImportResult,

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -196,6 +196,15 @@ export function formatNumber(n: number): string {
   return String(n);
 }
 
+/**
+ * Summarizer calls cost fractions of a cent, so two decimals would print a
+ * real charge as "$0.00" — the same "absent reads as free" bug an unreported
+ * cost already guards against. Sub-dollar amounts keep six decimals.
+ */
+export function formatUsd(n: number): string {
+  return n >= 1 ? `$${n.toFixed(2)}` : `$${n.toFixed(6)}`;
+}
+
 export function formatRatio(before: number, after: number): string {
   if (before > 0 && after > 0) return (before / after).toFixed(1);
   return "\u2013";
@@ -287,6 +296,37 @@ export function printStats(stats: OverallStats, verbose: boolean): void {
     const empty = barWidth - filled;
     const bar = "█".repeat(filled) + "░".repeat(empty);
     console.log(`    ${" ".repeat(cLabelWidth)}  ${barColor}${bar}${reset}`);
+  }
+
+  // Summarizer section (only once the summarizer has reported a call)
+  if (stats.llmUsage.calls > 0) {
+    const usage = stats.llmUsage;
+    console.log();
+    console.log(sectionHeader("Summarizer"));
+    console.log();
+
+    const usageRows: [string, string][] = [
+      ["Calls", `${usage.calls} (${usage.okCalls} ok, ${usage.failedCalls} failed)`],
+      ["Tokens", formatNumber(usage.tokensSpent)],
+      [
+        "  breakdown",
+        `${formatNumber(usage.tokensInput)} in (${formatNumber(usage.tokensCached)} cached), ` +
+        `${formatNumber(usage.tokensOutput)} out`,
+      ],
+      [
+        "Cost",
+        // No priced call means nobody reported a figure, which is unknown;
+        // printing $0.00 here would claim the summarization was free.
+        usage.callsWithCost > 0 && usage.costUsd !== null
+          ? `${formatUsd(usage.costUsd)} ${dim}(${usage.callsWithCost} of ${usage.calls} calls priced)${reset}`
+          : `unknown ${dim}(0 of ${usage.calls} calls priced)${reset}`,
+      ],
+    ];
+
+    const uLabelWidth = Math.max(...usageRows.map(([l]) => l.length));
+    for (const [label, value] of usageRows) {
+      console.log(`    ${dim}${pad(label, uLabelWidth, "left")}${reset}  ${value}`);
+    }
   }
 
   // Security section (always shown)

--- a/test/stats.test.ts
+++ b/test/stats.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { formatNumber, formatRatio, printStats } from "../src/stats.js";
+import { formatNumber, formatRatio, formatUsd, printStats } from "../src/stats.js";
 
 describe("formatNumber", () => {
   it("returns plain digits for numbers below 1000", () => {
@@ -74,6 +74,17 @@ describe("printStats", () => {
     conversationDetails: [],
     redactionCounts: { builtIn: 0, global: 0, project: 0, total: 0 },
     recallStats: { memoriesSurfaced: 0, memoriesActedUpon: 0, recallPrecision: null, topRecalled: [] },
+    llmUsage: {
+      calls: 0, okCalls: 0, failedCalls: 0,
+      tokensSpent: 0, tokensInput: 0, tokensCached: 0, tokensOutput: 0,
+      costUsd: null, callsWithCost: 0,
+    },
+  };
+
+  const priced = {
+    calls: 76, okCalls: 76, failedCalls: 0,
+    tokensSpent: 1019754, tokensInput: 956517, tokensCached: 24512, tokensOutput: 63237,
+    costUsd: 0.08996142, callsWithCost: 76,
   };
 
   it("prints the lossless-claude header", () => {
@@ -234,5 +245,49 @@ describe("printStats", () => {
       },
     }, false));
     expect(out).toContain("Recall");
+  });
+  it("omits the Summarizer section until a call is recorded", () => {
+    const out = captureLog(() => printStats(baseStats, false));
+    expect(out).not.toContain("Summarizer");
+  });
+
+  it("prints calls, tokens and cost once the summarizer has run", () => {
+    const out = captureLog(() => printStats({ ...baseStats, llmUsage: priced }, false));
+    expect(out).toContain("Summarizer");
+    expect(out).toContain("76 (76 ok, 0 failed)");
+    expect(out).toContain("956.5k in (24.5k cached), 63.2k out");
+    expect(out).toContain("$0.089961");
+    expect(out).toContain("76 of 76 calls priced");
+  });
+
+  it("says unknown, never $0.00, when no call reported a price", () => {
+    const out = captureLog(() => printStats({
+      ...baseStats,
+      llmUsage: { ...priced, costUsd: null, callsWithCost: 0 },
+    }, false));
+    expect(out).toContain("unknown");
+    expect(out).toContain("0 of 76 calls priced");
+    expect(out).not.toContain("$");
+  });
+
+  it("flags a partially priced total rather than passing it off as complete", () => {
+    const out = captureLog(() => printStats({
+      ...baseStats,
+      llmUsage: { ...priced, costUsd: 0.0005, callsWithCost: 12 },
+    }, false));
+    expect(out).toContain("12 of 76 calls priced");
+  });
+});
+
+describe("formatUsd", () => {
+  it("keeps six decimals below a dollar so a sub-cent charge stays visible", () => {
+    // Two decimals would render this real GLM Flash charge as "$0.00".
+    expect(formatUsd(0.000082)).toBe("$0.000082");
+    expect(formatUsd(0.08996142)).toBe("$0.089961");
+  });
+
+  it("uses two decimals from a dollar up", () => {
+    expect(formatUsd(1)).toBe("$1.00");
+    expect(formatUsd(12.3456)).toBe("$12.35");
   });
 });


### PR DESCRIPTION
Follow-up to #351, which was scoped to persistence and deliberately left rendering out.

`collectStats` has always computed `llmUsage`; `printStats` has never rendered it. So the token counts — and, since #351, the cost — sat in `llm_usage_stats` with no way to read them from the CLI.

## Output

Against this repo's own memory, after the dogfood replay:

```
── Summarizer ────────────────────────────

Calls        76 (76 ok, 0 failed)
Tokens       1.0M
  breakdown  956.5k in (24.5k cached), 63.2k out
Cost         $0.089961 (76 of 76 calls priced)
```

The section follows the existing conditional pattern — it appears only once a call has been recorded, the way Compression waits for a summary.

## Cost rendering

Identical rule to the replay receipt, so `formatUsd` moves to `stats.ts` and `import-summary.ts` imports it rather than keeping a second copy:

- six decimals below a dollar — two would print a real GLM Flash charge as `$0.00`
- `unknown (0 of N calls priced)` when nothing reported a figure, never `$0.00`
- `N of M calls priced` so a partially priced total cannot pass for a complete one

## Note

The `printStats` test fixture was missing `llmUsage` altogether, which is why nothing caught the missing section. Fixed, with 6 new tests covering the priced, unknown, partial and omitted-section cases plus `formatUsd` directly.

`docs/configuration.md` now says `lcm stats` alongside `lcm import --replay`.

Full suite: 1276 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU