### PR TITLE
fix(compaction): let the previous chunk's summary reach the providers

### DIFF
--- a/.changeset/previous-summary-reaches-providers.md
+++ b/.changeset/previous-summary-reaches-providers.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Leaf and condensed summaries now see the preceding chunk's summary. The compaction engine always passed it, but `SummarizeContext` had no field for it and no provider rendered it, so `<previous_context>` was always `(none)` on the daemon path and `/compact`'s `previous_summary` was accepted and ignored.

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -1,12 +1,11 @@
 import Anthropic from "@anthropic-ai/sdk";
 import {
   LCM_SUMMARIZER_SYSTEM_PROMPT,
-  buildLeafSummaryPrompt,
-  buildCondensedSummaryPrompt,
   resolveTargetTokens,
   resolveMaxOutputTokens,
 } from "../summarize.js";
 import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "./types.js";
+import { buildSummaryPrompt } from "./prompt.js";
 
 export type { LcmSummarizeFn } from "./types.js";
 
@@ -60,9 +59,7 @@ export function createAnthropicSummarizer(opts: SummarizerOptions): LcmSummarize
       condensedTargetTokens: 2000,
     });
 
-    const prompt = ctx.taskPrompt !== undefined ? text : ctx.isCondensed
-      ? buildCondensedSummaryPrompt({ text, targetTokens, depth: ctx.depth ?? 1 })
-      : buildLeafSummaryPrompt({ text, mode: aggressive ? "aggressive" : "normal", targetTokens });
+    const prompt = buildSummaryPrompt(text, aggressive, { ...ctx, targetTokens });
 
     let lastError: Error | undefined;
 

--- a/src/llm/openai.ts
+++ b/src/llm/openai.ts
@@ -1,9 +1,8 @@
 import OpenAI from "openai";
 import type { LcmSummarizeFn, SummarizeContext, SummarizerUsage } from "./types.js";
+import { buildSummaryPrompt } from "./prompt.js";
 import {
   LCM_SUMMARIZER_SYSTEM_PROMPT,
-  buildLeafSummaryPrompt,
-  buildCondensedSummaryPrompt,
   resolveTargetTokens,
   resolveMaxOutputTokens,
 } from "../summarize.js";
@@ -77,9 +76,7 @@ export function createOpenAISummarizer(opts: OpenAISummarizerOptions): LcmSummar
         condensedTargetTokens: 2000,
       });
 
-    const prompt = ctx.taskPrompt !== undefined ? text : ctx.isCondensed
-      ? buildCondensedSummaryPrompt({ text, targetTokens, depth: ctx.depth ?? 1 })
-      : buildLeafSummaryPrompt({ text, mode: aggressive ? "aggressive" : "normal", targetTokens });
+    const prompt = buildSummaryPrompt(text, aggressive, { ...ctx, targetTokens });
 
     let lastError: Error | undefined;
 

--- a/src/llm/prompt.ts
+++ b/src/llm/prompt.ts
@@ -22,8 +22,13 @@ export function buildSummaryPrompt(
   });
 
   return ctx.isCondensed
-    ? buildCondensedSummaryPrompt({ text, targetTokens, depth: ctx.depth ?? 1 })
-    : buildLeafSummaryPrompt({ text, mode: aggressive ? "aggressive" : "normal", targetTokens });
+    ? buildCondensedSummaryPrompt({
+        text, targetTokens, depth: ctx.depth ?? 1, previousSummary: ctx.previousSummary,
+      })
+    : buildLeafSummaryPrompt({
+        text, mode: aggressive ? "aggressive" : "normal", targetTokens,
+        previousSummary: ctx.previousSummary,
+      });
 }
 
 /** The same prompt with the system preamble prepended, for CLIs with no system-prompt flag. */

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -45,6 +45,8 @@ export type SummarizeContext = {
   isCondensed?: boolean;
   targetTokens?: number;
   depth?: number;
+  /** The preceding chunk's summary, rendered into the prompt so chunks read as one thread. */
+  previousSummary?: string;
   onUsage?: (usage: SummarizerUsage) => void;
 };
 

--- a/test/llm/openai.test.ts
+++ b/test/llm/openai.test.ts
@@ -33,6 +33,18 @@ describe("createOpenAISummarizer", () => {
     expect(args.messages[0].content).toContain("context-compaction summarization engine");
   });
 
+  it("sends the previous chunk's summary in the prompt it puts on the wire", async () => {
+    const mockClient = makeClient("Summary.");
+    const summarizer = createOpenAISummarizer({
+      model: "m", baseURL: "http://x/v1", _clientOverride: mockClient as any,
+    });
+    await summarizer("Conversation text", false, {
+      previousSummary: "Earlier the user chose SQLite over Postgres.",
+    });
+    const args = mockClient.chat.completions.create.mock.calls[0][0];
+    expect(args.messages[0].content).toContain("Earlier the user chose SQLite over Postgres.");
+  });
+
   it("sends reasoning verbatim when configured and omits the key otherwise", async () => {
     const withReasoning = makeClient("Summary.");
     await createOpenAISummarizer({

--- a/test/llm/prompt-previous-summary.test.ts
+++ b/test/llm/prompt-previous-summary.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { buildSummaryPrompt, buildSummaryPromptWithSystem } from "../../src/llm/prompt.js";
+
+/**
+ * The compaction engine hands every chunk the previous chunk's summary so the
+ * chunks read as one thread. It reached the provider context but was never
+ * rendered into the prompt (#380).
+ */
+describe("buildSummaryPrompt carries the previous chunk's summary", () => {
+  const PREVIOUS = "Earlier the user chose SQLite over Postgres for the event store.";
+
+  /** The block the leaf template fills with the previous summary, or "(none)". */
+  function previousContextBlock(prompt: string): string {
+    return prompt.match(/<previous_context>([\s\S]*?)<\/previous_context>/)?.[1].trim() ?? "";
+  }
+
+  it("renders it into a leaf prompt in place of the empty marker", () => {
+    const prompt = buildSummaryPrompt("some conversation", false, { previousSummary: PREVIOUS });
+    expect(previousContextBlock(prompt)).toBe(PREVIOUS);
+  });
+
+  it("renders it into a condensed prompt", () => {
+    const prompt = buildSummaryPrompt("some summaries", false, {
+      isCondensed: true, depth: 1, previousSummary: PREVIOUS,
+    });
+    expect(prompt).toContain(PREVIOUS);
+    expect(prompt).toContain("<previous_context>");
+  });
+
+  it("keeps the empty marker when there is no previous chunk", () => {
+    const prompt = buildSummaryPrompt("some conversation", false, {});
+    expect(previousContextBlock(prompt)).toBe("(none)");
+  });
+
+  it("reaches the CLI providers that prepend the system prompt", () => {
+    const prompt = buildSummaryPromptWithSystem("some conversation", false, {
+      previousSummary: PREVIOUS,
+    });
+    expect(prompt).toContain(PREVIOUS);
+  });
+
+  it("is left out of an alternate task prompt, which sends the text verbatim", () => {
+    const prompt = buildSummaryPrompt("raw text", false, {
+      taskPrompt: "do something else", previousSummary: PREVIOUS,
+    });
+    expect(prompt).toBe("raw text");
+  });
+});


### PR DESCRIPTION
Closes #380.

## The bug

`CompactionEngine` passes `previousSummary` on every leaf and condensed call, and `/compact` accepts a `previous_summary` field. Neither reached a provider: `SummarizeContext` had no such field and no provider rendered one. So `<previous_context>` was always `(none)` on the daemon path, and every leaf summary was written without knowing what came before it. Only the legacy `createLcmSummarizeFromLegacyParams`, which has no callers under `src/`, honoured it.

## The fix

- `previousSummary?: string` added to `SummarizeContext`.
- `buildSummaryPrompt` forwards it to `buildLeafSummaryPrompt` and `buildCondensedSummaryPrompt`, which already accepted it. That covers `claude-process`, `codex-process`, `copilot-process` and the `session` provider in one place.
- `anthropic.ts` and `openai.ts` had inlined a byte-identical copy of that builder. They call `buildSummaryPrompt` instead, so the render has one source and the fix reaches them too. Net negative lines.

Nothing changed in `CompactionSummarizeFn`; the engine already sent the value.

## Tests

- `test/llm/prompt-previous-summary.test.ts`: the leaf block holds the previous summary instead of `(none)`, the condensed prompt gets a `<previous_context>` block, an absent previous chunk still renders `(none)`, and an alternate `taskPrompt` still sends the text verbatim.
- `test/llm/openai.test.ts`: the text reaches the message actually put on the wire, not just the builder.

`npx tsc --noEmit` clean. `test/llm`, `test/compaction.test.ts`, `test/summarize.test.ts`, `test/daemon/session-compact.test.ts` and `test/daemon/summarize-jobs.test.ts` pass.

## Risks

- Every leaf prompt grows by one previous summary, in practice ~4k chars. Only `copilot-process` passes the prompt through argv; its existing 200k-byte guard already covers the 50k cap on `previous_summary`. The other providers use stdin.
- Summary text changes for every provider, by design. No stored summary is rewritten.

## AR Status

[SKIP_AR: not run — request `/adversarial-review` on this PR if wanted.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ga2dD8xzcqyoXuq6NkZB6L