### PR TITLE
docs(test): warn that bench rejection fixtures need a capitalized identifier

### DIFF
--- a/test/bench/bench.test.ts
+++ b/test/bench/bench.test.ts
@@ -99,7 +99,15 @@ async function seedProject(cwd: string): Promise<void> {
   }
 }
 
-/** Adds sessions to an already seeded project; `prompt` may carry several turns. */
+/**
+ * Adds sessions to an already seeded project; `prompt` may carry several turns.
+ *
+ * A fixture that tests a *rejection* needs a capitalized mid-sentence identifier
+ * (e.g. "GitHub", "Stripe"). Without one, `mechanicalQuestion` falls through to a
+ * subjectless question that is rejected for an unrelated reason, so the prompt is
+ * absent from the bench file whether or not the filter under test exists — and the
+ * test passes with the fix removed. This has produced three vacuous tests so far.
+ */
 async function addSessions(cwd: string, entries: Array<{ sessionId: string; prompt: string | string[] }>): Promise<void> {
   const db = new DatabaseSync(projectDbPath(cwd));
   try {


### PR DESCRIPTION
## Changes

A comment-only change to `addSessions` in the bench test file.

Three tests in this suite have now passed with the fix under test removed, all for the same reason: the fixture prompt had no capitalized mid-sentence identifier, so `mechanicalQuestion` fell through `capitalizedIdentifiers` → uppercase-token → `OUTCOME_FALLBACKS` and produced a subjectless question that `questionProblem` rejects for an unrelated reason. The prompt is then absent from the bench file whether or not the filter being tested exists.

The warning belongs next to the helper where the fixture is written.

## Files Touched

- `test/bench/bench.test.ts` — docstring on `addSessions`

## Issue Reference

Refs #358

## Test Evidence

`Tests  23 passed (23)` on `test/bench/bench.test.ts`. No behaviour change — comment only.

## Risks & Follow-ups

None. No production code touched, no changeset (comment-only).

## AR Status

[SKIP_AR: comment-only change to one test file, no executable code]

## Introspection Findings

The failure mode is specific to this suite's generator fallback chain, which is why the general "mutation-check every test" rule kept not being enough — it catches the vacuous test after the fact, three times, rather than preventing it.

## Token Cost

~4k tokens (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU