### PR TITLE
chore(release): publish through npm trusted publishing

### DIFF
--- a/.changeset/npm-trusted-publishing.md
+++ b/.changeset/npm-trusted-publishing.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Publish through npm trusted publishing (OIDC) instead of a stored token. 2FA-bypass automation tokens lose direct publish around January 2027, and the stored one had already expired. The workflow now authenticates as itself through the OIDC token it was already granted, and `docs/releasing.md` records the setup.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,17 +75,21 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         run: npm test
 
-      - name: Verify npm identity
+      # Trusted publishing (OIDC) needs npm 11.5.1+; Node 22 ships npm 10.x.
+      # Upgraded only here, after the build and tests have run on the stock
+      # npm, so the release artifact is built exactly as CI builds it. Pinned
+      # below 12, whose install defaults (allowScripts off) would change how
+      # dependencies install.
+      - name: Upgrade npm for trusted publishing
         if: steps.check.outputs.skip == 'false'
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm install -g npm@^11.5.1
 
-      - name: Publish to npm
+      # No NODE_AUTH_TOKEN: the registry authenticates the workflow itself
+      # through the OIDC token granted by `id-token: write`. 2FA-bypass
+      # automation tokens lose direct publish around January 2027.
+      - name: Publish to npm via trusted publishing
         if: steps.check.outputs.skip == 'false'
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Create and push release tag
         if: steps.check.outputs.skip == 'false'

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,6 +20,17 @@ GitHub Actions publisher:
 The environment must match the `environment:` key on the publish job, or the
 registry rejects the token.
 
+**Tick "Allow `npm publish`".** Without it the publisher may only run
+`npm stage publish`, which parks the release until someone approves it on
+npmjs.com; the workflow calls `npm publish` directly and would fail.
+
+Then, under **Publishing access**, select *Require two-factor authentication
+and disallow bypass 2fa tokens*. Trusted publishers work under either option,
+so this only closes the stored-token path, which nothing uses any more. Do it
+after the first successful OIDC publish, so the tightening follows proof that
+the new path works. Interactive publishing with a 2FA code still works, so
+there is no way to lock yourself out.
+
 ## Cutting a release
 
 1. Merge the changesets version PR (opened automatically by `version-pr.yml`),

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,52 @@
+# Releasing
+
+Publishing runs from `main` through `.github/workflows/publish.yml`, and is
+authenticated by **trusted publishing (OIDC)** — no npm token is stored
+anywhere. The registry verifies the workflow's own identity, granted by
+`permissions: id-token: write`.
+
+## One-time npm setup
+
+On npmjs.com, under the package's **Settings → Trusted publishing**, add a
+GitHub Actions publisher:
+
+| Field | Value |
+|---|---|
+| Organization or user | `lossless-claude` |
+| Repository | `lcm` |
+| Workflow filename | `publish.yml` |
+| Environment | `npm-publish` |
+
+The environment must match the `environment:` key on the publish job, or the
+registry rejects the token.
+
+## Cutting a release
+
+1. Merge the changesets version PR (opened automatically by `version-pr.yml`),
+   or bump the version by hand across `package.json`, `package-lock.json`,
+   `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, and move
+   the CHANGELOG's top section to the release date.
+2. The push to `main` publishes, because the workflow watches `package.json`.
+   Run it manually with `gh workflow run publish.yml --ref main` when the
+   version file did not change in that push.
+3. The workflow skips a version already on npm or already tagged, so an
+   ordinary merge is a no-op and a re-run after a failure is safe.
+
+It publishes, then tags `vX.Y.Z`, then opens the GitHub release with the
+CHANGELOG section. A failure before the publish step leaves no tag behind.
+
+## Why not a token
+
+npm granular access tokens that bypass 2FA lose the ability to publish
+directly around January 2027, and already cannot perform account or package
+management. Trusted publishing replaces them and expires nothing.
+
+## Local publishing
+
+Only as a fallback, and it needs an interactive 2FA code:
+
+```bash
+npm publish --access public --otp=<code>
+```
+
+Then create the tag and release by hand, which the workflow would otherwise do.


### PR DESCRIPTION
Follows the [npm GAT bypass2fa deprecation](https://github.blog/changelog/2026-07-08-npm-install-time-security-and-gat-bypass2fa-deprecation/).

## Why

The dispatched publish run reached `npm whoami` with `NODE_AUTH_TOKEN` set (masked in the log, so the secret exists) and got a **401** — the stored `NPM_TOKEN` is expired.

Rotating it buys little. Per the changelog, 2FA-bypass granular access tokens:

- **already** cannot perform account, package or organization management (took effect early August 2026);
- **lose direct publish around January 2027**, reduced to staging a publish that a human then approves with 2FA.

The recommended replacement is trusted publishing (OIDC).

## What changed

`permissions: id-token: write` was already on the job, so the registry can authenticate the workflow itself. Removed:

- `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` from the publish step
- the `Verify npm identity` step — `npm whoami` exists to prove a token works, and there is no longer a token

Added an npm upgrade, because OIDC needs **npm 11.5.1+** and Node 22 ships npm 10.9.x. It runs *after* build and tests, so the release artifact is still produced by the same npm every other workflow uses, and is pinned below 12 — npm v12 turns `allowScripts` off by default, which would change how dependencies install.

## One manual step before this works

On npmjs.com, package **Settings → Trusted publishing**, add a GitHub Actions publisher:

| Field | Value |
|---|---|
| Organization or user | `lossless-claude` |
| Repository | `lcm` |
| Workflow filename | `publish.yml` |
| Environment | `npm-publish` |

The environment has to match the job's `environment:` key or the registry rejects the token. Once configured, `NPM_TOKEN` can be deleted from the `npm-publish` environment.

## Also

`docs/releasing.md` — the flow had no written record, which is part of how it drifted for six months.

Stacked on #359, which repaired the workflow's trigger, step order and ripgrep dependency. v0.10.0 is still unpublished; after this merges and the publisher is configured, `gh workflow run publish.yml --ref main` ships it with no credential involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU