### PR TITLE
feat(search): damp session scores by session length

### DIFF
--- a/.changeset/session-length-normalisation.md
+++ b/.changeset/session-length-normalisation.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": minor
+---
+
+Rank sessions by relevance rather than by size. `lcm search` scored a session by the reciprocal rank of the best position any single one of its rows reached, so a long session — entering the candidate pool many times — landed a row high on almost any query and crowded out shorter, more relevant ones: measured, one 368 KB session took 11 of 13 top-5 slots on unrelated questions. Session scores are now damped by the session's message count, the way bm25 already damps a message by its length. Chosen on five corpora and graded once on four it had never seen, hit@5 moves 0.269 to 0.320 (+13 questions against −3, sign test p = 0.02), improving on every held-out corpus.

--- a/docs/search.md
+++ b/docs/search.md
@@ -135,6 +135,23 @@ each project database as `.lcm-bench-validation.json` and the seed is fixed, so 
 the same questions and are comparable. Each row also prints the corpus's session count: a live
 corpus grows between runs, and a delta measured over different content is not a delta.
 
+### Tuning against one half, grading against the other
+
+A parameter chosen on the same questions that report the score is fitted, not measured — the
+score stops being evidence. `LCM_BENCH_GROUP` splits the corpora in two so the two roles stay
+apart:
+
+```bash
+LCM_BENCH_GROUP=tune    npx tsx scripts/bench-corpora.mts run   # sweep a parameter here
+LCM_BENCH_GROUP=holdout npx tsx scripts/bench-corpora.mts run   # grade, once, here
+```
+
+The split is by corpus (`HELD_OUT_CORPORA` in the script), not by question, so no session appears
+on both sides. Build the held-out questions with `LCM_BENCH_SEED` set to something other than the
+default, so they are a different sample from the ones any sweep has already seen; `LCM_BENCH_N`
+raises the count per corpus. Grade the held-out group **once**, after the parameter is fixed — a
+second look at it makes it a tuning set too.
+
 These are mechanically generated questions: diagnostic only, never release evidence. What the
 harness is for is the **direction** of a change and whether one corpus disagrees with another.
 Two ranking changes that read as clean wins on a single 13-question set did not survive it —

--- a/scripts/bench-corpora.mts
+++ b/scripts/bench-corpora.mts
@@ -55,13 +55,30 @@ function inGroup(cwd: string, selected: Group): boolean {
   const held = HELD_OUT_CORPORA.has(basename(cwd));
   return selected === "holdout" ? held : !held;
 }
-const QUESTIONS_PER_CORPUS = Number(process.env.LCM_BENCH_N ?? 30);
+/**
+ * A positive integer from the environment, or the default when unset.
+ *
+ * Anything else stops the run: a silently coerced `NaN` seed would reach the
+ * PRNG and make a "fixed seed" produce a different sample every time, which is
+ * the one failure this harness must never have.
+ */
+function positiveInteger(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, got "${raw}".`);
+  }
+  return value;
+}
+
+const QUESTIONS_PER_CORPUS = positiveInteger("LCM_BENCH_N", 30);
 /**
  * Fixed so a rerun scores the same questions, and two runs are comparable.
  * `LCM_BENCH_SEED` draws a different sample from the same corpus — use it when
  * a set has to be unseen, not when comparing two runs.
  */
-const SEED = Number(process.env.LCM_BENCH_SEED ?? 1234);
+const SEED = positiveInteger("LCM_BENCH_SEED", 1234);
 /** Below this a project holds too few sessions to rank anything meaningfully. */
 const MIN_DB_BYTES = 8 * 1024 * 1024;
 

--- a/scripts/bench-corpora.mts
+++ b/scripts/bench-corpora.mts
@@ -27,9 +27,41 @@ import { buildBench, runBench } from "../src/bench.js";
 import { projectDbPath } from "../src/daemon/project.js";
 
 const VALIDATION_FILENAME = ".lcm-bench-validation.json";
-const QUESTIONS_PER_CORPUS = 30;
-/** Fixed so a rerun scores the same questions, and two runs are comparable. */
-const SEED = 1234;
+
+/**
+ * Corpora reserved for the held-out grade, named by directory.
+ *
+ * A parameter chosen on the same questions that report the score is fitted, not
+ * measured — the score stops being evidence. So the corpora split in two, once,
+ * and stay split: a candidate is tuned against everything outside this list and
+ * graded exactly once against everything inside it.
+ *
+ * The split is by corpus rather than by question, so no session appears on both
+ * sides. The `lcm` corpus is deliberately on the tuning side: its questions have
+ * already been scored across a parameter sweep and cannot serve as unseen.
+ */
+const HELD_OUT_CORPORA = new Set([".claude", "Inspector", "trilha-probatoria", "xgh"]);
+
+type Group = "tune" | "holdout" | "all";
+
+function group(): Group {
+  const requested = process.env.LCM_BENCH_GROUP ?? "all";
+  if (requested === "tune" || requested === "holdout") return requested;
+  return "all";
+}
+
+function inGroup(cwd: string, selected: Group): boolean {
+  if (selected === "all") return true;
+  const held = HELD_OUT_CORPORA.has(basename(cwd));
+  return selected === "holdout" ? held : !held;
+}
+const QUESTIONS_PER_CORPUS = Number(process.env.LCM_BENCH_N ?? 30);
+/**
+ * Fixed so a rerun scores the same questions, and two runs are comparable.
+ * `LCM_BENCH_SEED` draws a different sample from the same corpus — use it when
+ * a set has to be unseen, not when comparing two runs.
+ */
+const SEED = Number(process.env.LCM_BENCH_SEED ?? 1234);
 /** Below this a project holds too few sessions to rank anything meaningfully. */
 const MIN_DB_BYTES = 8 * 1024 * 1024;
 
@@ -132,7 +164,9 @@ async function run(corpora: string[]): Promise<void> {
 }
 
 const command = process.argv[2] ?? "run";
-const corpora = await discoverCorpora();
+const selected = group();
+const corpora = (await discoverCorpora()).filter(cwd => inGroup(cwd, selected));
+if (selected !== "all") console.log(`group: ${selected} (${corpora.length} corpora)\n`);
 if (corpora.length === 0) {
   console.log(`No corpora found. Set LCM_BENCH_CORPORA to a "${delimiter}" separated list of project paths.`);
 } else if (command === "build") {

--- a/src/search/native-history.ts
+++ b/src/search/native-history.ts
@@ -114,17 +114,55 @@ function drawBySession(
 }
 
 /**
+ * Length-normalisation strength, in the role BM25's `b` plays for message
+ * length. 0 leaves scores untouched, 1 divides by the size ratio outright.
+ *
+ * Chosen on five corpora (171 questions) and graded once on four it had never
+ * seen (197): 0.269 to 0.320, +13 questions against -3. The curve is a broad
+ * plateau — every value from 0.25 to 0.75 beats no normalisation at all — so
+ * this sits at its centre rather than on a peak.
+ */
+const SESSION_LENGTH_NORM = 0.4;
+
+/**
+ * Damp a session's score by how large the session is, the way bm25 already
+ * damps a message's score by how long the message is.
+ *
+ * A session scores the reciprocal rank of the *best* position any one of its
+ * rows reached. A long session enters the candidate pool many times, so one of
+ * its rows lands high on almost any query — measured, a single 368 KB session
+ * took 11 of 13 top-5 slots on unrelated questions. Nothing below the row level
+ * corrected for that.
+ *
+ * `sizeOf` returning undefined leaves that session unnormalised, so a session
+ * whose size cannot be established is neither rewarded nor punished for it.
+ */
+function normaliseBySessionSize(score: Map<string, number>, sizeOf: (group: string) => number | undefined): void {
+  const sizes = [...score.keys()].map(sizeOf).filter((size): size is number => size !== undefined && size > 0);
+  if (sizes.length === 0) return;
+  const average = sizes.reduce((sum, size) => sum + size, 0) / sizes.length;
+  if (average <= 0) return;
+  for (const [group, value] of score) {
+    const size = sizeOf(group);
+    if (size === undefined || size <= 0) continue;
+    score.set(group, value / (1 - SESSION_LENGTH_NORM + SESSION_LENGTH_NORM * (size / average)));
+  }
+}
+
+/**
  * Fuse message and summary candidates by session: a session scores the sum of
  * reciprocal ranks of its best message and best summary, so evidence present
- * in both sources rises. Summaries draw first against a reserved share of the
- * limit, messages take the rest, and whichever side underfills hands its
- * leftover to the other. Emission stays round-robin, one hit per session per
- * pass, so a small limit still spans several sessions.
+ * in both sources rises, damped by how large the session is. Summaries draw
+ * first against a reserved share of the limit, messages take the rest, and
+ * whichever side underfills hands its leftover to the other. Emission stays
+ * round-robin, one hit per session per pass, so a small limit still spans
+ * several sessions.
  */
 export function fuseHistoryBySession(
   messages: RankedHistoryHit[],
   summaries: RankedHistoryHit[],
   limit: number,
+  sessionSize?: (group: string) => number | undefined,
 ): RankedHistoryHit[] {
   const groupOf = (hit: RankedHistoryHit) => hit.sessionId ?? `conversation:${hit.conversationId}`;
   const score = new Map<string, number>();
@@ -137,6 +175,8 @@ export function fuseHistoryBySession(
       score.set(group, (score.get(group) ?? 0) + 1 / (FUSION_RANK_OFFSET + position));
     });
   }
+  // Callers that cannot supply sizes keep the unnormalised order.
+  if (sessionSize) normaliseBySessionSize(score, sessionSize);
   const groups = [...score.entries()].sort((a, b) => b[1] - a[1]).map(([group]) => group);
 
   const reserved = limit >= 2 ? Math.ceil(limit * SUMMARY_LIMIT_SHARE) : 0;
@@ -174,7 +214,37 @@ export async function rankNativeHistory(
     }
     return ranked;
   };
-  return fuseHistoryBySession(await attach(result.messages), await attach(result.summaries), input.limit);
+  const rankedMessages = await attach(result.messages);
+  const rankedSummaries = await attach(result.summaries);
+  return fuseHistoryBySession(rankedMessages, rankedSummaries, input.limit, sessionSizes(db, [...rankedMessages, ...rankedSummaries], sessionOf));
+}
+
+/**
+ * How many messages each candidate session holds, for the length normalisation.
+ *
+ * Counting rows in the candidate pool instead would be free, and was tried: it
+ * loses on every question set. That signal is query-dependent — a session about
+ * one subject fills the pool on queries about that subject, exactly when it is
+ * the right answer, so it is damped hardest when it should win. The transcript
+ * count does not move with the query. It costs one grouped count over the
+ * conversations already in hand: 0.1 ms against a 500 ms budget.
+ */
+function sessionSizes(
+  db: DatabaseSync,
+  hits: RankedHistoryHit[],
+  sessionOf: Map<number, string | null>,
+): (group: string) => number | undefined {
+  const conversations = [...new Set(hits.map(hit => hit.conversationId))];
+  if (conversations.length === 0) return () => undefined;
+  const rows = db.prepare(
+    `SELECT conversation_id, COUNT(*) AS n FROM messages WHERE conversation_id IN (${conversations.map(() => "?").join(",")}) GROUP BY conversation_id`,
+  ).all(...conversations) as Array<{ conversation_id: number; n: number }>;
+  const bySession = new Map<string, number>();
+  for (const row of rows) {
+    const group = sessionOf.get(row.conversation_id) ?? `conversation:${row.conversation_id}`;
+    bySession.set(group, (bySession.get(group) ?? 0) + row.n);
+  }
+  return (group: string) => bySession.get(group);
 }
 
 /** Read one request's ranked history and bounded source context inside a savepoint on the caller's connection. */

--- a/test/search/fusion.test.ts
+++ b/test/search/fusion.test.ts
@@ -31,6 +31,27 @@ describe("fuseHistoryBySession", () => {
     expect(countSummaries(fuseHistoryBySession(messages, summaries, limit))).toBe(expected);
   });
 
+  it("ranks a small session above a large one that reached the same position", () => {
+    // Both sessions' best row sits at the same place; only their sizes differ.
+    const messages = [message("sess-big", 0), message("sess-small", 1)];
+    const sizes = new Map([["sess-big", 400], ["sess-small", 40]]);
+    const order = fuseHistoryBySession(messages, [], 2, (group) => sizes.get(group));
+
+    expect(order.map((hit) => hit.sessionId)).toEqual(["sess-small", "sess-big"]);
+    // Without sizes the raw positions stand, so the large session keeps its lead.
+    expect(fuseHistoryBySession(messages, [], 2).map((hit) => hit.sessionId)).toEqual(["sess-big", "sess-small"]);
+  });
+
+  it("leaves a session of unknown size where its rank put it", () => {
+    // Ranked big, unknown, small. Normalisation demotes big and promotes small
+    // past it; the session with no size is carried by neither move.
+    const messages = [message("sess-big", 0), message("sess-unknown", 1), message("sess-small", 2)];
+    const sizes = new Map([["sess-big", 400], ["sess-small", 40]]);
+    const order = fuseHistoryBySession(messages, [], 3, (group) => sizes.get(group));
+
+    expect(order.map((hit) => hit.sessionId)).toEqual(["sess-small", "sess-unknown", "sess-big"]);
+  });
+
   it("spends a single slot on the message, as callers already expect", () => {
     const { messages, summaries } = oneEach(3);
     const hits = fuseHistoryBySession(messages, summaries, 1);


### PR DESCRIPTION
## Changes

`lcm search` scored a session by the reciprocal rank of the best position any **single** one of its rows reached. A long session enters the candidate pool many times, so one of its rows lands high on almost any query — it buys more lottery tickets. Measured on a real corpus, one 368 KB session took **11 of 13 top-5 slots on unrelated questions**. bm25 already normalises a message by its length; nothing normalised a session.

Session scores are now divided by a saturating size term, in the role BM25's `b` plays for message length:

```ts
score / (1 - b + b * (size / averageSize))
```

### The size signal is the whole decision

Counting a session's **rows in the candidate pool** is free — the data is already in memory — and it was the obvious choice. It was implemented and it **loses on every question set** (13-question reviewed 0.385→0.308, human-provenance 27 0.407→0.370, pooled 220 0.277→0.259, hardest corpus 0.067→0.033). The reason is structural: that signal is *query-dependent*. A session about one subject fills the pool on queries about that subject — exactly when it is the right answer — so it is damped hardest when it should win.

The session's **message count** does not move with the query. It costs one grouped count over the conversations already in hand: **0.1 ms** measured, against a 500 ms p95 budget. (An earlier note in #358 claimed this query was too expensive; that number belonged to candidate-pool *enlargement*, a different operation, and is retracted.) Cardinality was verified across all 3451 ingested corpora: zero sessions span more than one conversation, so the count is the true session size.

### How the constant was chosen

Two prior ranking changes were rejected here by measurement, and a third — top-K mean fusion — was rejected during this work (pooled gain +8/−3, p = 0.58, and it zeroed the hardest corpus). So this one was not allowed to pick its own parameter on the sets that grade it.

`scripts/bench-corpora.mts` grows `LCM_BENCH_GROUP`, splitting the corpora **by corpus** (not by question, so no session appears on both sides) into a tuning group and a held-out group. The `lcm` corpus is deliberately on the tuning side: its questions had already been scored across a sweep and cannot serve as unseen. Held-out questions were built with a different `LCM_BENCH_SEED` so they are a fresh sample.

Sweep on the tuning group only — 5 corpora, 171 questions:

| b | hit@5 |
|---:|---:|
| 0 (none) | 0.205 |
| 0.10 | 0.240 |
| **0.25** | **0.269** |
| **0.40** | **0.269** |
| 0.60 | 0.263 |
| 0.75 | 0.257 |
| 1.00 | 0.187 |

A broad plateau, not a spike — every value from 0.25 to 0.75 beats no normalisation, including BM25's canonical 0.75. `b = 0.40` was fixed as the plateau's centre and **pre-registered before the held-out group was looked at**.

Graded once, on 4 corpora and 197 questions the parameter had never seen:

| | baseline | b = 0.40 |
|---|---:|---:|
| xgh (794 sessions) | 0.150 | 0.167 |
| .claude (139) | 0.267 | 0.300 |
| Inspector (102) | 0.429 | 0.524 |
| trilha-probatoria (61) | 0.286 | 0.371 |
| **pooled (197)** | **0.269** | **0.320** |

Per-question: **+13 gained, −3 lost**, 352 unchanged. Sign test on the 16 discordant pairs: **p = 0.021**. Improves on all four.

On the tuning-side sets, measured in the same window: reviewed 13 unchanged at 0.385 (the long-session question that `b = 0.25` lost is retained at 0.40), human-provenance 27 goes 0.333 → 0.519.

## Files Touched

- `src/search/native-history.ts` — `SESSION_LENGTH_NORM`, `normaliseBySessionSize`, `sessionSizes`
- `scripts/bench-corpora.mts` — `LCM_BENCH_GROUP` tune/holdout split, `LCM_BENCH_SEED`/`LCM_BENCH_N` overrides
- `test/search/fusion.test.ts` — two tests
- `docs/search.md` — the tune/grade protocol
- `.changeset/session-length-normalisation.md`

## Issue Reference

Refs #358

## Test Evidence

```
Test Files  126 passed | 1 skipped (127)
     Tests  1290 passed | 4 skipped (1294)
```

`npx tsc --noEmit` clean.

Both new tests mutation-checked against two independent mutations — setting the constant to 0, and removing the normalisation call. Each mutation fails exactly those two tests. The first version of the unknown-size test passed under mutation (with one known size the average is that size, so the divisor is 1) and was rewritten with three sessions.

Note: the suite is flaky in this environment independently of this change — see #372. The run above is green; a rerun may show 3 failures in `passive-learning`/`post-tool`, which reproduce on `main`.

## Risks & Follow-ups

- A genuinely long, genuinely relevant session is damped by construction. At `b = 0.40` the one such question in the reviewed set survives, but the mechanism's cost is real and this is where a regression would appear first.
- `averageSize` is the mean over the candidate sessions of that query, where BM25's `avgdl` is corpus-wide. Per-query was chosen because it needs no extra state; if the plateau ever proves unstable across corpora, this is the first thing to try.
- The held-out group has now been read once. A future parameter change needs a fresh split or a new corpus, not a second look at this one.
- Baselines drift between runs because the corpora grow during a session (0.277 / 0.282 / 0.286 for the same configuration). Every number above was measured in one window against its own baseline; the `sessions=` column added in #368 is what makes that visible.

## AR Status

[SKIP_AR: single mechanism in one function, both tests mutation-checked, decision graded on a pre-registered held-out set]

## Introspection Findings

A parameter sweep on a small set lies through its *shape*, not just its precision. On 13 questions the `b` curve alternated 0.385 / 0.308 / 0.385 / 0.308 with no pattern, and I read that as "no defensible value exists — anything that works is a fit". On 171 questions the same sweep is smooth and unimodal. The serrated curve was one question flipping, not absent signal. Before concluding a parameter has no principled value, check the set is large enough to show the curve's shape.

## Token Cost

~180k tokens (Opus 5, plus 10 haiku design cells)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU
