### PR TITLE
test(search): run the recall gate through the real /search path

### DIFF
--- a/.changeset/recall-gate-real-search-path.md
+++ b/.changeset/recall-gate-real-search-path.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Point the recall gate at the search path it claims to measure. It ranked sessions by concatenating `RetrievalEngine.grep` candidates by hand, skipping session fusion, the result limit and selection — the stages a caller actually receives — so a fusion bug passed it green in both directions. It now calls `searchNativeHistory`, and a new case covers the message/summary mix that session-level recall is blind to.

--- a/test/search/recall-fixtures.test.ts
+++ b/test/search/recall-fixtures.test.ts
@@ -236,11 +236,11 @@ describe("recall fixtures", () => {
     });
 
     /**
-     * Ranks sessions through the daemon's own `/search` entry point, so the
-     * gate measures what a caller receives rather than what the candidate
-     * layer produces. Concatenating the two candidate lists by hand — as this
-     * did — skips session fusion, the limit and selection entirely, which is
-     * how a fusion bug once passed the gate green in both directions.
+     * Ranks sessions through the same implementation used by the daemon's `/search` episodic layer, so the
+     * gate measures what a caller receives rather than what the candidate layer produces.
+     * Concatenating the two candidate lists by hand — as this did — skips session fusion,
+     * the result limit, and snippet selection entirely, which is how a fusion bug once
+     * passed the gate green in both directions.
      */
     async function searchSessionRanking(question: string): Promise<string[]> {
       const all = await searchNativeHistory(db, { query: question, limit: RECALL_K });

--- a/test/search/recall-fixtures.test.ts
+++ b/test/search/recall-fixtures.test.ts
@@ -6,6 +6,7 @@ import { runLcmMigrations } from "../../src/db/migration.js";
 import { ConversationStore } from "../../src/store/conversation-store.js";
 import { SummaryStore } from "../../src/store/summary-store.js";
 import { RetrievalEngine } from "../../src/retrieval.js";
+import { searchNativeHistory } from "../../src/search/native-history.js";
 import { extractQueryTerms } from "../../src/store/fts5-query.js";
 
 /**
@@ -19,6 +20,11 @@ import { extractQueryTerms } from "../../src/store/fts5-query.js";
  * These fixtures prove no regression. They are NOT a quality score — the
  * corpus is small, clean, and nothing like a real one. Real numbers come
  * from `lcm bench` (Layer 2) against a user's own sessions.
+ *
+ * Recall here is measured at session level, which is deliberately blind to
+ * which kind of hit answered: every fixture summary is the concatenation of
+ * its own messages, so it never carries evidence a message lacks. Properties
+ * about the mix of messages and summaries need their own case.
  */
 
 const FIXTURES_DIR = join(__dirname, "..", "fixtures", "recall");
@@ -184,7 +190,7 @@ describe("recall fixtures", () => {
     }
   });
 
-  describe("recall gate (runs the same /search episodic path as the daemon)", () => {
+  describe("recall gate (runs the daemon's /search episodic path end to end)", () => {
     let db: DatabaseSync;
     let stemmer: DatabaseSync;
     // Seed: one conversation + leaf summary per fixture session.
@@ -229,13 +235,15 @@ describe("recall fixtures", () => {
       stemmer?.close();
     });
 
+    /**
+     * Ranks sessions through the daemon's own `/search` entry point, so the
+     * gate measures what a caller receives rather than what the candidate
+     * layer produces. Concatenating the two candidate lists by hand — as this
+     * did — skips session fusion, the limit and selection entirely, which is
+     * how a fusion bug once passed the gate green in both directions.
+     */
     async function searchSessionRanking(question: string): Promise<string[]> {
-      const engine = new RetrievalEngine(
-        new ConversationStore(db),
-        new SummaryStore(db),
-      );
-      const result = await engine.grep({ query: question, mode: "full_text", scope: "both" });
-      const all = [...result.messages, ...result.summaries];
+      const all = await searchNativeHistory(db, { query: question, limit: RECALL_K });
       const ranking: string[] = [];
       const seen = new Set<string>();
       for (const match of all) {
@@ -329,6 +337,42 @@ describe("recall fixtures", () => {
         p95,
         `p95 query latency ${p95.toFixed(1)}ms above ${P95_LATENCY_MS}ms`,
       ).toBeLessThanOrEqual(P95_LATENCY_MS);
+    });
+
+    /**
+     * Session-level recall cannot see #353: it asks which sessions came back,
+     * and every fixture summary is the concatenation of its own messages, so a
+     * summary never carries evidence a message lacks. This case supplies the
+     * missing shape — more matching sessions than the limit — and asserts the
+     * result is not all messages. It fails on the pre-#354 fusion.
+     */
+    it("returns summaries when every matching session also has a matching message", async () => {
+      const starved = new DatabaseSync(":memory:");
+      try {
+        runLcmMigrations(starved);
+        const convStore = new ConversationStore(starved);
+        const summStore = new SummaryStore(starved);
+        // One more session than the limit, each with both kinds of evidence.
+        for (let i = 0; i < RECALL_K + 1; i++) {
+          const conv = await convStore.createConversation({ sessionId: `starved-${i}` });
+          await convStore.createMessagesBulk([{
+            conversationId: conv.conversationId, seq: 0, role: "user",
+            content: "The saffron rollout stalled again.", tokenCount: 10,
+          }]);
+          await summStore.insertSummary({
+            summaryId: `sum_starved_${i}`, conversationId: conv.conversationId, kind: "condensed",
+            content: "Decision: the saffron rollout was paused pending a rewrite.", tokenCount: 12,
+          });
+        }
+        const hits = await searchNativeHistory(starved, { query: "saffron", limit: RECALL_K });
+        expect(hits).toHaveLength(RECALL_K);
+        expect(
+          hits.filter((hit) => "summaryId" in hit).length,
+          "every slot went to a message; summaries are starved by the fusion",
+        ).toBeGreaterThan(0);
+      } finally {
+        starved.close();
+      }
     });
 
     it("single-keyword lookups still work (issue's control queries)", async () => {


### PR DESCRIPTION
Closes #356

The gate was labelled `runs the same /search episodic path as the daemon` while calling `RetrievalEngine.grep` and concatenating its two candidate lists by hand — skipping session fusion, the limit and selection. It is why #353 passed green both before and after its own fix.

## Recall is unchanged

| | before (`engine.grep`) | after (`searchNativeHistory`) |
|---|---|---|
| recall@5 | 28/30 (0.93) | 28/30 (0.93) |
| grep baseline | 25/30 (0.83) | 25/30 (0.83) |
| empty rate | 7% | 7% |
| p95 | 0.8 ms | 6.0 ms |

Same two misses, both stopword-heavy phrasings. No threshold re-baseline needed; latency stays two orders of magnitude under the 500 ms bound.

## Identical numbers are the finding, not a null result

Session-level recall asks *which sessions came back*. Every fixture summary is seeded as the concatenation of its own messages, so a summary can never carry evidence its messages lack — the metric is structurally blind to which kind of hit answered. Wiring the real path is therefore necessary but not sufficient, and the gate would still not have caught #353.

So the gate also gets the missing shape: **more matching sessions than the limit, each with both a matching message and a matching summary**. That is #353 exactly.

Verified by reverting `src/search/native-history.ts` to its pre-#354 state:

```
× returns summaries when every matching session also has a matching message
  → every slot went to a message; summaries are starved by the fusion:
    expected 0 to be greater than 0
```

and it passes on current `main`.

The file's docstring now records the session-level blind spot, so the next person does not assume this corpus covers hit-mix properties.

Full suite: 1277 passing.

## Still open

`test/bench/real-corpus.test.ts` has the right thresholds against a reviewed real benchmark and is `describe.skipIf(!file || !cwd)` with nothing to run against. That is the remaining gap between "no regression" and a number worth quoting; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU