### PR TITLE
feat(bench): score retrieval across several corpora, not one

### DIFF
--- a/.changeset/bench-multi-corpus-harness.md
+++ b/.changeset/bench-multi-corpus-harness.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Add `scripts/bench-corpora.mts`, which scores `lcm bench` across several local project corpora and pools the result. A single benchmark cannot separate a ranking improvement from noise: two changes that read as clean wins on one 13-question set did not survive pooling over 221 questions from eight corpora, one of them turning negative and pushing p95 past the latency budget. Retrieval ranking changes are measured here from now on.

--- a/docs/search.md
+++ b/docs/search.md
@@ -111,6 +111,29 @@ Example output:
   p95 latency    3.2ms
 ```
 
+### Measuring a ranking change across corpora
+
+One benchmark cannot separate a ranking improvement from noise. `scripts/bench-corpora.mts`
+scores several local projects at once and pools the result:
+
+```bash
+npx tsx scripts/bench-corpora.mts build   # (re)generate one question set per corpus
+npx tsx scripts/bench-corpora.mts run     # score them all, print the pooled hit rate
+```
+
+Corpora come from `LCM_BENCH_CORPORA` (colon-separated project paths) or, unset, from every
+ingested project whose database is large enough to hold one. Question sets are written next to
+each project database as `.lcm-bench-validation.json` and the seed is fixed, so two runs score
+the same questions and are comparable.
+
+These are mechanically generated questions: diagnostic only, never release evidence. What the
+harness is for is the **direction** of a change and whether one corpus disagrees with another.
+Two ranking changes that read as clean wins on a single 13-question set did not survive it —
+query-term coverage in session fusion was +2 there and +1 pooled over 221 questions, and
+enlarging the candidate pool came out negative while pushing p95 past the latency budget.
+
+Require a non-negative direction on every corpus, not just a better pooled number.
+
 ### Manually reviewed queries
 
 Real user wording and short lookups are first-class benchmark inputs. In a version-1 benchmark

--- a/docs/search.md
+++ b/docs/search.md
@@ -121,7 +121,7 @@ npx tsx scripts/bench-corpora.mts build   # (re)generate one question set per co
 npx tsx scripts/bench-corpora.mts run     # score them all, print the pooled hit rate
 ```
 
-Corpora come from `LCM_BENCH_CORPORA` (colon-separated project paths) or, unset, from every
+Corpora come from `LCM_BENCH_CORPORA` (the platform path delimiter — `:`, or `;` on Windows) or, unset, from every
 ingested project whose database is large enough to hold one. Question sets are written next to
 each project database as `.lcm-bench-validation.json` and the seed is fixed, so two runs score
 the same questions and are comparable.

--- a/scripts/bench-corpora.mts
+++ b/scripts/bench-corpora.mts
@@ -1,0 +1,123 @@
+/**
+ * Run `lcm bench` across several local project corpora and pool the result.
+ *
+ * A single benchmark cannot tell a ranking improvement from noise. Measured on
+ * one 13-question set, adding query-term coverage to session fusion read as a
+ * clean +2; pooled over 221 questions from eight corpora the same change was
+ * +1, and enlarging the candidate pool — which looked principled — came out
+ * negative and pushed p95 past the latency budget. Neither would have been
+ * caught by one corpus, so a change to retrieval ranking is measured here.
+ *
+ * Scores are diagnostic. Mechanically generated questions are not release
+ * evidence; what this harness is for is the *direction* of a change, and
+ * whether one corpus disagrees with another.
+ *
+ *   npx tsx scripts/bench-corpora.mts build     # (re)generate the question sets
+ *   npx tsx scripts/bench-corpora.mts run       # score every corpus, print the pool
+ *
+ * Corpora come from `LCM_BENCH_CORPORA` (colon-separated project paths), or
+ * from every ingested project whose database is large enough to hold one.
+ */
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { buildBench, runBench } from "../src/bench.js";
+import { projectDbPath } from "../src/daemon/project.js";
+
+const VALIDATION_FILENAME = ".lcm-bench-validation.json";
+const QUESTIONS_PER_CORPUS = 30;
+/** Fixed so a rerun scores the same questions, and two runs are comparable. */
+const SEED = 1234;
+/** Below this a project holds too few sessions to rank anything meaningfully. */
+const MIN_DB_BYTES = 8 * 1024 * 1024;
+
+async function discoverCorpora(): Promise<string[]> {
+  const configured = process.env.LCM_BENCH_CORPORA;
+  if (configured) return configured.split(":").filter(Boolean);
+
+  const root = join(homedir(), ".lossless-claude", "projects");
+  if (!existsSync(root)) return [];
+  const found: Array<{ cwd: string; size: number }> = [];
+  for (const entry of await readdir(root)) {
+    const db = join(root, entry, "db.sqlite");
+    const meta = join(root, entry, "meta.json");
+    if (!existsSync(db) || !existsSync(meta)) continue;
+    let size: number;
+    try {
+      size = statSync(db).size;
+    } catch {
+      continue;
+    }
+    if (size < MIN_DB_BYTES) continue;
+    try {
+      const cwd = (JSON.parse(readFileSync(meta, "utf-8")) as { cwd?: string }).cwd;
+      if (cwd && existsSync(projectDbPath(cwd))) found.push({ cwd, size });
+    } catch {
+      continue;
+    }
+  }
+  return found.sort((a, b) => b.size - a.size).map(entry => entry.cwd);
+}
+
+function validationFile(cwd: string): string {
+  return join(dirname(projectDbPath(cwd)), VALIDATION_FILENAME);
+}
+
+function label(cwd: string): string {
+  return (cwd.split("/").pop() || cwd).slice(0, 22).padEnd(22);
+}
+
+async function build(corpora: string[]): Promise<void> {
+  for (const cwd of corpora) {
+    const result = await buildBench({ cwd, n: QUESTIONS_PER_CORPUS, seed: SEED, out: validationFile(cwd) });
+    console.log(`${label(cwd)} ${result.exitCode === 0 ? result.stdout.split("\n")[0] : `skipped: ${result.stdout.split("\n")[0]}`}`);
+  }
+}
+
+async function run(corpora: string[]): Promise<void> {
+  let hits = 0;
+  let total = 0;
+  let beatsGrep = 0;
+  let scored = 0;
+  for (const cwd of corpora) {
+    const file = validationFile(cwd);
+    if (!existsSync(file)) {
+      console.log(`${label(cwd)} no question set — run \`build\` first`);
+      continue;
+    }
+    const result = await runBench({ cwd, benchFile: file, k: 5, json: true });
+    if (result.exitCode !== 0) {
+      console.log(`${label(cwd)} skipped: ${result.stdout.split("\n")[0]}`);
+      continue;
+    }
+    const report = JSON.parse(result.stdout) as {
+      total: number; searchHitRate: number; grepHitRate: number; emptyRate: number; p95LatencyMs: number;
+    };
+    hits += Math.round(report.searchHitRate * report.total);
+    total += report.total;
+    scored++;
+    if (report.searchHitRate > report.grepHitRate) beatsGrep++;
+    console.log(
+      `${label(cwd)} n=${String(report.total).padStart(3)}  search=${report.searchHitRate.toFixed(3)}` +
+      `  grep=${report.grepHitRate.toFixed(3)}  empty=${report.emptyRate.toFixed(2)}  p95=${report.p95LatencyMs}ms`,
+    );
+  }
+  if (total === 0) {
+    console.log("\nNothing scored. Run `build` first, or point LCM_BENCH_CORPORA at a project with ingested sessions.");
+    return;
+  }
+  console.log(`\npooled  ${hits}/${total} = ${(hits / total).toFixed(3)}   beats grep on ${beatsGrep}/${scored} corpora`);
+}
+
+const command = process.argv[2] ?? "run";
+const corpora = await discoverCorpora();
+if (corpora.length === 0) {
+  console.log("No corpora found. Set LCM_BENCH_CORPORA to a colon-separated list of project paths.");
+} else if (command === "build") {
+  await build(corpora);
+} else if (command === "run") {
+  await run(corpora);
+} else {
+  console.log(`Unknown command "${command}". Use \`build\` or \`run\`.`);
+}

--- a/scripts/bench-corpora.mts
+++ b/scripts/bench-corpora.mts
@@ -15,13 +15,13 @@
  *   npx tsx scripts/bench-corpora.mts build     # (re)generate the question sets
  *   npx tsx scripts/bench-corpora.mts run       # score every corpus, print the pool
  *
- * Corpora come from `LCM_BENCH_CORPORA` (colon-separated project paths), or
+ * Corpora come from `LCM_BENCH_CORPORA` (`:` separated, `;` on Windows), or
  * from every ingested project whose database is large enough to hold one.
  */
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, delimiter, dirname, join } from "node:path";
 import { buildBench, runBench } from "../src/bench.js";
 import { projectDbPath } from "../src/daemon/project.js";
 
@@ -34,7 +34,7 @@ const MIN_DB_BYTES = 8 * 1024 * 1024;
 
 async function discoverCorpora(): Promise<string[]> {
   const configured = process.env.LCM_BENCH_CORPORA;
-  if (configured) return configured.split(":").filter(Boolean);
+  if (configured) return configured.split(delimiter).filter(Boolean);
 
   const root = join(homedir(), ".lossless-claude", "projects");
   if (!existsSync(root)) return [];
@@ -65,7 +65,7 @@ function validationFile(cwd: string): string {
 }
 
 function label(cwd: string): string {
-  return (cwd.split("/").pop() || cwd).slice(0, 22).padEnd(22);
+  return (basename(cwd) || cwd).slice(0, 22).padEnd(22);
 }
 
 async function build(corpora: string[]): Promise<void> {
@@ -113,7 +113,7 @@ async function run(corpora: string[]): Promise<void> {
 const command = process.argv[2] ?? "run";
 const corpora = await discoverCorpora();
 if (corpora.length === 0) {
-  console.log("No corpora found. Set LCM_BENCH_CORPORA to a colon-separated list of project paths.");
+  console.log(`No corpora found. Set LCM_BENCH_CORPORA to a "${delimiter}" separated list of project paths.`);
 } else if (command === "build") {
   await build(corpora);
 } else if (command === "run") {


### PR DESCRIPTION
## Changes

While working #358 I tried two ranking changes. Both looked like clean wins on the reviewed 13-question benchmark. Neither survived being measured against more than one corpus, and one of them would have shipped a latency regression.

That is the actual blocker on #358, so this PR fixes the ruler rather than the ranking.

`scripts/bench-corpora.mts` generates one question set per local project and scores them all:

```bash
npx tsx scripts/bench-corpora.mts build
npx tsx scripts/bench-corpora.mts run
```

```text
lossless-claude        n= 30  search=0.067  grep=0.067  empty=0.00  p95=133.6ms
xgh                    n= 30  search=0.167  grep=0.067  empty=0.00  p95=103.8ms
dwigt                  n= 30  search=0.167  grep=0.167  empty=0.00  p95=52ms
.claude                n= 30  search=0.433  grep=0.267  empty=0.00  p95=36.8ms
Inspector              n= 30  search=0.567  grep=0.233  empty=0.00  p95=57.5ms
trilha-probatoria      n= 30  search=0.400  grep=0.333  empty=0.00  p95=106.7ms
autoimprove            n= 11  search=0.545  grep=0.182  empty=0.00  p95=19.7ms
lcm                    n= 30  search=0.233  grep=0.167  empty=0.00  p95=28.3ms

pooled  67/221 = 0.303   beats grep on 6/8 corpora
```

## What it caught

| change | reviewed set (n=13) | pooled (n=221) | verdict |
|---|---|---|---|
| query-term coverage in session fusion | 0.385 → **0.462** | 0.303 → 0.308 | +1 question for ~2× latency — noise |
| enlarge the candidate pool | 0.385 → 0.385 | 0.303 → **0.294** | negative, and p95 544 ms on the largest corpus, past the gate's 500 ms |

The second is the interesting one: it was justified structurally, not by a number. The candidate pool is a fixed 50 rows and one session was holding up to 17 of them, so only 12 of 105 sessions ever reached the ranking. Widening it does let far more sessions compete — a target that was entirely absent appears at rank 19 — and the score still gets *worse*, because the extra sessions outrank the right one. That rules out the pool as the constraint and points squarely at the scoring.

## Files Touched

- `scripts/bench-corpora.mts` — the harness; discovery, `build`, `run`, pooled report
- `docs/search.md` — how to use it and what its numbers are and are not good for
- `.changeset/bench-multi-corpus-harness.md` — patch changeset

## Issue Reference

Refs #358. Does not close it — this makes the next attempt measurable, it does not improve retrieval.

## Test Evidence

`npx tsc --noEmit` clean; `npx vitest run` unaffected (no `src/` change). The harness output above is a real run over eight local corpora.

Question sets land next to each project database as `.lcm-bench-validation.json`, never in the repo, and the seed is fixed so two runs score the same questions.

## Risks & Follow-ups

- Mechanically generated questions are diagnostic. The rule the docs now state is: require a non-negative direction on *every* corpus, not a better pooled number.
- Discovery walks `~/.lossless-claude/projects` and keeps databases over 8 MB; on this machine that is 8 corpora out of 19,677 directories. `LCM_BENCH_CORPORA` overrides it.
- `autoimprove` yields 11 questions rather than 30 — its corpus has few prompts that pass the unique-evidence filter. Pooling weights it accordingly.
- Latency is reported per corpus because a ranking change that helps can still breach the budget; that is how the pool change was caught.

## AR Status

[SKIP_AR: a measurement script and docs, no `src/` change and no product behaviour]

## Introspection Findings

The reviewed 13-question set and the mechanical 20-question set disagreeing was the first warning; I nearly read the coverage result as a win because the reviewed set is the one I trusted. The lesson is that trusting the *better-labelled* set is not the same as having enough of it — 13 well-chosen questions still cannot resolve a 2-question difference.

## Token Cost

~65k tokens (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU
