### PR TITLE
fix(bench): count only scorable sessions when detecting repeated prompts

### DIFF
--- a/.changeset/bench-scorable-sessions-only.md
+++ b/.changeset/bench-scorable-sessions-only.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Count only scorable sessions when `lcm bench build` detects repeated prompts. The uniqueness pass grouped over every conversation while sampling draws only from conversations with a nonempty session id, so a prompt held once by a real session and once by a session-less conversation counted as two and was excluded — though it is unique among the sessions a question can be scored against.

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -240,6 +240,11 @@ function questionProblem(question: unknown, ctx: { prompt: string; seen: Set<str
  * evidence is not unique cannot be scored against a single source label:
  * search can return another session that genuinely contains it and still be
  * counted as a miss.
+ *
+ * Only sessions the sampler can draw from count towards the total — the same
+ * nonempty-session filter `buildBench` applies. Counting a session-less
+ * conversation would exclude a prompt that is in fact unique among scorable
+ * sessions.
  */
 function repeatedPrompts(db: DatabaseSync): Set<string> {
   const rows = db
@@ -247,7 +252,7 @@ function repeatedPrompts(db: DatabaseSync): Set<string> {
       `SELECT m.content AS content
        FROM messages m
        JOIN conversations c ON c.conversation_id = m.conversation_id
-       WHERE m.role = 'user'
+       WHERE m.role = 'user' AND c.session_id IS NOT NULL AND c.session_id != ''
        GROUP BY m.content
        HAVING COUNT(DISTINCT c.session_id) > 1`,
     )

--- a/test/bench/bench.test.ts
+++ b/test/bench/bench.test.ts
@@ -298,9 +298,28 @@ describe("lcm bench", () => {
     ]);
 
     const build = await buildBench({ cwd, n: 20, seed: 7 });
+    expect(build.exitCode, build.stdout).toBe(0);
     const bench = JSON.parse(readFileSync(build.out, "utf-8")) as BenchFile;
     expect(bench.queries.some((q) => q.prompt === shared)).toBe(false);
     expect(bench.queries.length).toBeGreaterThan(0);
+  });
+
+  it("counts only sessions the sampler can draw from as repeats", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "lcm-bench-"));
+    tempDirs.push(cwd);
+    await seedProject(cwd);
+    // Unique among scorable sessions: the second copy lives in a conversation
+    // with no session id, which buildBench never samples.
+    const unique = "The Redis eviction policy is dropping hot keys under memory pressure and the cache hit ratio collapsed overnight.";
+    await addSessions(cwd, [
+      { sessionId: "sess-cache", prompt: unique },
+      { sessionId: "", prompt: unique },
+    ]);
+
+    const build = await buildBench({ cwd, n: 20, seed: 7 });
+    expect(build.exitCode, build.stdout).toBe(0);
+    const bench = JSON.parse(readFileSync(build.out, "utf-8")) as BenchFile;
+    expect(bench.queries.some((q) => q.prompt === unique)).toBe(true);
   });
 
   it("never samples harness boilerplate as a prompt", async () => {


### PR DESCRIPTION
## Changes

`repeatedPrompts` grouped over every conversation in the project:

```sql
WHERE m.role = 'user'
GROUP BY m.content
HAVING COUNT(DISTINCT c.session_id) > 1
```

But `buildBench` samples only conversations with a nonempty session id (`.filter((c) => c.sessionId.length > 0)`). So a prompt held once by a real session and once by a session-less conversation counted as two sessions and was excluded from sampling — even though it is unique among the sessions a question can actually be scored against. On a corpus with many unlabelled conversations this quietly starves `build` of candidates and contradicts the rule the previous PR introduced.

The fix adds `AND c.session_id IS NOT NULL AND c.session_id != ''`, so the uniqueness count is taken over exactly the sessions the sampler can draw from.

`IS NOT NULL` is redundant against `COUNT(DISTINCT)`, which already skips nulls — it is there so the predicate states the rule rather than relying on that.

## Files Touched

- `src/bench.ts` — the session filter on the uniqueness query, and a docblock line saying why it must match `buildBench`
- `test/bench/bench.test.ts` — new test; plus the missing `exitCode` assertion on the neighbouring repeated-prompt test
- `.changeset/bench-scorable-sessions-only.md` — patch changeset

## Issue Reference

Part of #362 (the confirmed-findings list from the #361 review panel). Does not close it — the other twelve findings remain.

## Test Evidence

`npx vitest run` → **1281 passed | 4 skipped (127 files)**. `npx tsc --noEmit` clean.

The new test is mutation-checked: reverting the `WHERE` clause to `WHERE m.role = 'user'` makes `counts only sessions the sampler can draw from as repeats` fail.

## Risks & Follow-ups

- The uniqueness key is still exact byte equality, so the same prompt differing only in surrounding whitespace still escapes the filter. Tracked in #362, not fixed here.
- A prompt that appears *only* in session-less conversations now falls out of the repeated set entirely. Harmless: those conversations are never sampled, so it can never become a question.
- #362 keeps the remaining twelve findings, including the one that actually skews a number: search is cut at `k` rows before session dedup while the grep baseline walks until `k` distinct sessions.

## AR Status

PASSED on the parent PR #361 (Tier A1 adversarial: 0 critical, 0 high; Tier A2 uncle-bob: warn-level only). This change is one of that panel's confirmed findings; not re-reviewed.

## Introspection Findings

Committed before mutation-testing this time. Doing it the other way round earlier in the session cost a full redo — `git checkout <file>` discards uncommitted work along with the mutation.

## Token Cost

~25k tokens (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU
