### PR TITLE
feat(hooks): dedup tool events on (session_id, tool_use_id)

### DIFF
--- a/.changeset/tool-use-id-dedup.md
+++ b/.changeset/tool-use-id-dedup.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+Passive-learning events now dedup on `(session_id, tool_use_id)`. Both the command hook and the function-hooks module receive Claude Code's call id, so a session that runs both paths records each tool call once instead of twice. Events schema v4 adds the column and its index; a database written before it migrates on open.

--- a/docs/hook-protocol.md
+++ b/docs/hook-protocol.md
@@ -107,6 +107,7 @@ Invoked after a tool call **succeeds**, and only for the tools the `PostToolUse`
 | `session_id` | string | Session identifier |
 | `cwd` | string | Working directory |
 | `tool_name` | string | Name of the tool that was called |
+| `tool_use_id` | string | Claude Code's id for this call; the dedup key |
 | `tool_input` | object | The tool's input arguments |
 | `tool_response` | any | The tool's response object |
 | `tool_output` | string | Plaintext output (if available) |
@@ -130,7 +131,9 @@ A daemon that answers 404 (an older lcm build without these routes) is logged on
 
 **Daemon lifecycle:** the daemon exits when idle, and the command hooks brought it back through `ensureDaemon`. The module does the same: on a connection failure it runs `lcm daemon start --detach` through the host (at most once per minute) and retries the request once, and `session.start` checks `/health` before the first prompt. This needs an `lcm` binary on PATH; without one the module logs it once and events are lost until a command hook (SessionStart, Stop, SessionEnd) restarts the daemon.
 
-**Dedup rule:** while `CLAUDE_CODE_ENABLE_FUNCTION_HOOKS=1` is set, `lcm post-tool`, `lcm user-prompt` and `lcm session-snapshot` exit without recording or printing anything; otherwise every event would land twice and the model would read the memory context twice. The variable is one of two switches that load the module; the other is Claude Code's remote gate (`tengu_plugin_hooks_modules`), which the command hook cannot see. Known limits of this rule: a module that fails to load loses passive capture for the session (the failure is named in Claude Code's debug log), and a session where the remote gate loads the module without the variable records every event twice. The durable fix is dedup on `(session_id, tool_use_id)` in the events DB, which both paths receive.
+**Dedup rule:** while `CLAUDE_CODE_ENABLE_FUNCTION_HOOKS=1` is set, `lcm post-tool`, `lcm user-prompt` and `lcm session-snapshot` exit without recording or printing anything; otherwise every event would land twice and the model would read the memory context twice. The variable is one of two switches that load the module; the other is Claude Code's remote gate (`tengu_plugin_hooks_modules`), which the command hook cannot see. A module that fails to load still loses passive capture for the session; the failure is named in Claude Code's debug log.
+
+**Dedup on the call id:** the env var only avoids the wasted work. The durable guard is `tool_use_id`, which both paths receive: `recordPostToolEvents` skips a call whose `(session_id, tool_use_id)` is already in the events DB, so a session where the remote gate loads the module without the variable records each call once. The whole call is skipped rather than each event, because one call extracts several events. Rows written before schema v4 have no id and never dedup against; a payload without one is recorded as before.
 
 **Types:** run `/plugin-types` in a session with the flag on; it writes `claude-code.d.ts` for the running build. Regenerate after a Claude Code update rather than editing. `claude plugin validate` reads the module statically: `$` may only be passed to a top-level function, and calls must be spelled `$.noun.method(...)`.
 

--- a/src/daemon/routes/tool-event.ts
+++ b/src/daemon/routes/tool-event.ts
@@ -40,9 +40,9 @@ export function createToolEventHandler(config: DaemonConfig): RouteHandler {
 
     const outcome = recordPostToolEvents({
       ...input, cwd, session_id: input.session_id, tool_name: input.tool_name,
-      // Dedup key against the command-hook path; a non-string is dropped rather
-      // than written, so it never becomes a row that matches nothing.
-      tool_use_id: typeof input.tool_use_id === "string" ? input.tool_use_id : undefined,
+      // recordPostToolEvents owns the dedup key's validation, so both paths drop a
+      // non-string the same way instead of writing a row that matches nothing.
+      tool_use_id: input.tool_use_id as string | undefined,
     });
     sendJson(res, 200, { recorded: outcome.recorded, promoted: outcome.hasPriority1 });
 

--- a/src/daemon/routes/tool-event.ts
+++ b/src/daemon/routes/tool-event.ts
@@ -40,6 +40,9 @@ export function createToolEventHandler(config: DaemonConfig): RouteHandler {
 
     const outcome = recordPostToolEvents({
       ...input, cwd, session_id: input.session_id, tool_name: input.tool_name,
+      // Dedup key against the command-hook path; a non-string is dropped rather
+      // than written, so it never becomes a row that matches nothing.
+      tool_use_id: typeof input.tool_use_id === "string" ? input.tool_use_id : undefined,
     });
     sendJson(res, 200, { recorded: outcome.recorded, promoted: outcome.hasPriority1 });
 

--- a/src/hooks/events-db.ts
+++ b/src/hooks/events-db.ts
@@ -100,6 +100,14 @@ export class EventsDb {
     }
   }
 
+  /** Rows written before v4 have no tool_use_id and never dedup against. */
+  private ensureToolUseIdColumn(): void {
+    const columns = this.db.prepare("PRAGMA table_info(events)").all() as { name: string }[];
+    if (!columns.some((c) => c.name === "tool_use_id")) {
+      this.db.exec("ALTER TABLE events ADD COLUMN tool_use_id TEXT");
+    }
+  }
+
   private migrate(): void {
     // Check if schema_version table exists
     const row = this.db.prepare(
@@ -128,8 +136,12 @@ export class EventsDb {
         );
         CREATE INDEX IF NOT EXISTS idx_error_log_created ON error_log(created_at);
         CREATE INDEX IF NOT EXISTS idx_events_pattern_lookup ON events(type, category, data, created_at);
-        CREATE INDEX IF NOT EXISTS idx_events_tool_use ON events(session_id, tool_use_id);
       `);
+      // The events table here may predate v4, so the column has to exist before the index.
+      this.ensureToolUseIdColumn();
+      this.db.exec(
+        "CREATE INDEX IF NOT EXISTS idx_events_tool_use ON events(session_id, tool_use_id)"
+      );
       return;
     }
 
@@ -156,11 +168,7 @@ export class EventsDb {
           );
         }
         if (currentVersion < 4) {
-          // Rows written before this migration have no id and never dedup against.
-          const columns = this.db.prepare("PRAGMA table_info(events)").all() as { name: string }[];
-          if (!columns.some((c) => c.name === "tool_use_id")) {
-            this.db.exec("ALTER TABLE events ADD COLUMN tool_use_id TEXT");
-          }
+          this.ensureToolUseIdColumn();
           this.db.exec(
             "CREATE INDEX IF NOT EXISTS idx_events_tool_use ON events(session_id, tool_use_id)"
           );
@@ -199,6 +207,32 @@ export class EventsDb {
       "SELECT 1 FROM events WHERE session_id = ? AND tool_use_id = ? LIMIT 1"
     ).get(sessionId, toolUseId);
     return row !== undefined;
+  }
+
+  /**
+   * Writes one tool call's events, or none when another path already recorded that call.
+   * The check and the inserts share one write transaction: without it, two paths handling
+   * the same call could both read "not present" and both insert.
+   */
+  insertToolCallEvents(
+    sessionId: string, events: ExtractedEvent[], sourceHook: string, toolUseId?: string,
+  ): number {
+    if (!toolUseId) {
+      for (const event of events) this.insertEvent(sessionId, event, sourceHook);
+      return events.length;
+    }
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const duplicate = this.hasToolCall(sessionId, toolUseId);
+      if (!duplicate) {
+        for (const event of events) this.insertEvent(sessionId, event, sourceHook, toolUseId);
+      }
+      this.db.exec("COMMIT");
+      return duplicate ? 0 : events.length;
+    } catch (e) {
+      try { this.db.exec("ROLLBACK"); } catch { /* the transaction is already gone */ }
+      throw e;
+    }
   }
 
   getUnprocessed(limit = 500): EventRow[] {

--- a/src/hooks/events-db.ts
+++ b/src/hooks/events-db.ts
@@ -23,6 +23,7 @@ export interface EventRow {
   data: string;
   priority: number;
   source_hook: string;
+  tool_use_id: string | null;
   prev_event_id: number | null;
   processed_at: string | null;
   created_at: string;
@@ -41,7 +42,7 @@ export interface PatternReinforcementStats {
   distinctSessions: number;
 }
 
-const SCHEMA_VERSION = 3;
+const SCHEMA_VERSION = 4;
 
 const SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
@@ -54,6 +55,7 @@ CREATE TABLE IF NOT EXISTS events (
   data          TEXT NOT NULL,
   priority      INTEGER DEFAULT 3,
   source_hook   TEXT NOT NULL,
+  tool_use_id   TEXT,
   prev_event_id INTEGER,
   processed_at  TEXT,
   created_at    TEXT DEFAULT (datetime('now'))
@@ -61,6 +63,7 @@ CREATE TABLE IF NOT EXISTS events (
 CREATE INDEX IF NOT EXISTS idx_events_unprocessed ON events(processed_at) WHERE processed_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_events_session ON events(session_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_events_pattern_lookup ON events(type, category, data, created_at);
+CREATE INDEX IF NOT EXISTS idx_events_tool_use ON events(session_id, tool_use_id);
 CREATE TABLE IF NOT EXISTS error_log (
   id         INTEGER PRIMARY KEY AUTOINCREMENT,
   hook       TEXT NOT NULL,
@@ -125,6 +128,7 @@ export class EventsDb {
         );
         CREATE INDEX IF NOT EXISTS idx_error_log_created ON error_log(created_at);
         CREATE INDEX IF NOT EXISTS idx_events_pattern_lookup ON events(type, category, data, created_at);
+        CREATE INDEX IF NOT EXISTS idx_events_tool_use ON events(session_id, tool_use_id);
       `);
       return;
     }
@@ -151,6 +155,16 @@ export class EventsDb {
             "CREATE INDEX IF NOT EXISTS idx_events_pattern_lookup ON events(type, category, data, created_at)"
           );
         }
+        if (currentVersion < 4) {
+          // Rows written before this migration have no id and never dedup against.
+          const columns = this.db.prepare("PRAGMA table_info(events)").all() as { name: string }[];
+          if (!columns.some((c) => c.name === "tool_use_id")) {
+            this.db.exec("ALTER TABLE events ADD COLUMN tool_use_id TEXT");
+          }
+          this.db.exec(
+            "CREATE INDEX IF NOT EXISTS idx_events_tool_use ON events(session_id, tool_use_id)"
+          );
+        }
         this.db.prepare("UPDATE schema_version SET version = ?").run(SCHEMA_VERSION);
         this.db.exec("COMMIT");
       } catch (e) {
@@ -161,17 +175,30 @@ export class EventsDb {
     }
   }
 
-  insertEvent(sessionId: string, event: ExtractedEvent, sourceHook: string): number {
+  insertEvent(sessionId: string, event: ExtractedEvent, sourceHook: string, toolUseId?: string): number {
     const stmt = this.db.prepare(`
-      INSERT INTO events (session_id, seq, type, category, data, priority, source_hook)
+      INSERT INTO events (session_id, seq, type, category, data, priority, source_hook, tool_use_id)
       VALUES (?, (SELECT COALESCE(MAX(seq), 0) + 1 FROM events WHERE session_id = ?),
-              ?, ?, ?, ?, ?)
+              ?, ?, ?, ?, ?, ?)
     `);
     const result = stmt.run(
       sessionId, sessionId,
-      event.type, event.category, event.data, event.priority, sourceHook
+      event.type, event.category, event.data, event.priority, sourceHook, toolUseId ?? null
     );
     return Number(result.lastInsertRowid);
+  }
+
+  /**
+   * True when this tool call was already recorded, whichever path recorded it.
+   * The command hook and the function-hooks module both receive `tool_use_id`, so a
+   * session that runs both (Claude Code's remote gate loads the module without the
+   * env var) records each call once instead of twice.
+   */
+  hasToolCall(sessionId: string, toolUseId: string): boolean {
+    const row = this.db.prepare(
+      "SELECT 1 FROM events WHERE session_id = ? AND tool_use_id = ? LIMIT 1"
+    ).get(sessionId, toolUseId);
+    return row !== undefined;
   }
 
   getUnprocessed(limit = 500): EventRow[] {

--- a/src/hooks/post-tool.ts
+++ b/src/hooks/post-tool.ts
@@ -25,6 +25,8 @@ export interface PostToolPayload {
   tool_input?: Record<string, unknown>;
   tool_response?: unknown;
   tool_output?: { isError?: boolean };
+  /** Claude Code's id for this tool call; both hook paths receive it. */
+  tool_use_id?: string;
   hook_event_name?: string;
   error?: string;
   is_interrupt?: boolean;
@@ -58,7 +60,14 @@ export function recordPostToolEvents(payload: PostToolPayload): RecordedPostTool
 
   const db = new EventsDb(eventsDbPath(payload.cwd));
   try {
-    for (const event of events) db.insertEvent(payload.session_id, event, sourceHook);
+    // Skip the whole call, not each event: one call extracts several events, and a
+    // per-event check would leave a half batch when the paths raced.
+    if (payload.tool_use_id && db.hasToolCall(payload.session_id, payload.tool_use_id)) {
+      return { recorded: 0, hasPriority1: false, sourceHook };
+    }
+    for (const event of events) {
+      db.insertEvent(payload.session_id, event, sourceHook, payload.tool_use_id);
+    }
   } finally {
     db.close();
   }

--- a/src/hooks/post-tool.ts
+++ b/src/hooks/post-tool.ts
@@ -58,20 +58,23 @@ export function recordPostToolEvents(payload: PostToolPayload): RecordedPostTool
   });
   if (events.length === 0) return { recorded: 0, hasPriority1: false, sourceHook };
 
+  // The command hook forwards raw stdin, so the id is only trusted once it is a
+  // non-empty string; both call sites get the same normalization this way.
+  const toolUseId = typeof payload.tool_use_id === "string" && payload.tool_use_id
+    ? payload.tool_use_id
+    : undefined;
+
   const db = new EventsDb(eventsDbPath(payload.cwd));
+  let recorded: number;
   try {
-    // Skip the whole call, not each event: one call extracts several events, and a
+    // Dedup on the whole call, not each event: one call extracts several events, and a
     // per-event check would leave a half batch when the paths raced.
-    if (payload.tool_use_id && db.hasToolCall(payload.session_id, payload.tool_use_id)) {
-      return { recorded: 0, hasPriority1: false, sourceHook };
-    }
-    for (const event of events) {
-      db.insertEvent(payload.session_id, event, sourceHook, payload.tool_use_id);
-    }
+    recorded = db.insertToolCallEvents(payload.session_id, events, sourceHook, toolUseId);
   } finally {
     db.close();
   }
-  return { recorded: events.length, hasPriority1: events.some(e => e.priority === 1), sourceHook };
+  if (recorded === 0) return { recorded: 0, hasPriority1: false, sourceHook };
+  return { recorded, hasPriority1: events.some(e => e.priority === 1), sourceHook };
 }
 
 /**

--- a/test/hooks/events-db.test.ts
+++ b/test/hooks/events-db.test.ts
@@ -136,10 +136,16 @@ describe("EventsDb", () => {
       const indexRow = db.raw().prepare(
         "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_events_pattern_lookup'"
       ).get();
+      const toolUseIndex = db.raw().prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND name='idx_events_tool_use'"
+      ).get();
+      const columns = db.raw().prepare("PRAGMA table_info(events)").all() as { name: string }[];
       expect(tableRow).toBeDefined();
       expect(indexRow).toBeDefined();
+      expect(toolUseIndex).toBeDefined();
+      expect(columns.map((c) => c.name)).toContain("tool_use_id");
       const versionRow = db.raw().prepare("SELECT version FROM schema_version").get() as { version: number };
-      expect(versionRow.version).toBe(3);
+      expect(versionRow.version).toBe(4);
       db.close();
     });
 

--- a/test/hooks/tool-use-dedup.test.ts
+++ b/test/hooks/tool-use-dedup.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../src/db/events-path.js", () => ({
   eventsDir: () => process.env.TEST_EVENTS_DIR!,
 }));
 
-import { recordPostToolEvents } from "../../src/hooks/post-tool.js";
+import { recordPostToolEvents, type PostToolPayload } from "../../src/hooks/post-tool.js";
 import { EventsDb } from "../../src/hooks/events-db.js";
 
 /**
@@ -21,12 +21,12 @@ import { EventsDb } from "../../src/hooks/events-db.js";
 describe("tool call dedup on (session_id, tool_use_id)", () => {
   let dir: string;
 
-  function call(overrides: Record<string, unknown> = {}) {
+  function call(overrides: Partial<PostToolPayload> = {}) {
     return recordPostToolEvents({
       session_id: "s1", cwd: dir, tool_name: "AskUserQuestion",
       tool_input: { question: "Use SQLite?" }, tool_response: "yes",
       tool_use_id: "toolu_abc", ...overrides,
-    } as never);
+    });
   }
 
   function rows() {
@@ -106,5 +106,28 @@ describe("tool call dedup on (session_id, tool_use_id)", () => {
 
     expect(call().recorded).toBeGreaterThan(0);
     expect(call().recorded).toBe(0);
+  });
+
+  it("opens a pre-migration database whose schema_version table is empty", () => {
+    const path = join(dir, "events.db");
+    const legacy = new DatabaseSync(path);
+    legacy.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      CREATE TABLE events (
+        event_id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL,
+        seq INTEGER NOT NULL DEFAULT 0, type TEXT NOT NULL, category TEXT NOT NULL,
+        data TEXT NOT NULL, priority INTEGER DEFAULT 3, source_hook TEXT NOT NULL,
+        prev_event_id INTEGER, processed_at TEXT, created_at TEXT DEFAULT (datetime('now'))
+      );
+    `);
+    legacy.close();
+
+    // The version row is missing, so the migration steps are skipped; the column still
+    // has to exist before the index that names it.
+    const db = new EventsDb(path);
+    try {
+      const columns = db.raw().prepare("PRAGMA table_info(events)").all() as { name: string }[];
+      expect(columns.some((c) => c.name === "tool_use_id")).toBe(true);
+    } finally { db.close(); }
   });
 });

--- a/test/hooks/tool-use-dedup.test.ts
+++ b/test/hooks/tool-use-dedup.test.ts
@@ -1,0 +1,110 @@
+// test/hooks/tool-use-dedup.test.ts
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { DatabaseSync } from "node:sqlite";
+
+vi.mock("../../src/db/events-path.js", () => ({
+  eventsDbPath: () => join(process.env.TEST_EVENTS_DIR!, "events.db"),
+  eventsDir: () => process.env.TEST_EVENTS_DIR!,
+}));
+
+import { recordPostToolEvents } from "../../src/hooks/post-tool.js";
+import { EventsDb } from "../../src/hooks/events-db.js";
+
+/**
+ * The command hook and the function-hooks module both receive Claude Code's
+ * `tool_use_id`. A session that runs both (the remote gate loads the module
+ * without CLAUDE_CODE_ENABLE_FUNCTION_HOOKS) must record each call once.
+ */
+describe("tool call dedup on (session_id, tool_use_id)", () => {
+  let dir: string;
+
+  function call(overrides: Record<string, unknown> = {}) {
+    return recordPostToolEvents({
+      session_id: "s1", cwd: dir, tool_name: "AskUserQuestion",
+      tool_input: { question: "Use SQLite?" }, tool_response: "yes",
+      tool_use_id: "toolu_abc", ...overrides,
+    } as never);
+  }
+
+  function rows() {
+    const db = new DatabaseSync(join(dir, "events.db"), { readOnly: true });
+    try {
+      return db.prepare("SELECT session_id, tool_use_id FROM events").all() as {
+        session_id: string; tool_use_id: string | null;
+      }[];
+    } finally { db.close(); }
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "tool-dedup-"));
+    process.env.TEST_EVENTS_DIR = dir;
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.TEST_EVENTS_DIR;
+  });
+
+  it("records the same tool call once, whichever path arrives second", () => {
+    const first = call();
+    expect(first.recorded).toBeGreaterThan(0);
+
+    const second = call({ hook_event_name: "PostToolUse" });
+    expect(second.recorded).toBe(0);
+    expect(second.hasPriority1).toBe(false);
+
+    expect(rows()).toHaveLength(first.recorded);
+    expect(rows().every((r) => r.tool_use_id === "toolu_abc")).toBe(true);
+  });
+
+  it("records two different calls in the same session", () => {
+    const first = call();
+    const second = call({ tool_use_id: "toolu_def" });
+    expect(second.recorded).toBe(first.recorded);
+    expect(rows()).toHaveLength(first.recorded + second.recorded);
+  });
+
+  it("records the same id in a different session", () => {
+    const first = call();
+    const other = call({ session_id: "s2" });
+    expect(other.recorded).toBe(first.recorded);
+  });
+
+  it("still records a payload with no tool_use_id, and never dedups on it", () => {
+    const first = call({ tool_use_id: undefined });
+    const second = call({ tool_use_id: undefined });
+    expect(first.recorded).toBeGreaterThan(0);
+    expect(second.recorded).toBe(first.recorded);
+    expect(rows().every((r) => r.tool_use_id === null)).toBe(true);
+  });
+
+  it("adds the column and index to a database written before the migration", () => {
+    const path = join(dir, "events.db");
+    const legacy = new DatabaseSync(path);
+    legacy.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      CREATE TABLE events (
+        event_id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL,
+        seq INTEGER NOT NULL DEFAULT 0, type TEXT NOT NULL, category TEXT NOT NULL,
+        data TEXT NOT NULL, priority INTEGER DEFAULT 3, source_hook TEXT NOT NULL,
+        prev_event_id INTEGER, processed_at TEXT, created_at TEXT DEFAULT (datetime('now'))
+      );
+      INSERT INTO schema_version (version) VALUES (3);
+      INSERT INTO events (session_id, type, category, data, source_hook)
+      VALUES ('s1', 'decision', 'c', '{}', 'PostToolUse');
+    `);
+    legacy.close();
+
+    const db = new EventsDb(path);
+    try {
+      // The pre-migration row has no id, so it never dedups a later call against itself.
+      expect(db.hasToolCall("s1", "toolu_abc")).toBe(false);
+    } finally { db.close(); }
+
+    expect(call().recorded).toBeGreaterThan(0);
+    expect(call().recorded).toBe(0);
+  });
+});


### PR DESCRIPTION
The durable dedup named as a follow-up in #377.

## Why

`CLAUDE_CODE_ENABLE_FUNCTION_HOOKS=1` was the only thing stopping double capture: while it is set the command hooks exit silently. But that variable is one of two switches that load the module. The other is Claude Code's remote gate, which the command hook cannot see, so a session where the gate loads the module without the variable recorded every event twice.

## What was measured, not assumed

`docs/hook-protocol.md` listed the PostToolUse stdin fields and `tool_use_id` was not among them, so the dedup key was in doubt. A headless session with a throwaway `PostToolUse` hook that dumped stdin settled it:

```
keys: ['cwd', 'duration_ms', 'effort', 'hook_event_name', 'permission_mode',
       'prompt_id', 'session_id', 'tool_input', 'tool_name', 'tool_response',
       'tool_use_id', 'transcript_path']
tool_use_id: 'toolu_0172gx2VHbogwVgWHykzs92U'
```

Both paths receive it; the module already sent it to `/tool-event`. The docs table now lists it.

## The change

- Events schema v4: `tool_use_id TEXT` on `events`, plus `idx_events_tool_use ON events(session_id, tool_use_id)`. A database written before it migrates on open, and the empty-`schema_version` edge case reaches v4 too.
- `recordPostToolEvents` skips a call whose `(session_id, tool_use_id)` is already present. The **whole call** is skipped, not each event, because one call extracts several events and a per-event check would leave a half batch when the paths race.
- `/tool-event` forwards `tool_use_id` only when it is a string, so a bad value is dropped rather than written as a row that matches nothing.

The env-var rule stays. It still avoids the wasted work; the id is the guard for when the rule does not apply.

## Compatibility

Rows written before v4 have no id and never dedup a later call against themselves. A payload with no `tool_use_id` records exactly as before. A test covers both.

## Tests

`test/hooks/tool-use-dedup.test.ts`: the same call twice records once, two ids record twice, the same id in another session records, a payload with no id still records, and a v3 database gains the column and index on open.

`npx tsc --noEmit` clean. 230 tests pass across `test/hooks/`, `test/db/` and `test/daemon/routes/tool-event.test.ts`.

## AR Status

[SKIP_AR: not run — request `/adversarial-review` on this PR if wanted.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ga2dD8xzcqyoXuq6NkZB6L