### PR TITLE
feat(search): stop offering subagent transcripts as memory

### DIFF
--- a/.changeset/exclude-subagent-transcripts.md
+++ b/.changeset/exclude-subagent-transcripts.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": minor
+---
+
+Stop `lcm search` from returning subagent transcripts. Claude Code writes a dispatched agent's transcript as `agent-<id>.jsonl` and ingestion keeps it as a session, so ranked recall was competing the user's own history against review panels arguing about diffs — 78% of ingested sessions here, above 90% on some projects. Measured over 202 questions whose answers are human sessions, skipping them gains 14 and loses none (hit@5 0.337 to 0.406, sign test p = 0.0001). The transcripts stay ingested and stay reachable through `lcm grep` and `lcm expand`; only ranked search stops offering them unprompted. `lcm bench build` samples from the same population, so its questions are answerable by the search it grades.

--- a/docs/search.md
+++ b/docs/search.md
@@ -88,6 +88,10 @@ lcm bench run   --project /path/to/project
   Output defaults to `~/.lossless-claude/projects/<hash>/.lcm-bench.json`, local and uncommitted.
   Use `--out <file>` to choose another location. Invalid files are rejected by `run` before scoring.
   Both `build --help` and `run --help` show usage without generating questions or running searches.
+Questions are sampled from the user's own sessions only. Subagent transcripts — the `agent-*`
+sessions Claude Code writes for dispatched agents — are skipped, because `lcm search` does not
+return them either, so a question labelled with one could never be answered.
+
 - **`run`** uses the retrieval engine behind `lcm search`, deduplicates matches by session for
   scoring, and reports:
 

--- a/scripts/bench-corpora.mts
+++ b/scripts/bench-corpora.mts
@@ -80,7 +80,7 @@ const QUESTIONS_PER_CORPUS = positiveInteger("LCM_BENCH_N", 30);
  */
 const SEED = positiveInteger("LCM_BENCH_SEED", 1234);
 /** Below this a project holds too few sessions to rank anything meaningfully. */
-const MIN_DB_BYTES = 8 * 1024 * 1024;
+const MIN_DB_BYTES = 2 * 1024 * 1024;
 
 async function discoverCorpora(): Promise<string[]> {
   const configured = process.env.LCM_BENCH_CORPORA;

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -447,8 +447,11 @@ export async function buildBench(
     // Migrations may backfill on first open, so this handle is read-write.
     runLcmMigrations(db);
     const convStore = new ConversationStore(db);
+    // Questions must come from the population search can return. Search skips
+    // subagent transcripts, so a question labelled with one is unanswerable by
+    // construction and would score as a miss that no ranking could fix.
     const conversations = (await convStore.listConversations()).filter(
-      (c) => c.sessionId.length > 0,
+      (c) => c.sessionId.length > 0 && !c.sessionId.startsWith("agent-"),
     );
     if (conversations.length === 0) {
       return { out: "", exitCode: 1, stdout: "No conversations in the project database.\n" };

--- a/src/search/native-history.ts
+++ b/src/search/native-history.ts
@@ -214,9 +214,48 @@ export async function rankNativeHistory(
     }
     return ranked;
   };
-  const rankedMessages = await attach(result.messages);
-  const rankedSummaries = await attach(result.summaries);
-  return fuseHistoryBySession(rankedMessages, rankedSummaries, input.limit, sessionSizes(db, [...rankedMessages, ...rankedSummaries], sessionOf));
+  return rankHistoryHits(await attach(result.messages), await attach(result.summaries), input.limit, sizes => sessionSizes(db, sizes, sessionOf));
+}
+
+/** Filter subagent transcripts out of the candidates, then fuse what remains. */
+export function rankHistoryHits(
+  messages: RankedHistoryHit[],
+  summaries: RankedHistoryHit[],
+  limit: number,
+  sizesOf?: (hits: RankedHistoryHit[]) => (group: string) => number | undefined,
+): RankedHistoryHit[] {
+  const rankedMessages = withoutSubagents(messages);
+  const rankedSummaries = withoutSubagents(summaries);
+  const sizes = sizesOf?.([...rankedMessages, ...rankedSummaries]);
+  return fuseHistoryBySession(rankedMessages, rankedSummaries, limit, sizes);
+}
+
+/**
+ * Subagent transcripts, by the session id a transcript filename becomes.
+ *
+ * Claude Code writes a dispatched agent's transcript as `agent-<id>.jsonl`
+ * beside the session's own, and ingestion takes the session id from the
+ * filename. That naming is an external convention: if it ever changes, this
+ * filter silently stops matching and search quietly gets noisier again.
+ */
+const SUBAGENT_SESSION = /^agent-/;
+
+/**
+ * Drop subagent transcripts from the ranked candidates.
+ *
+ * They are 78% of ingested sessions here — above 90% on some projects — and
+ * they are not the user's memory: a review panel arguing about a diff, stored
+ * as though the user had said it. Ranking searched a haystack that was mostly
+ * machines talking to each other. Measured over 202 questions whose answers are
+ * human sessions, dropping them gains 14 and loses **none** (0.337 to 0.406,
+ * sign test p = 0.0001).
+ *
+ * They stay ingested and stay reachable: `lcm grep` and `lcm expand` go through
+ * the retrieval engine directly and are untouched. What changes is only what
+ * ranked recall offers up on its own.
+ */
+function withoutSubagents(hits: RankedHistoryHit[]): RankedHistoryHit[] {
+  return hits.filter(hit => !(hit.sessionId && SUBAGENT_SESSION.test(hit.sessionId)));
 }
 
 /**

--- a/test/search/fusion.test.ts
+++ b/test/search/fusion.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { fuseHistoryBySession, type RankedHistoryHit } from "../../src/search/native-history.js";
+import { fuseHistoryBySession, rankHistoryHits, type RankedHistoryHit } from "../../src/search/native-history.js";
 
 // Summaries are given a far better rank than any message, so a summary that
 // fails to surface has been hidden by the fusion structure, not outscored.
@@ -50,6 +50,14 @@ describe("fuseHistoryBySession", () => {
     const order = fuseHistoryBySession(messages, [], 3, (group) => sizes.get(group));
 
     expect(order.map((hit) => hit.sessionId)).toEqual(["sess-small", "sess-unknown", "sess-big"]);
+  });
+
+  it("never offers a subagent transcript, however well it ranks", () => {
+    // The subagent sits first; only the human session may be returned.
+    const messages = [message("agent-a1f87c09d", 0), message("sess-human", 1)];
+    const order = rankHistoryHits(messages, [], 5);
+
+    expect(order.map((hit) => hit.sessionId)).toEqual(["sess-human"]);
   });
 
   it("spends a single slot on the message, as callers already expect", () => {


### PR DESCRIPTION
## Changes

`lcm search` was ranking the user's own history against review panels arguing about diffs.

Claude Code writes a dispatched agent's transcript as `agent-<id>.jsonl` beside the session's own, and ingestion takes the session id from the filename. Measured across every corpus on this account with 20+ sessions:

| corpus | sessions | `agent-*` | share |
|---|---:|---:|---:|
| lossless-claude | 816 | 703 | 86% |
| xgh | 794 | 734 | 92% |
| dwigt | 296 | 239 | 81% |
| .claude | 139 | 0 | 0% |
| lcm | 106 | 44 | 42% |
| Inspector | 102 | 97 | 95% |
| autoimprove | 71 | 0 | 0% |
| trilha-probatoria | 62 | 44 | 71% |
| **total** | **2386** | **1861** | **78%** |

Ranked recall now skips them. Nothing about ranking changed — the haystack did.

### The measurement had to be set up before it could be trusted

**65% of the existing bench questions were labelled with an `agent-*` session** (241 of 368), because `bench build` sampled prompts from every session. Scoring the exclusion against those sets would have made 241 questions unanswerable by construction and reported this change as a large regression. So `bench build` now samples from the same population search can return, and the question sets were rebuilt on that basis — 202 questions whose answers are human sessions, fresh seed.

Graded on those, same questions both sides:

| corpus | keeping them | skipping them |
|---|---:|---:|
| lossless-claude (n=37) | 0.351 | 0.432 |
| xgh (n=27) | 0.037 | **0.222** |
| lcm (n=24) | 0.333 | 0.458 |
| trilha-probatoria (n=10) | 0.700 | 0.900 |
| Inspector (n=2) | 0.500 | 1.000 |
| dwigt (n=24) | 0.208 | 0.208 |
| .claude (n=60) | 0.333 | 0.333 |
| autoimprove (n=7) | 0.286 | 0.286 |
| **pooled (n=202)** | **0.337** | **0.406** |

Per-question: **+14 gained, 0 lost**, 188 unchanged. Sign test: **p = 0.0001**.

Not one question got worse. And the three corpora that do not move are exactly the ones with nothing to remove — `.claude` and `autoimprove` have zero subagent sessions, and `dwigt`'s human questions happen not to compete with theirs. The effect appears only where the noise is.

This also resolves a confound in #358: what looked like "bigger corpus is harder to search" was partly "bigger corpus is fuller of agent chatter" — the two corpora scoring best per session are the two with none.

### Scope

The transcripts stay ingested and stay reachable: `lcm grep` and `lcm expand` go through `RetrievalEngine` directly and are untouched. Only ranked search stops offering them unprompted. Nothing is deleted and no migration runs.

## Files Touched

- `src/search/native-history.ts` — `SUBAGENT_SESSION`, `withoutSubagents`, and `rankHistoryHits` extracted so the filter and the fusion are testable as one unit
- `src/bench.ts` — the sampler skips subagent sessions
- `scripts/bench-corpora.mts` — corpus threshold 8 MB to 2 MB
- `test/search/fusion.test.ts` — one test
- `docs/search.md`, `.changeset/exclude-subagent-transcripts.md`

## Issue Reference

Closes #369
Refs #358

## Test Evidence

```
Test Files  126 passed | 1 skipped (127)
     Tests  1291 passed | 4 skipped (1295)
```

`npx tsc --noEmit` clean.

The new test is mutation-checked: pointing `SUBAGENT_SESSION` at a pattern that matches nothing fails it and only it.

## Risks & Follow-ups

- **The `agent-` filename convention is external.** If Claude Code renames those transcripts, the filter silently stops matching and search quietly gets noisier again, with no error. Called out in the constant's docstring; a `lcm stats` line showing the excluded share would make a drift visible, and is not in this PR.
- A user who genuinely wants to recall what a review panel concluded now has to reach it through `lcm grep` or `lcm expand`. That is the intended trade — but it is a behaviour change, not only a quality one.
- Question sets shrank sharply once subagent-labelled questions were dropped (368 to 202), and some corpora are now too small to say anything alone (`Inspector` has 2). The pooled number carries the result; individual small corpora do not.
- Lowering the harness threshold to 2 MB added corpora that turn out to be nearly all subagent traffic, contributing 1-3 human questions each. It is a small gain in held-out capacity, not the doubling I expected.

## AR Status

[SKIP_AR: one filter in one function plus the matching sampler change, mutation-checked, graded on rebuilt sets with a stated confound corrected]

## Introspection Findings

The obvious way to measure this would have scored it as a large regression, because the ground truth had been sampled from the population the change removes. Whenever a change alters *what can be returned*, the question sets have to be rebuilt before the comparison means anything — the labels are part of the system under test, not a fixed reference.

## Token Cost

~40k tokens (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qoAnX9wwe9e4EaS5hZHvU
