### PR TITLE
fix(bench): cut the search and grep columns at the same point

### DIFF
--- a/.changeset/bench-fair-session-cutoff.md
+++ b/.changeset/bench-fair-session-cutoff.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Cut both `lcm bench` columns at the same point. The score is over sessions but search ranks rows, so asking for `k` rows and then deduplicating by session surfaced 3.3 sessions per query on a real 105-session corpus instead of `k` — several rows of one session ate the budget — while the ripgrep baseline walks its hits until it has `k` distinct sessions and always fills them. The comparison handed grep more chances than search on the same question. Search now gets a row budget that fills every slot; the reported hit rates are unchanged on both local benchmarks, so this removes a confound rather than moving a number.

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -516,6 +516,20 @@ function collectSessionIds(...groups: Array<Array<{ sessionId?: string | null }>
   return [...new Set(ranked)];
 }
 
+/**
+ * Rows to request per session slot, so both columns are cut at the same point.
+ *
+ * The score is over sessions, but search ranks rows. Asking for `k` rows and
+ * then deduplicating by session surfaced 3.3 sessions per query on a real
+ * 105-session corpus, never 5 — several rows of one session ate the budget —
+ * while the ripgrep baseline walks its hits until it has `k` distinct sessions
+ * and always fills them. That handed grep more chances than search on the same
+ * question. Doubling the row budget fills all `k` slots on both benchmarks
+ * measured, and larger multiples change no score, so the value is a saturation
+ * point rather than a tuned one.
+ */
+const SESSION_ROW_BUDGET = 2;
+
 type ScoreContext = {
   db: DatabaseSync;
   promotedStore: PromotedStore;
@@ -527,8 +541,8 @@ type ScoreContext = {
 async function scoreQuery(query: BenchQuery, ctx: ScoreContext): Promise<QueryOutcome> {
   const start = performance.now();
   // The same ranking explicit search emits, so the bench measures what callers see.
-  const history = await rankNativeHistory(ctx.db, { query: query.question, limit: ctx.k });
-  const promoted = ctx.promotedStore.search(query.question, ctx.k, undefined, ctx.projectId);
+  const history = await rankNativeHistory(ctx.db, { query: query.question, limit: ctx.k * SESSION_ROW_BUDGET });
+  const promoted = ctx.promotedStore.search(query.question, ctx.k * SESSION_ROW_BUDGET, undefined, ctx.projectId);
   const latencyMs = performance.now() - start;
 
   const sessionIds = collectSessionIds(history, promoted);

--- a/test/bench/bench.test.ts
+++ b/test/bench/bench.test.ts
@@ -99,22 +99,21 @@ async function seedProject(cwd: string): Promise<void> {
   }
 }
 
-/** Adds one-prompt sessions to an already seeded project. */
-async function addSessions(cwd: string, entries: Array<{ sessionId: string; prompt: string }>): Promise<void> {
+/** Adds sessions to an already seeded project; `prompt` may carry several turns. */
+async function addSessions(cwd: string, entries: Array<{ sessionId: string; prompt: string | string[] }>): Promise<void> {
   const db = new DatabaseSync(projectDbPath(cwd));
   try {
     const convStore = new ConversationStore(db);
     for (const entry of entries) {
       const conv = await convStore.createConversation({ sessionId: entry.sessionId });
-      await convStore.createMessagesBulk([
-        {
-          conversationId: conv.conversationId,
-          seq: 0,
-          role: "user" as const,
-          content: entry.prompt,
-          tokenCount: Math.ceil(entry.prompt.length / 4),
-        },
-      ]);
+      const prompts = Array.isArray(entry.prompt) ? entry.prompt : [entry.prompt];
+      await convStore.createMessagesBulk(prompts.map((content, seq) => ({
+        conversationId: conv.conversationId,
+        seq,
+        role: "user" as const,
+        content,
+        tokenCount: Math.ceil(content.length / 4),
+      })));
     }
   } finally {
     db.close();
@@ -363,11 +362,15 @@ describe("lcm bench", () => {
     const cwd = mkdtempSync(join(tmpdir(), "lcm-bench-"));
     tempDirs.push(cwd);
     await seedProject(cwd);
-    // Six sessions all discussing the same subject, each with two messages, so
-    // ranking rows rather than sessions would spend the budget inside a few.
+    // Six sessions on the same subject, each with several matching turns, so a
+    // row budget spent inside one session starves the others of a slot.
     await addSessions(cwd, Array.from({ length: 6 }, (_, i) => ({
       sessionId: `sess-quota-${i}`,
-      prompt: `The nightly quota reconciliation job overshot its budget again on shard ${i} and paged the on-call engineer.`,
+      prompt: [
+        `The nightly quota reconciliation job overshot its budget again on shard ${i} and paged the on-call engineer.`,
+        `Quota reconciliation paged us twice more on shard ${i}; the budget alarm keeps firing before the job finishes.`,
+        `We raised the quota budget for shard ${i} and the reconciliation job stopped paging, but it still overshoots.`,
+      ],
     })));
     const file = join(cwd, "manual.json");
     const question = "quota reconciliation budget shard paged";

--- a/test/bench/bench.test.ts
+++ b/test/bench/bench.test.ts
@@ -358,4 +358,26 @@ describe("lcm bench", () => {
     writeFileSync(file, JSON.stringify({ version: 1, queries: [{ ...query, sessionIds: [" "] }] }));
     expect((await runBench({ cwd, benchFile: file })).stdout).toContain("sessionIds must be a list");
   });
+
+  it("gives search enough rows to fill every session slot the grep column fills", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "lcm-bench-"));
+    tempDirs.push(cwd);
+    await seedProject(cwd);
+    // Six sessions all discussing the same subject, each with two messages, so
+    // ranking rows rather than sessions would spend the budget inside a few.
+    await addSessions(cwd, Array.from({ length: 6 }, (_, i) => ({
+      sessionId: `sess-quota-${i}`,
+      prompt: `The nightly quota reconciliation job overshot its budget again on shard ${i} and paged the on-call engineer.`,
+    })));
+    const file = join(cwd, "manual.json");
+    const question = "quota reconciliation budget shard paged";
+    writeFileSync(file, JSON.stringify({ version: 1, queries: [
+      { id: "wide", sessionId: "sess-quota-0", prompt: question, question, generator: "manual" },
+    ] }));
+
+    const run = await runBench({ cwd, benchFile: file, k: 5 });
+    expect(run.exitCode, run.stdout).toBe(0);
+    const { outcomes } = JSON.parse(readFileSync(run.out, "utf-8")) as { outcomes: Array<{ searchTopK: string[] }> };
+    expect(outcomes[0].searchTopK).toHaveLength(5);
+  });
 });


### PR DESCRIPTION
## Changes

While investigating #358 (the real hit rate, 0.54 then, 0.385 now that the corpus grew) I found that the two columns the gate compares are cut at different points.

The bench scores **sessions**, but search ranks **rows**. `scoreQuery` asked `rankNativeHistory` for `k` rows and then deduplicated by session, so several rows of one session ate the budget. Measured on the real 105-session corpus, the history side surfaced **3.3 distinct sessions per query** where `k` was 5 — it could not fill the slots it was being scored on. The ripgrep baseline does the opposite: `rgSessionIds` walks *all* its hits until it has `k` distinct sessions, and always fills them.

So `expect(searchHitRate).toBeGreaterThan(grepHitRate)` was comparing a column allowed 3.3 chances against one allowed 5. Search now gets a row budget per session slot.

The constant is a saturation point, not a tuned one:

| rows requested | reviewed set (n=13) | mechanical set (n=20) | distinct sessions surfaced |
|---|---|---|---|
| `k` | 4/13 | 9/20 | 3.3 |
| `k × 2` | 5/13 | 9/20 | 5.0 |
| `k × 3` | 5/13 | 9/20 | 5.0 |
| `k × 5` | 5/13 | 9/20 | 5.0 |
| `k × 10` | 5/13 | 9/20 | 5.0 |

**The reported hit rates do not move** — 0.385 and 0.450 before and after on the two local benchmarks — because promoted memories were already filling the gap the history side left. This removes a confound from the measurement; it does not improve retrieval.

## Files Touched

- `src/bench.ts` — `SESSION_ROW_BUDGET` and its two uses in `scoreQuery`
- `test/bench/bench.test.ts` — a test that six same-subject sessions fill all five slots
- `.changeset/bench-fair-session-cutoff.md` — patch changeset

## Issue Reference

Refs #358 and #362 (the medium finding from the review panel). Neither is closed — see below.

## Test Evidence

`npx vitest run` → **1282 passed | 4 skipped (127 files)**. `npx tsc --noEmit` clean. The synthetic gate is unchanged at `recall@5=0.93` vs grep `0.83`.

Mutation-checked: reverting both call sites to `ctx.k` makes the new test fail with `expected [ 'sess-rollback', …(3) ] to have a length of 5 but got 4`.

## What I found about #358 itself, and did not ship

The misses are a **ranking** problem, not a candidate-recall one. For 8 of the 9 questions search gets wrong, the correct session is in the candidate pool, at session rank 5 to 18. Only r013 — the "dezesseis gigabytes" vs `16G` numeral question the issue itself says to drop — is absent entirely.

The same few large sessions occupy the top 5 of unrelated questions: one 368 KB session appears in 11 of 13 top-5s, another in 10. `fuseHistoryBySession` scores a session by the best position *any single row* of it reached, so a long session buys more lottery tickets — it is likelier that one of its many rows lands high on any query. That, not vocabulary, is what pushes real answers to rank 6-18.

I tried the obvious fix: score each candidate session by how many query terms occur anywhere in it, fused as a third RRF list. On the reviewed set it went 0.385 → 0.462. **It did not survive validation** — on the mechanical 20-question set it went 0.450 → 0.400, and sweeping the fusion weight produced 0.462 / 0.308 / 0.385 for weights 1 / 2 / 3, which is not a trend, it is noise at n=13. One question better here and one worse there is not evidence, so the re-ranker is not in this PR.

The honest blocker for #358 is the evidence base: 13 reviewed questions cannot separate a real ranking improvement from noise. A larger labelled set has to come first.

## Risks & Follow-ups

- Search now reads twice the rows per query. Measured p95 went 22 ms → 21.5 ms on the real corpus (within noise); the gate's budget is 500 ms.
- The extra rows are fetched and discarded when a query's hits already span `k` sessions.
- The RRF size bias described above is untouched and is the real lead for #358.

## AR Status

[SKIP_AR: two call sites and a constant; the behavioural claim is mutation-checked and every number above is measured, not argued]

## Introspection Findings

Validating on a second corpus is what killed the coverage re-ranker — on the reviewed set alone it looked like a clean +2 questions. Also: coverage computed over *candidate rows* measures nothing (those matched the query by construction, 0.385 → 0.385); only whole-session coverage moved anything. Worth knowing before anyone tries the same idea.

## Token Cost

~120k tokens (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU
