### PR TITLE
fix(bench): report a labelled-session hit rate over unique evidence

### DIFF
--- a/.changeset/bench-labelled-session-hit-rate.md
+++ b/.changeset/bench-labelled-session-hit-rate.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Report what `lcm bench` actually measures. The `--json` report exposed a single-source hit rate under the name `searchRecall`, and `bench build` sampled any user prompt — including harness boilerplate and text repeated across sessions, neither of which a single source label can score: search can return a genuinely correct session and be counted as a miss. `build` now only samples prompts whose text occurs in exactly one session, questions take an optional `sessionIds` list whose every entry scores as a hit, and the report fields are `searchHitRate` and `grepHitRate` with `hit@k` in the human output.

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -221,7 +221,7 @@ async function createDaemonClientOrExit(): Promise<DaemonClient> {
 export function registerBenchCommands(program: Command): void {
   // ─── bench ─────────────────────────────────────────────────────────────────
   const benchCmd = new Command("bench").description(
-    "Build and run a natural-language recall benchmark from this project's ingested sessions",
+    "Build and run a natural-language retrieval benchmark from this project's ingested sessions",
   );
   benchCmd.action(() => { benchCmd.outputHelp(); });
 
@@ -248,7 +248,7 @@ export function registerBenchCommands(program: Command): void {
     .command("run")
     .description("Run the benchmark against search and a grep baseline")
     .option("--project <path>", "Project directory (default: cwd)")
-    .option("--k <n>", "Recall cutoff (default: 5)", "5")
+    .option("--k <n>", "Hit-rate cutoff (default: 5)", "5")
     .option("--bench-file <file>", "Benchmark file path (default: project memory directory)")
     .option("--json", "Output structured JSON")
     .action(async (opts) => {

--- a/docs/design/search-infrastructure.md
+++ b/docs/design/search-infrastructure.md
@@ -32,7 +32,7 @@ Current implementation anchors:
 | [prompt-search route](../../src/daemon/routes/prompt-search.ts) | Searches promoted memories only; owns recency, feedback, cooldown and context packing. |
 | [retrieval](../../src/retrieval.ts) | Provides grep, describe and summary expansion; preserves within-source relevance after the recent fix. |
 | [conversation store](../../src/store/conversation-store.ts), [summary store](../../src/store/summary-store.ts) | Duplicate FTS preparation, filtering and fallback policies. |
-| [benchmark](../../src/bench.ts) | Independently builds a session ranking; its single-source hit metric is not full evidence recall. |
+| [benchmark](../../src/bench.ts) | Independently builds a session ranking; its labelled-session hit metric is not full evidence recall. |
 | [query preparation](../../src/store/fts5-query.ts) | English stopwords and AND→OR fallback; no semantic understanding. |
 | [import](../../src/import.ts), [Codex parser](../../src/codex-transcript.ts) | Coverage depends on explicit runtime selection and retained event types. |
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -57,17 +57,19 @@ layer errors are logged with `console.warn` and surfaced in the response as
 `{ "episodic": [...], "promoted": [...], "errors": ["episodic: …"] }`. An empty result set with an
 `errors` key means something broke; an empty result set without it means nothing matched.
 
-## Measuring recall: `lcm bench`
+## Measuring retrieval: `lcm bench`
 
 The synthetic fixtures in `test/fixtures/recall/` prove the pipeline works, but they are small and
-clean. Real recall numbers come from your own ingested sessions:
+clean. Real numbers come from your own ingested sessions:
 
 ```bash
 lcm bench build --project /path/to/project --n 20 --generator llm
 lcm bench run   --project /path/to/project
 ```
 
-- **`build`** samples ingested conversations and paraphrases one user prompt per session.
+- **`build`** samples ingested conversations and paraphrases one user prompt per session. Only
+  prompts whose text occurs in exactly one session are sampled; harness boilerplate and repeated
+  prompts are skipped, because neither can anchor a single-label question.
   `--generator llm` calls your configured summarizer (including its local OpenAI-compatible endpoint).
   Disabled or mock summarizers cannot produce an LLM benchmark; provider failures do not silently
   switch to mechanical questions. Review generated questions for a specific subject, correct source
@@ -83,14 +85,15 @@ lcm bench run   --project /path/to/project
 
   | metric | what it tells you |
   |---|---|
-  | `recall@5` (search) | single-source hit@5: fraction whose recorded source session appears in the top 5 |
-  | `recall@5` (grep) | real ripgrep over the same retained messages, summaries and promoted memories, ranked by matched terms then occurrences; falls back to a labelled SQLite LIKE baseline when `rg` is missing. Not raw-JSONL grep |
+  | `hit@5` (search) | fraction of questions whose labelled session appears in the top 5 |
+  | `hit@5` (grep) | real ripgrep over the same retained messages, summaries and promoted memories, ranked by matched terms then occurrences; falls back to a labelled SQLite LIKE baseline when `rg` is missing. Not raw-JSONL grep |
   | empty-result rate | fraction returning zero results — the worst failure mode |
   | p95 latency | a retrieval path slower than reading the file is not worth calling |
 
-  The metric named `recall@5` is a single-source hit rate, not complete relevance recall:
-  another session may also answer the question. Review and record those cases before interpreting
-  misses. Ground truth from one sampled prompt cannot prove that its session is the only valid answer.
+  The reported `searchHitRate` and `grepHitRate` are labelled-session hit rates, not complete
+  relevance recall: a session outside the labels may also answer the question. When review finds
+  such a session, add it to the query's optional `sessionIds` list — every session listed there is
+  scored as a hit alongside `sessionId`. Do not quote a hit rate as a recall figure.
   The grep baseline searches the retained corpus; results from external raw-JSONL grep are a different
   experiment and must not be compared as if the corpus and ranking were identical.
 
@@ -101,7 +104,7 @@ lcm bench run   --project /path/to/project
 Example output:
 
 ```text
-  recall@5  search 17/20 (85%)  vs  grep 12/20 (60%)
+  hit@5  search 17/20 (85%)  vs  grep 12/20 (60%)
   empty results  1/20 (5%)
   p95 latency    3.2ms
 ```
@@ -112,7 +115,8 @@ Real user wording and short lookups are first-class benchmark inputs. In a versi
 file, set each curated query's `generator` to `"manual"` (and the file-level `generator` to
 `"manual"` for an entirely curated set). Keep `id`, `sessionId`, `prompt`, and `question` on each
 entry: `sessionId` identifies the expected source, `prompt` records the source/context, and
-`question` is the exact query to run. The prompt may equal the query.
+`question` is the exact query to run. The prompt may equal the query. Add `sessionIds` when other
+sessions answer the question too; each one counts as a hit.
 
 Manual queries require nonempty text and a nonempty source session; duplicate query text is
 rejected. They may contain actual copied user questions, short keywords, or identifiers such as

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -15,21 +15,27 @@ import { tmpdir } from "node:os";
 import { prepareRgCorpus, searchRg, type GrepDocument, type PreparedRgCorpus } from "./bench/rg-baseline.js";
 
 /**
- * Layer 2 recall benchmark (issue #309): build and run a natural-language
- * recall benchmark from the user's own ingested sessions — the only corpus
- * with realistic noise. Benchmark files are written next to the project DB
+ * Layer 2 retrieval benchmark: build and run a natural-language question set
+ * from the user's own ingested sessions — the only corpus with realistic
+ * noise. Benchmark files are written next to the project DB
  * (under ~/.lossless-claude) and never touch the repository.
  *
- * `build` samples user prompts and records their source sessions. Generated
- * questions need review: that source label does not prove an answer exists
- * or that no other session is relevant. Explicit LLM generation preserves
- * subject details; mechanical generation is diagnostic only. Curated manual
- * queries can retain the user's wording and exact identifiers.
+ * `build` only samples user prompts whose text occurs in exactly one session,
+ * so the recorded source label can anchor a single-label question. Generated
+ * questions still need review: unique evidence does not prove that no other
+ * session also answers the question — when one does, list it in `sessionIds`.
+ * Explicit LLM generation preserves subject details; mechanical generation is
+ * diagnostic only. Curated manual queries can retain the user's wording and
+ * exact identifiers.
+ *
+ * The scored metric is a labelled-session hit rate, not relevance recall.
  */
 
 export type BenchQuery = {
   id: string;
   sessionId: string;
+  /** Further sessions that also answer the question; scored as hits alongside `sessionId`. */
+  sessionIds?: string[];
   prompt: string;
   question: string;
   generator: "mechanical" | "llm" | "manual";
@@ -84,9 +90,22 @@ function mulberry32(seed: number): () => number {
 }
 
 /**
+ * Harness boilerplate the transcript records as user turns. It is neither
+ * something the user asked nor evidence of a subject, so it can never anchor
+ * a question.
+ */
+const BOILERPLATE_PROMPTS = [
+  /the user (doesn't|does not) want to proceed with this tool use/i,
+  /^\s*(error:\s*)?file does not exist/i,
+  /\[request interrupted by/i,
+  /^\s*api error/i,
+  /tool use was rejected/i,
+];
+
+/**
  * True when the prompt looks like a real instruction rather than noise:
- * slash commands, tool output pastes, XML-ish system blocks, and empty
- * shells are excluded.
+ * slash commands, tool output pastes, XML-ish system blocks, harness
+ * boilerplate, and empty shells are excluded.
  */
 function isDistinctivePrompt(content: string): boolean {
   const trimmed = content.trim();
@@ -95,6 +114,7 @@ function isDistinctivePrompt(content: string): boolean {
   if (/^\s*[{[]/.test(trimmed)) return false;
   if (/caveat: the messages below were generated/i.test(trimmed)) return false;
   if (/^\s*\[?\s*(tool|function)[_\s-]?(call|result|output)/i.test(trimmed)) return false;
+  if (BOILERPLATE_PROMPTS.some((pattern) => pattern.test(trimmed))) return false;
   // Must contain at least one content word that survives stopword removal.
   return extractQueryTerms(trimmed).length >= 2;
 }
@@ -208,8 +228,28 @@ function questionProblem(question: unknown, prompt: string, seen: Set<string>, m
 }
 
 /**
+ * User prompt texts that appear in more than one session. A question whose
+ * evidence is not unique cannot be scored against a single source label:
+ * search can return another session that genuinely contains it and still be
+ * counted as a miss.
+ */
+function repeatedPrompts(db: DatabaseSync): Set<string> {
+  const rows = db
+    .prepare(
+      `SELECT m.content AS content
+       FROM messages m
+       JOIN conversations c ON c.conversation_id = m.conversation_id
+       WHERE m.role = 'user'
+       GROUP BY m.content
+       HAVING COUNT(DISTINCT c.session_id) > 1`,
+    )
+    .all() as Array<{ content: string }>;
+  return new Set(rows.map((r) => r.content));
+}
+
+/**
  * Build the benchmark file: sample sessions, extract a distinctive user
- * prompt from each, and produce a question for review.
+ * prompt unique to each, and produce a question for review.
  * Pass `generateQuestion` to use the configured summarizer for paraphrasing;
  * without it, the mechanical fallback is used for every prompt.
  */
@@ -246,6 +286,7 @@ export async function buildBench(
       [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
     }
 
+    const repeated = repeatedPrompts(db);
     const queries: BenchQuery[] = [];
     const seenQuestions = new Set<string>();
     const rejected: string[] = [];
@@ -255,7 +296,7 @@ export async function buildBench(
       if (queries.length >= n) break;
       const messages = await convStore.getMessages(conv.conversationId);
       const candidates = messages.filter(
-        (m) => m.role === "user" && isDistinctivePrompt(m.content),
+        (m) => m.role === "user" && isDistinctivePrompt(m.content) && !repeated.has(m.content),
       );
       if (candidates.length === 0) continue;
       const prompt = candidates[Math.floor(rand() * candidates.length)];
@@ -319,7 +360,7 @@ export async function buildBench(
 type QueryOutcome = {
   id: string;
   question: string;
-  expectedSessionId: string;
+  expectedSessionIds: string[];
   searchTopK: string[];
   searchHit: boolean;
   empty: boolean;
@@ -378,7 +419,7 @@ async function rgSessionIds(baseline: RgBaseline, question: string, k: number): 
 
 export async function runBench(opts: BenchOptions): Promise<BenchResult> {
   const k = opts.k ?? 5;
-  if (!Number.isInteger(k) || k < 1) return { out: "", exitCode: 1, stdout: "Recall cutoff must be a positive integer.\n" };
+  if (!Number.isInteger(k) || k < 1) return { out: "", exitCode: 1, stdout: "Hit-rate cutoff must be a positive integer.\n" };
   const file = benchPath(opts.cwd, opts.benchFile);
   let bench: BenchFile;
   try {
@@ -395,6 +436,7 @@ export async function runBench(opts: BenchOptions): Promise<BenchResult> {
   const seenQuestions = new Set<string>();
   for (const q of bench.queries) {
     if (!q || typeof q.sessionId !== "string" || !q.sessionId.trim() || typeof q.prompt !== "string") return { out: "", exitCode: 1, stdout: "Invalid benchmark: each question needs a source session and prompt.\n" };
+    if (q.sessionIds !== undefined && (!Array.isArray(q.sessionIds) || q.sessionIds.some((s) => typeof s !== "string" || !s.trim()))) return { out: "", exitCode: 1, stdout: `Invalid benchmark question ${q.id}: sessionIds must be a list of nonempty session ids.\n` };
     const problem = questionProblem(q.question, q.prompt, seenQuestions, q.generator === "manual");
     if (problem) return { out: "", exitCode: 1, stdout: `Invalid benchmark question ${q.id}: ${problem}.\n` };
   }
@@ -447,14 +489,16 @@ export async function runBench(opts: BenchOptions): Promise<BenchResult> {
         }
       }
 
+      // Every labelled session answers the question, so any of them counts as a hit.
+      const accepted = new Set([q.sessionId, ...(q.sessionIds ?? [])]);
       const empty = sessionIds.length === 0;
-      const searchHit = sessionIds.slice(0, k).includes(q.sessionId);
+      const searchHit = sessionIds.slice(0, k).some((s) => accepted.has(s));
       const grepTopK = rgBaseline ? await rgSessionIds(rgBaseline, q.question, k) : grepSessionIds(db, q.question).slice(0, k);
-      const grepHit = grepTopK.includes(q.sessionId);
+      const grepHit = grepTopK.some((s) => accepted.has(s));
       outcomes.push({
         id: q.id,
         question: q.question,
-        expectedSessionId: q.sessionId,
+        expectedSessionIds: [...accepted],
         searchTopK: sessionIds.slice(0, k),
         searchHit,
         empty,
@@ -469,12 +513,12 @@ export async function runBench(opts: BenchOptions): Promise<BenchResult> {
     const emptyCount = outcomes.filter((o) => o.empty).length;
     const latencies = outcomes.map((o) => o.latencyMs).sort((a, b) => a - b);
     const p95 = latencies[Math.min(latencies.length - 1, Math.ceil(latencies.length * 0.95) - 1)] ?? 0;
-    const searchRecall = searchHits / total;
-    const grepRecall = grepHits / total;
+    const searchHitRate = searchHits / total;
+    const grepHitRate = grepHits / total;
 
     const report = {
       file,
-      metric: "single-source hit rate",
+      metric: "labelled-session hit rate",
       baseline: rgBaseline ? RG_BASELINE : SQL_BASELINE,
       warnings: [
         ...(bench.queries.some((q) => q.generator !== "llm" && q.generator !== "manual") ? ["Mechanical or unverified questions: diagnostic score, not release evidence."] : []),
@@ -482,13 +526,13 @@ export async function runBench(opts: BenchOptions): Promise<BenchResult> {
       ],
       total,
       k,
-      searchRecall,
-      grepRecall,
+      searchHitRate,
+      grepHitRate,
       emptyRate: emptyCount / total,
       p95LatencyMs: Math.round(p95 * 10) / 10,
       misses: outcomes
         .filter((o) => !o.searchHit)
-        .map((o) => ({ id: o.id, question: o.question, expected: o.expectedSessionId, got: o.searchTopK })),
+        .map((o) => ({ id: o.id, question: o.question, expected: o.expectedSessionIds, got: o.searchTopK })),
     };
 
     const resultsPath = join(dirname(dbPath), DEFAULT_RESULTS_FILENAME);
@@ -501,7 +545,7 @@ export async function runBench(opts: BenchOptions): Promise<BenchResult> {
     const lines = [
       "",
       ...report.warnings.map((warning) => `  Warning: ${warning}`),
-      `  recall@${k}  search ${searchHits}/${total} (${(searchRecall * 100).toFixed(0)}%)  vs  grep ${grepHits}/${total} (${(grepRecall * 100).toFixed(0)}%)`,
+      `  hit@${k}  search ${searchHits}/${total} (${(searchHitRate * 100).toFixed(0)}%)  vs  grep ${grepHits}/${total} (${(grepHitRate * 100).toFixed(0)}%)`,
       `  empty results  ${emptyCount}/${total} (${((emptyCount / total) * 100).toFixed(0)}%)`,
       `  p95 latency    ${report.p95LatencyMs}ms`,
       "",
@@ -509,7 +553,7 @@ export async function runBench(opts: BenchOptions): Promise<BenchResult> {
     if (report.misses.length > 0) {
       lines.push("  misses:");
       for (const m of report.misses) {
-        lines.push(`    ${m.id}  "${m.question}"  (wanted ${m.expected})`);
+        lines.push(`    ${m.id}  "${m.question}"  (wanted ${m.expected.join(", ")})`);
       }
       lines.push("");
     }

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -90,11 +90,14 @@ function mulberry32(seed: number): () => number {
 }
 
 /**
- * Harness boilerplate the transcript records as user turns. It is neither
- * something the user asked nor evidence of a subject, so it can never anchor
- * a question.
+ * User turns that are not something the user asked: slash commands, pasted
+ * tool output, XML-ish system blocks, and harness boilerplate. None of them
+ * names a subject, so none can anchor a question.
  */
-const BOILERPLATE_PROMPTS = [
+const REJECTED_PROMPTS = [
+  /^[<\/{[]/,
+  /caveat: the messages below were generated/i,
+  /^\s*\[?\s*(tool|function)[_\s-]?(call|result|output)/i,
   /the user (doesn't|does not) want to proceed with this tool use/i,
   /^\s*(error:\s*)?file does not exist/i,
   /\[request interrupted by/i,
@@ -102,20 +105,14 @@ const BOILERPLATE_PROMPTS = [
   /tool use was rejected/i,
 ];
 
-/**
- * True when the prompt looks like a real instruction rather than noise:
- * slash commands, tool output pastes, XML-ish system blocks, harness
- * boilerplate, and empty shells are excluded.
- */
+const MIN_PROMPT_LENGTH = 40;
+const MAX_PROMPT_LENGTH = 1200;
+
+/** True when the prompt is a real instruction carrying at least two content words. */
 function isDistinctivePrompt(content: string): boolean {
   const trimmed = content.trim();
-  if (trimmed.length < 40 || trimmed.length > 1200) return false;
-  if (trimmed.startsWith("<") || trimmed.startsWith("/")) return false;
-  if (/^\s*[{[]/.test(trimmed)) return false;
-  if (/caveat: the messages below were generated/i.test(trimmed)) return false;
-  if (/^\s*\[?\s*(tool|function)[_\s-]?(call|result|output)/i.test(trimmed)) return false;
-  if (BOILERPLATE_PROMPTS.some((pattern) => pattern.test(trimmed))) return false;
-  // Must contain at least one content word that survives stopword removal.
+  if (trimmed.length < MIN_PROMPT_LENGTH || trimmed.length > MAX_PROMPT_LENGTH) return false;
+  if (REJECTED_PROMPTS.some((pattern) => pattern.test(trimmed))) return false;
   return extractQueryTerms(trimmed).length >= 2;
 }
 
@@ -211,19 +208,31 @@ export async function configuredQuestionGenerator(): Promise<QuestionGenerator> 
   );
 }
 
-function questionProblem(question: unknown, prompt: string, seen: Set<string>, manual = false): string | null {
+const SUBJECTLESS_QUESTION = /^(what did we work on in that session|what was (this|that) (session|conversation) about)\??$/i;
+
+/** A question with no subject matches every session equally, so it scores nothing. */
+function isSubjectless(question: string): boolean {
+  const trimmed = question.trim();
+  return OUTCOME_FALLBACKS.some((fallback) => fallback.question === trimmed.toLowerCase()) || SUBJECTLESS_QUESTION.test(trimmed);
+}
+
+/** Checks only generated questions face; curated ones keep the user's own wording. */
+function generatedQuestionProblem(question: string, prompt: string): string | null {
+  const trimmed = question.trim();
+  if (trimmed.length < 15 || question.length > 500 || !trimmed.endsWith("?")) return "expected a single specific question ending in ?";
+  if (question.includes("\n") || prompt.toLowerCase().includes(trimmed.toLowerCase())) return "question must paraphrase the source prompt";
+  if (isSubjectless(question)) return "question has no identifiable subject";
+  return null;
+}
+
+/** Records the question in `seen` unless it has a problem. */
+function questionProblem(question: unknown, ctx: { prompt: string; seen: Set<string>; manual?: boolean }): string | null {
   if (typeof question !== "string" || !question.trim()) return "expected nonempty query text";
   const normalized = question.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, " ").trim() || question.trim();
-  if (seen.has(normalized)) return "duplicate question";
-  if (manual) {
-    seen.add(normalized);
-    return null;
-  }
-  if (question.trim().length < 15 || question.length > 500 || !question.trim().endsWith("?")) return "expected a single specific question ending in ?";
-  if (question.includes("\n") || prompt.toLowerCase().includes(question.trim().toLowerCase())) return "question must paraphrase the source prompt";
-  if (OUTCOME_FALLBACKS.some((fallback) => fallback.question === question.trim().toLowerCase())) return "question has no identifiable subject";
-  if (/^(what did we work on in that session|what was (this|that) (session|conversation) about)\??$/i.test(question.trim())) return "question has no identifiable subject";
-  seen.add(normalized);
+  if (ctx.seen.has(normalized)) return "duplicate question";
+  const problem = ctx.manual ? null : generatedQuestionProblem(question, ctx.prompt);
+  if (problem) return problem;
+  ctx.seen.add(normalized);
   return null;
 }
 
@@ -245,6 +254,75 @@ function repeatedPrompts(db: DatabaseSync): Set<string> {
     )
     .all() as Array<{ content: string }>;
   return new Set(rows.map((r) => r.content));
+}
+
+type SampledConversation = { conversationId: number; sessionId: string };
+
+type SampleContext = {
+  convStore: ConversationStore;
+  repeated: Set<string>;
+  seenQuestions: Set<string>;
+  rand: () => number;
+  generateQuestion?: QuestionGenerator;
+  requireLlm: boolean;
+};
+
+/**
+ * One sampling attempt. `aborted` is distinct from `rejected`: an explicit LLM
+ * generator that returns nothing must fail the whole build rather than quietly
+ * fall back to a mechanical question.
+ */
+type SampledQuery =
+  | { status: "sampled"; query: BenchQuery; usedLlm: boolean }
+  | { status: "rejected"; reason: string; usedLlm: boolean }
+  | { status: "skipped" }
+  | { status: "aborted"; stdout: string };
+
+/** Draw one reviewable question from a conversation, or say why none was drawn. */
+async function sampleQuery(conv: SampledConversation, ctx: SampleContext, id: string): Promise<SampledQuery> {
+  const messages = await ctx.convStore.getMessages(conv.conversationId);
+  const candidates = messages.filter(
+    (m) => m.role === "user" && isDistinctivePrompt(m.content) && !ctx.repeated.has(m.content),
+  );
+  if (candidates.length === 0) return { status: "skipped" };
+  const prompt = candidates[Math.floor(ctx.rand() * candidates.length)];
+
+  let question = ctx.generateQuestion ? await ctx.generateQuestion(prompt.content) : null;
+  const usedLlm = Boolean(question);
+  if (!question) {
+    if (ctx.requireLlm) return { status: "aborted", stdout: "LLM generator returned no question; benchmark was not written.\n" };
+    question = mechanicalQuestion(prompt.content, ctx.rand);
+  }
+
+  const problem = questionProblem(question, { prompt: prompt.content, seen: ctx.seenQuestions });
+  if (problem) return { status: "rejected", reason: problem, usedLlm };
+  return {
+    status: "sampled",
+    usedLlm,
+    query: { id, sessionId: conv.sessionId, prompt: prompt.content, question, generator: usedLlm ? "llm" : "mechanical" },
+  };
+}
+
+/** Deterministic Fisher-Yates, so a seed reproduces the same benchmark. */
+function shuffle<T>(items: T[], rand: () => number): T[] {
+  const shuffled = [...items];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(rand() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+}
+
+function benchGeneratorLabel(queries: BenchQuery[], usedLlm: boolean): string {
+  if (!usedLlm) return "mechanical";
+  return queries.every((q) => q.generator === "llm") ? "llm" : "llm+mechanical";
+}
+
+function formatBuildReport(bench: BenchFile, out: string, rejected: string[]): string {
+  const lines = [`Wrote ${bench.queries.length} benchmark questions (${bench.generator}) to ${out}`];
+  if (rejected.length > 0) lines.push(`Rejected ${rejected.length} invalid questions: ${rejected.join("; ")}`);
+  if (bench.generator.includes("mechanical")) lines.push("Warning: mechanical questions are diagnostic only; review questions before using scores as release evidence.");
+  return lines.join("\n") + "\n";
 }
 
 /**
@@ -279,53 +357,29 @@ export async function buildBench(
       return { out: "", exitCode: 1, stdout: "No conversations in the project database.\n" };
     }
 
-    // Deterministic shuffle, then walk until we have n usable prompts.
-    const shuffled = [...conversations];
-    for (let i = shuffled.length - 1; i > 0; i--) {
-      const j = Math.floor(rand() * (i + 1));
-      [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-    }
-
-    const repeated = repeatedPrompts(db);
-    const queries: BenchQuery[] = [];
-    const seenQuestions = new Set<string>();
-    const rejected: string[] = [];
     if (opts.generator === "llm" && !generateQuestion) generateQuestion = await configuredQuestionGenerator();
+    // Deterministic shuffle, then walk until we have n usable prompts.
+    const shuffled = shuffle(conversations, rand);
+    const ctx: SampleContext = {
+      convStore,
+      repeated: repeatedPrompts(db),
+      seenQuestions: new Set<string>(),
+      rand,
+      generateQuestion,
+      requireLlm: opts.generator === "llm",
+    };
+
+    const queries: BenchQuery[] = [];
+    const rejected: string[] = [];
     let usedLlm = false;
     for (const conv of shuffled) {
       if (queries.length >= n) break;
-      const messages = await convStore.getMessages(conv.conversationId);
-      const candidates = messages.filter(
-        (m) => m.role === "user" && isDistinctivePrompt(m.content) && !repeated.has(m.content),
-      );
-      if (candidates.length === 0) continue;
-      const prompt = candidates[Math.floor(rand() * candidates.length)];
-
-      let question: string | null = null;
-      let generator: BenchQuery["generator"] = "mechanical";
-      if (generateQuestion) {
-        question = await generateQuestion(prompt.content);
-        if (question) {
-          generator = "llm";
-          usedLlm = true;
-        }
-      }
-      if (!question) {
-        if (opts.generator === "llm") return { out: "", exitCode: 1, stdout: "LLM generator returned no question; benchmark was not written.\n" };
-        question = mechanicalQuestion(prompt.content, rand);
-      }
-      const problem = questionProblem(question, prompt.content, seenQuestions);
-      if (problem) {
-        rejected.push(`${conv.sessionId}: ${problem}`);
-        continue;
-      }
-      queries.push({
-        id: String(queries.length + 1).padStart(3, "0"),
-        sessionId: conv.sessionId,
-        prompt: prompt.content,
-        question,
-        generator,
-      });
+      const sampled = await sampleQuery(conv, ctx, String(queries.length + 1).padStart(3, "0"));
+      if (sampled.status === "aborted") return { out: "", exitCode: 1, stdout: sampled.stdout };
+      if (sampled.status === "skipped") continue;
+      usedLlm ||= sampled.usedLlm;
+      if (sampled.status === "rejected") rejected.push(`${conv.sessionId}: ${sampled.reason}`);
+      else queries.push(sampled.query);
     }
 
     if (queries.length === 0) {
@@ -340,16 +394,12 @@ export async function buildBench(
       version: 1,
       cwd: opts.cwd,
       generatedAt: new Date().toISOString(),
-      generator: usedLlm ? (queries.every((q) => q.generator === "llm") ? "llm" : "llm+mechanical") : "mechanical",
+      generator: benchGeneratorLabel(queries, usedLlm),
       queries,
     };
     const out = benchPath(opts.cwd, opts.out);
     await writeFile(out, JSON.stringify(bench, null, 2));
-    return {
-      out,
-      exitCode: 0,
-      stdout: `Wrote ${queries.length} benchmark questions (${bench.generator}) to ${out}\n${rejected.length ? `Rejected ${rejected.length} invalid questions: ${rejected.join("; ")}\n` : ""}${bench.generator.includes("mechanical") ? "Warning: mechanical questions are diagnostic only; review questions before using scores as release evidence.\n" : ""}`,
-    };
+    return { out, exitCode: 0, stdout: formatBuildReport(bench, out, rejected) };
   } finally {
     closeLcmConnection(dbPath);
   }
@@ -417,29 +467,146 @@ async function rgSessionIds(baseline: RgBaseline, question: string, k: number): 
   return sessionIds;
 }
 
-export async function runBench(opts: BenchOptions): Promise<BenchResult> {
-  const k = opts.k ?? 5;
-  if (!Number.isInteger(k) || k < 1) return { out: "", exitCode: 1, stdout: "Hit-rate cutoff must be a positive integer.\n" };
-  const file = benchPath(opts.cwd, opts.benchFile);
+type BenchLoad = { bench: BenchFile } | { error: string };
+
+function benchQueryProblem(query: BenchQuery, seen: Set<string>): string | null {
+  if (!query || typeof query.sessionId !== "string" || !query.sessionId.trim() || typeof query.prompt !== "string") return "Invalid benchmark: each question needs a source session and prompt.\n";
+  if (query.sessionIds !== undefined && (!Array.isArray(query.sessionIds) || query.sessionIds.some((s) => typeof s !== "string" || !s.trim()))) return `Invalid benchmark question ${query.id}: sessionIds must be a list of nonempty session ids.\n`;
+  const problem = questionProblem(query.question, { prompt: query.prompt, seen, manual: query.generator === "manual" });
+  return problem ? `Invalid benchmark question ${query.id}: ${problem}.\n` : null;
+}
+
+/** Parse and fully validate the benchmark before any search runs. */
+async function loadBenchFile(file: string): Promise<BenchLoad> {
   let bench: BenchFile;
   try {
     bench = JSON.parse(await readFile(file, "utf-8")) as BenchFile;
   } catch {
-    return {
-      out: "",
-      exitCode: 1,
-      stdout: `No benchmark file at ${file}.\nRun \`lcm bench build\` first.\n`,
-    };
+    return { error: `No benchmark file at ${file}.\nRun \`lcm bench build\` first.\n` };
   }
-
-  if (bench?.version !== 1 || !Array.isArray(bench.queries) || bench.queries.length === 0) return { out: "", exitCode: 1, stdout: "Invalid benchmark: expected version 1 with nonempty queries.\n" };
+  if (bench?.version !== 1 || !Array.isArray(bench.queries) || bench.queries.length === 0) return { error: "Invalid benchmark: expected version 1 with nonempty queries.\n" };
   const seenQuestions = new Set<string>();
-  for (const q of bench.queries) {
-    if (!q || typeof q.sessionId !== "string" || !q.sessionId.trim() || typeof q.prompt !== "string") return { out: "", exitCode: 1, stdout: "Invalid benchmark: each question needs a source session and prompt.\n" };
-    if (q.sessionIds !== undefined && (!Array.isArray(q.sessionIds) || q.sessionIds.some((s) => typeof s !== "string" || !s.trim()))) return { out: "", exitCode: 1, stdout: `Invalid benchmark question ${q.id}: sessionIds must be a list of nonempty session ids.\n` };
-    const problem = questionProblem(q.question, q.prompt, seenQuestions, q.generator === "manual");
-    if (problem) return { out: "", exitCode: 1, stdout: `Invalid benchmark question ${q.id}: ${problem}.\n` };
+  for (const query of bench.queries) {
+    const problem = benchQueryProblem(query, seenQuestions);
+    if (problem) return { error: problem };
   }
+  return { bench };
+}
+
+/** The ripgrep baseline, or the reason the run falls back to SQLite LIKE. */
+async function prepareRgBaseline(db: DatabaseSync, pid: string, directory: string): Promise<{ baseline?: RgBaseline; warning?: string }> {
+  try {
+    const baseline = await buildRgBaseline(db, pid, directory);
+    await searchRg(baseline.corpus, ["lcm"], 1);
+    return { baseline };
+  } catch (error) {
+    return { warning: `ripgrep baseline unavailable (${error instanceof Error ? error.message : String(error)}); grep column uses the SQLite LIKE fallback.` };
+  }
+}
+
+/** Search ranks rows; the bench scores sessions. Distinct sessions, in rank order. */
+function collectSessionIds(...groups: Array<Array<{ sessionId?: string | null }>>): string[] {
+  const ranked = groups.flat().map((hit) => hit.sessionId).filter((id): id is string => Boolean(id));
+  return [...new Set(ranked)];
+}
+
+type ScoreContext = {
+  db: DatabaseSync;
+  promotedStore: PromotedStore;
+  projectId: string;
+  rgBaseline?: RgBaseline;
+  k: number;
+};
+
+async function scoreQuery(query: BenchQuery, ctx: ScoreContext): Promise<QueryOutcome> {
+  const start = performance.now();
+  // The same ranking explicit search emits, so the bench measures what callers see.
+  const history = await rankNativeHistory(ctx.db, { query: query.question, limit: ctx.k });
+  const promoted = ctx.promotedStore.search(query.question, ctx.k, undefined, ctx.projectId);
+  const latencyMs = performance.now() - start;
+
+  const sessionIds = collectSessionIds(history, promoted);
+  const searchTopK = sessionIds.slice(0, ctx.k);
+  // Every labelled session answers the question, so any of them counts as a hit.
+  const accepted = new Set([query.sessionId, ...(query.sessionIds ?? [])]);
+  const grepTopK = ctx.rgBaseline
+    ? await rgSessionIds(ctx.rgBaseline, query.question, ctx.k)
+    : grepSessionIds(ctx.db, query.question).slice(0, ctx.k);
+
+  return {
+    id: query.id,
+    question: query.question,
+    expectedSessionIds: [...accepted],
+    searchTopK,
+    searchHit: searchTopK.some((s) => accepted.has(s)),
+    empty: sessionIds.length === 0,
+    grepHit: grepTopK.some((s) => accepted.has(s)),
+    latencyMs,
+  };
+}
+
+type ReportInput = {
+  file: string;
+  bench: BenchFile;
+  outcomes: QueryOutcome[];
+  k: number;
+  baseline: string;
+  baselineWarning?: string;
+};
+
+function buildReport({ file, bench, outcomes, k, baseline, baselineWarning }: ReportInput) {
+  const total = outcomes.length;
+  const latencies = outcomes.map((o) => o.latencyMs).sort((a, b) => a - b);
+  const p95 = latencies[Math.min(latencies.length - 1, Math.ceil(latencies.length * 0.95) - 1)] ?? 0;
+  return {
+    file,
+    metric: "labelled-session hit rate",
+    baseline,
+    warnings: [
+      ...(bench.queries.some((q) => q.generator !== "llm" && q.generator !== "manual") ? ["Mechanical or unverified questions: diagnostic score, not release evidence."] : []),
+      ...(baselineWarning ? [baselineWarning] : []),
+    ],
+    total,
+    k,
+    searchHitRate: outcomes.filter((o) => o.searchHit).length / total,
+    grepHitRate: outcomes.filter((o) => o.grepHit).length / total,
+    emptyRate: outcomes.filter((o) => o.empty).length / total,
+    p95LatencyMs: Math.round(p95 * 10) / 10,
+    misses: outcomes
+      .filter((o) => !o.searchHit)
+      .map((o) => ({ id: o.id, question: o.question, expected: o.expectedSessionIds, got: o.searchTopK })),
+  };
+}
+
+type BenchReport = ReturnType<typeof buildReport>;
+
+/** Human-readable summary. Counts come from the outcomes; the report carries only rates. */
+function renderReport(report: BenchReport, outcomes: QueryOutcome[], resultsPath: string): string {
+  const count = (predicate: (outcome: QueryOutcome) => boolean) => outcomes.filter(predicate).length;
+  const percent = (rate: number) => (rate * 100).toFixed(0);
+  const lines = [
+    "",
+    ...report.warnings.map((warning) => `  Warning: ${warning}`),
+    `  hit@${report.k}  search ${count((o) => o.searchHit)}/${report.total} (${percent(report.searchHitRate)}%)  vs  grep ${count((o) => o.grepHit)}/${report.total} (${percent(report.grepHitRate)}%)`,
+    `  empty results  ${count((o) => o.empty)}/${report.total} (${percent(report.emptyRate)}%)`,
+    `  p95 latency    ${report.p95LatencyMs}ms`,
+    "",
+  ];
+  if (report.misses.length > 0) {
+    lines.push("  misses:");
+    lines.push(...report.misses.map((m) => `    ${m.id}  "${m.question}"  (wanted ${m.expected.join(", ")})`));
+    lines.push("");
+  }
+  lines.push(`  full results written to ${resultsPath}`, "");
+  return lines.join("\n");
+}
+
+export async function runBench(opts: BenchOptions): Promise<BenchResult> {
+  const k = opts.k ?? 5;
+  if (!Number.isInteger(k) || k < 1) return { out: "", exitCode: 1, stdout: "Hit-rate cutoff must be a positive integer.\n" };
+  const file = benchPath(opts.cwd, opts.benchFile);
+  const loaded = await loadBenchFile(file);
+  if ("error" in loaded) return { out: "", exitCode: 1, stdout: loaded.error };
 
   const dbPath = projectDbPath(opts.cwd);
   if (!existsSync(dbPath)) {
@@ -452,113 +619,26 @@ export async function runBench(opts: BenchOptions): Promise<BenchResult> {
   const db = getLcmConnection(dbPath);
   try {
     runLcmMigrations(db);
-    const convStore = new ConversationStore(db);
-    const promotedStore = new PromotedStore(db);
     const pid = projectId(opts.cwd);
-
-    let rgBaseline: RgBaseline | undefined;
-    let baselineWarning: string | undefined;
-    try {
-      rgBaseline = await buildRgBaseline(db, pid, rgDir);
-      await searchRg(rgBaseline.corpus, ["lcm"], 1);
-    } catch (error) {
-      rgBaseline = undefined;
-      baselineWarning = `ripgrep baseline unavailable (${error instanceof Error ? error.message : String(error)}); grep column uses the SQLite LIKE fallback.`;
-    }
+    const { baseline, warning } = await prepareRgBaseline(db, pid, rgDir);
+    const ctx: ScoreContext = { db, promotedStore: new PromotedStore(db), projectId: pid, rgBaseline: baseline, k };
 
     const outcomes: QueryOutcome[] = [];
-    for (const q of bench.queries) {
-      const start = performance.now();
-      // The same ranking explicit search emits, so the bench measures what callers see.
-      const history = await rankNativeHistory(db, { query: q.question, limit: k });
-      const promoted = promotedStore.search(q.question, k, undefined, pid);
-      const latencyMs = performance.now() - start;
+    for (const query of loaded.bench.queries) outcomes.push(await scoreQuery(query, ctx));
 
-      const sessionIds: string[] = [];
-      const seen = new Set<string>();
-      for (const hit of history) {
-        if (hit.sessionId && !seen.has(hit.sessionId)) {
-          seen.add(hit.sessionId);
-          sessionIds.push(hit.sessionId);
-        }
-      }
-      for (const mem of promoted) {
-        if (mem.sessionId && !seen.has(mem.sessionId)) {
-          seen.add(mem.sessionId);
-          sessionIds.push(mem.sessionId);
-        }
-      }
-
-      // Every labelled session answers the question, so any of them counts as a hit.
-      const accepted = new Set([q.sessionId, ...(q.sessionIds ?? [])]);
-      const empty = sessionIds.length === 0;
-      const searchHit = sessionIds.slice(0, k).some((s) => accepted.has(s));
-      const grepTopK = rgBaseline ? await rgSessionIds(rgBaseline, q.question, k) : grepSessionIds(db, q.question).slice(0, k);
-      const grepHit = grepTopK.some((s) => accepted.has(s));
-      outcomes.push({
-        id: q.id,
-        question: q.question,
-        expectedSessionIds: [...accepted],
-        searchTopK: sessionIds.slice(0, k),
-        searchHit,
-        empty,
-        grepHit,
-        latencyMs,
-      });
-    }
-
-    const total = outcomes.length;
-    const searchHits = outcomes.filter((o) => o.searchHit).length;
-    const grepHits = outcomes.filter((o) => o.grepHit).length;
-    const emptyCount = outcomes.filter((o) => o.empty).length;
-    const latencies = outcomes.map((o) => o.latencyMs).sort((a, b) => a - b);
-    const p95 = latencies[Math.min(latencies.length - 1, Math.ceil(latencies.length * 0.95) - 1)] ?? 0;
-    const searchHitRate = searchHits / total;
-    const grepHitRate = grepHits / total;
-
-    const report = {
+    const report = buildReport({
       file,
-      metric: "labelled-session hit rate",
-      baseline: rgBaseline ? RG_BASELINE : SQL_BASELINE,
-      warnings: [
-        ...(bench.queries.some((q) => q.generator !== "llm" && q.generator !== "manual") ? ["Mechanical or unverified questions: diagnostic score, not release evidence."] : []),
-        ...(baselineWarning ? [baselineWarning] : []),
-      ],
-      total,
+      bench: loaded.bench,
+      outcomes,
       k,
-      searchHitRate,
-      grepHitRate,
-      emptyRate: emptyCount / total,
-      p95LatencyMs: Math.round(p95 * 10) / 10,
-      misses: outcomes
-        .filter((o) => !o.searchHit)
-        .map((o) => ({ id: o.id, question: o.question, expected: o.expectedSessionIds, got: o.searchTopK })),
-    };
-
+      baseline: baseline ? RG_BASELINE : SQL_BASELINE,
+      baselineWarning: warning,
+    });
     const resultsPath = join(dirname(dbPath), DEFAULT_RESULTS_FILENAME);
     await writeFile(resultsPath, JSON.stringify({ report, outcomes }, null, 2));
 
-    if (opts.json) {
-      return { out: resultsPath, exitCode: 0, stdout: JSON.stringify(report, null, 2) + "\n" };
-    }
-
-    const lines = [
-      "",
-      ...report.warnings.map((warning) => `  Warning: ${warning}`),
-      `  hit@${k}  search ${searchHits}/${total} (${(searchHitRate * 100).toFixed(0)}%)  vs  grep ${grepHits}/${total} (${(grepHitRate * 100).toFixed(0)}%)`,
-      `  empty results  ${emptyCount}/${total} (${((emptyCount / total) * 100).toFixed(0)}%)`,
-      `  p95 latency    ${report.p95LatencyMs}ms`,
-      "",
-    ];
-    if (report.misses.length > 0) {
-      lines.push("  misses:");
-      for (const m of report.misses) {
-        lines.push(`    ${m.id}  "${m.question}"  (wanted ${m.expected.join(", ")})`);
-      }
-      lines.push("");
-    }
-    lines.push(`  full results written to ${resultsPath}`, "");
-    return { out: resultsPath, exitCode: 0, stdout: lines.join("\n") };
+    if (opts.json) return { out: resultsPath, exitCode: 0, stdout: JSON.stringify(report, null, 2) + "\n" };
+    return { out: resultsPath, exitCode: 0, stdout: renderReport(report, outcomes, resultsPath) };
   } finally {
     closeLcmConnection(dbPath);
     await rm(rgDir, { recursive: true, force: true });

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -102,7 +102,6 @@ const REJECTED_PROMPTS = [
   /^\s*(error:\s*)?file does not exist/i,
   /\[request interrupted by/i,
   /^\s*api error/i,
-  /tool use was rejected/i,
 ];
 
 const MIN_PROMPT_LENGTH = 40;
@@ -349,6 +348,8 @@ export async function buildBench(
 
   const db = getLcmConnection(dbPath);
   try {
+    // Migrations may backfill on first open, so this handle is read-write.
+    runLcmMigrations(db);
     const convStore = new ConversationStore(db);
     const conversations = (await convStore.listConversations()).filter(
       (c) => c.sessionId.length > 0,

--- a/test/bench/bench.test.ts
+++ b/test/bench/bench.test.ts
@@ -99,6 +99,28 @@ async function seedProject(cwd: string): Promise<void> {
   }
 }
 
+/** Adds one-prompt sessions to an already seeded project. */
+async function addSessions(cwd: string, entries: Array<{ sessionId: string; prompt: string }>): Promise<void> {
+  const db = new DatabaseSync(projectDbPath(cwd));
+  try {
+    const convStore = new ConversationStore(db);
+    for (const entry of entries) {
+      const conv = await convStore.createConversation({ sessionId: entry.sessionId });
+      await convStore.createMessagesBulk([
+        {
+          conversationId: conv.conversationId,
+          seq: 0,
+          role: "user" as const,
+          content: entry.prompt,
+          tokenCount: Math.ceil(entry.prompt.length / 4),
+        },
+      ]);
+    }
+  } finally {
+    db.close();
+  }
+}
+
 describe("lcm bench", () => {
   it("accepts manually curated real wording and short identifier lookups", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "lcm-bench-"));
@@ -190,7 +212,7 @@ describe("lcm bench", () => {
     expect(result.stdout).toContain("No project database");
   });
 
-  it("run reports recall against the grep baseline", async () => {
+  it("run reports the hit rate against the grep baseline", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "lcm-bench-"));
     tempDirs.push(cwd);
     await seedProject(cwd);
@@ -200,7 +222,7 @@ describe("lcm bench", () => {
 
     const run = await runBench({ cwd, k: 5 });
     expect(run.exitCode).toBe(0);
-    expect(run.stdout).toContain("recall@5");
+    expect(run.stdout).toContain("hit@5");
     expect(run.stdout).toContain("grep");
     expect(run.stdout).toContain("empty results");
     expect(run.stdout).toContain("p95 latency");
@@ -217,14 +239,14 @@ describe("lcm bench", () => {
     expect(run.exitCode).toBe(0);
     const report = JSON.parse(run.stdout) as {
       total: number;
-      searchRecall: number;
-      grepRecall: number;
+      searchHitRate: number;
+      grepHitRate: number;
       emptyRate: number;
       p95LatencyMs: number;
     };
     expect(report.total).toBeGreaterThan(0);
-    expect(report.searchRecall).toBeGreaterThanOrEqual(0);
-    expect(report.grepRecall).toBeGreaterThanOrEqual(0);
+    expect(report.searchHitRate).toBeGreaterThanOrEqual(0);
+    expect(report.grepHitRate).toBeGreaterThanOrEqual(0);
     expect(report.emptyRate).toBeGreaterThanOrEqual(0);
   });
 
@@ -263,5 +285,58 @@ describe("lcm bench", () => {
       expect(q.question).not.toBe(q.prompt);
       expect(q.prompt).not.toContain(q.question);
     }
+  });
+
+  it("never samples a prompt that occurs in more than one session", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "lcm-bench-"));
+    tempDirs.push(cwd);
+    await seedProject(cwd);
+    const shared = "The Kubernetes ingress controller keeps dropping websocket upgrades after a rolling restart.";
+    await addSessions(cwd, [
+      { sessionId: "sess-dup-a", prompt: shared },
+      { sessionId: "sess-dup-b", prompt: shared },
+    ]);
+
+    const build = await buildBench({ cwd, n: 20, seed: 7 });
+    const bench = JSON.parse(readFileSync(build.out, "utf-8")) as BenchFile;
+    expect(bench.queries.some((q) => q.prompt === shared)).toBe(false);
+    expect(bench.queries.length).toBeGreaterThan(0);
+  });
+
+  it("never samples harness boilerplate as a prompt", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "lcm-bench-"));
+    tempDirs.push(cwd);
+    await seedProject(cwd);
+    const boilerplate = "The user doesn't want to proceed with this tool use. The tool use was rejected (eg. if it was a file edit, the new_string was NOT written to the file). STOP what you are doing and wait for the user to tell you how to proceed.";
+    await addSessions(cwd, [{ sessionId: "sess-boilerplate", prompt: boilerplate }]);
+
+    const build = await buildBench({ cwd, n: 20, seed: 3 });
+    const bench = JSON.parse(readFileSync(build.out, "utf-8")) as BenchFile;
+    expect(bench.queries.some((q) => q.prompt === boilerplate)).toBe(false);
+  });
+
+  it("counts any labelled session as a hit", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "lcm-bench-"));
+    tempDirs.push(cwd);
+    await seedProject(cwd);
+    const file = join(cwd, "manual.json");
+    const query = {
+      id: "multi",
+      sessionId: "sess-never-returned",
+      prompt: "Why did we choose SQLite for the memory daemon?",
+      question: "Why did we choose SQLite for the memory daemon?",
+      generator: "manual",
+    };
+
+    writeFileSync(file, JSON.stringify({ version: 1, queries: [query] }));
+    const single = await runBench({ cwd, benchFile: file, k: 5, json: true });
+    expect(JSON.parse(single.stdout).searchHitRate).toBe(0);
+
+    writeFileSync(file, JSON.stringify({ version: 1, queries: [{ ...query, sessionIds: ["sess-storage"] }] }));
+    const multi = await runBench({ cwd, benchFile: file, k: 5, json: true });
+    expect(JSON.parse(multi.stdout).searchHitRate).toBe(1);
+
+    writeFileSync(file, JSON.stringify({ version: 1, queries: [{ ...query, sessionIds: [" "] }] }));
+    expect((await runBench({ cwd, benchFile: file })).stdout).toContain("sessionIds must be a list");
   });
 });

--- a/test/bench/real-corpus.test.ts
+++ b/test/bench/real-corpus.test.ts
@@ -5,14 +5,14 @@ import { runBench } from "../../src/bench.js";
 const file = process.env.LCM_REAL_BENCH_FILE;
 const cwd = process.env.LCM_REAL_BENCH_PROJECT;
 
-describe.skipIf(!file || !cwd)("reviewed real-corpus recall gate", () => {
-  it("beats grep with useful recall and bounded empty rate and latency", async () => {
+describe.skipIf(!file || !cwd)("reviewed real-corpus hit-rate gate", () => {
+  it("beats grep with a useful hit rate and bounded empty rate and latency", async () => {
     expect(existsSync(file!)).toBe(true);
     const result = await runBench({ cwd: cwd!, benchFile: file, k: 5, json: true });
     expect(result.exitCode, result.stdout).toBe(0);
     const report = JSON.parse(result.stdout);
-    expect(report.searchRecall).toBeGreaterThanOrEqual(0.6);
-    expect(report.searchRecall).toBeGreaterThan(report.grepRecall);
+    expect(report.searchHitRate).toBeGreaterThanOrEqual(0.6);
+    expect(report.searchHitRate).toBeGreaterThan(report.grepHitRate);
     expect(report.emptyRate).toBeLessThanOrEqual(0.1);
     expect(report.p95LatencyMs).toBeLessThanOrEqual(500);
   });


### PR DESCRIPTION
## Changes

`searchRecall` was a single-source hit rate exposed under a recall name, and `bench build` sampled any user prompt — including harness boilerplate and text repeated across sessions, neither of which a single source label can score. Both halves of #358:

1. **Honest name.** The report now exposes `searchHitRate` / `grepHitRate`, `metric` reads `"labelled-session hit rate"`, and the human output prints `hit@k` instead of `recall@k`.
2. **Multi-label ground truth.** `BenchQuery` takes an optional `sessionIds: string[]`; every session listed there scores as a hit alongside `sessionId`, so a reviewed benchmark can record the other sessions that genuinely answer a question. Validated on load, backward compatible (version stays 1).
3. **Evidence filter in `build`.** One `GROUP BY content HAVING COUNT(DISTINCT session_id) > 1` pass collects prompts that occur in more than one session; those are skipped, as are known harness boilerplate turns ("The user doesn't want to proceed with this tool use", "File does not exist", "[Request interrupted…"). The uniqueness test is exact-text equality, one cheap `GROUP BY` pass instead of N pattern scans over a 41 MB corpus; the separate boilerplate list is anchored regexes. `buildBench` also runs migrations before it reads, as `runBench` already did.

4. **Refactor of `src/bench.ts`** (second commit, no behaviour change). `buildBench` and `runBench` were 101 and 147 lines with three levels of nesting. Split into named steps — `sampleQuery`, `loadBenchFile`, `prepareRgBaseline`, `scoreQuery`, `buildReport`, `renderReport` — the prompt rejection rules collapsed into one `REJECTED_PROMPTS` table, and `questionProblem` now takes a context object instead of four positional args. `sampleQuery` keeps `aborted` distinct from `rejected` so an explicit LLM generator returning nothing still fails the build.

**The `>= 0.6` real-corpus threshold is unchanged.** These fixes make the number honest; they do not move it. Tuning the gate down to the observed 0.54 is what the issue is complaining about, so it was left alone.

## Files Touched

- `src/bench.ts` — multi-label scoring, unique-evidence + boilerplate filter, renamed report fields, updated docstring; then split into intention-sized helpers
- `test/bench/bench.test.ts` — three new tests (repeated prompt never sampled, boilerplate never sampled, any labelled session counts as a hit) + `addSessions` helper; renamed field assertions
- `test/bench/real-corpus.test.ts` — gates on `searchHitRate`; threshold untouched
- `docs/search.md` — documents the filter, `sessionIds`, and that a hit rate is not a recall figure
- `docs/design/search-infrastructure.md` — one-line metric name fix

## Issue Reference

Closes #358

## Test Evidence

Full suite: `npx vitest run` → **1280 passed | 4 skipped (127 files)**. `npx tsc --noEmit` clean.

The refactor was golden-diffed against the real local 103-session corpus: same seed, same `--n`, and the benchmark file, the `build` stdout and the `--json` report all come back byte-identical before and after (only `generatedAt`, the output path and p95 latency differ).

All three new tests were mutation-checked — dropping the harness patterns from `REJECTED_PROMPTS` fails the boilerplate test, removing `!ctx.repeated.has(...)` fails the repeated-prompt test, and ignoring `sessionIds` fails the multi-label test.

`real-corpus.test.ts` stays `describe.skipIf` — it needs a local DB and a reviewed benchmark file CI cannot reach.

## Risks & Follow-ups

- The uniqueness filter is exact-text equality. A prompt that is near-duplicated across sessions (reworded, different whitespace) still passes; the issue's observed boilerplate was exact repeats.
- Running migrations in `buildBench` shifts which prompts qualify on a project whose DB was behind — that is the fix working, not a regression. The build stays deterministic for a given seed (verified across repeat runs).
- Fewer questions per `--n` on corpora heavy in repeated prompts. `build` already reports how many it produced.
- The new build tests share the existing suite's coupling to the PRNG seed (seed 3); adding fixture sessions shifts the stream. Same fragility every existing build test already has.
- Not addressed here: the 0.54 hit rate itself. That is a retrieval-quality question, not a measurement one.

## AR Status

[SKIP_AR: not requested]

## Introspection Findings

The first version of the boilerplate test was vacuous — the short fixture text had no capitalized identifier, so `mechanicalQuestion` already rejected it as subjectless and the test passed with the new filter disabled. Fixed by using the real harness string (it carries `NOT`/`STOP`, which survive into a valid question) and mutation-testing every new filter.

Mutation testing needs the whole rule group removed, not one line: the fixture matches two `REJECTED_PROMPTS` entries, so deleting only the first still passed.

## Token Cost

~190k tokens (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU

