### PR TITLE
chore(ci): run tests on the Mac mini

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,16 +6,43 @@ on:
       - main
       - release
   pull_request:
+  workflow_dispatch:
+    inputs:
+      hosted:
+        description: Use GitHub-hosted Linux when the Mac mini is unavailable
+        type: boolean
+        default: false
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    # Fork code stays off the persistent host. Keep one stable required check.
+    runs-on: ${{ fromJSON((inputs.hosted || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)) && '["ubuntu-latest"]' || '["self-hosted","macOS","ARM64","lcm"]') }}
+    timeout-minutes: 30
+    env:
+      LCM_SKIP_CACHE_SYNC: "1"
     steps:
+      - name: Prepare isolated job directories
+        run: |
+          mkdir -p "$RUNNER_TEMP/lcm-home" "$RUNNER_TEMP/lcm-tmp"
+          {
+            printf 'HOME=%s/lcm-home\n' "$RUNNER_TEMP"
+            printf 'TMPDIR=%s/lcm-tmp\n' "$RUNNER_TEMP"
+            printf 'TMP=%s/lcm-tmp\n' "$RUNNER_TEMP"
+            printf 'TEMP=%s/lcm-tmp\n' "$RUNNER_TEMP"
+          } >> "$GITHUB_ENV"
+
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          clean: true
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -27,7 +54,11 @@ jobs:
         run: npm ci
 
       - name: Install ripgrep (bench baseline)
+        if: runner.os == 'Linux'
         run: sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep
+
+      - name: Verify ripgrep
+        run: rg --version
 
       - name: Type-check
         run: npm run typecheck

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -1,10 +1,8 @@
 # CI on the Mac mini
 
 The `ci` job targets the repository-scoped runner `mac-mini-m4-lcm`, with labels
-`self-hosted`, `macOS`, `ARM64`, and `lcm`. Registration and service activation
-are pending; provision the runner before merging, or jobs will remain queued.
-Its service and working directory must be separate from dwigt's runner on the
-same host. Node 22 is provisioned by
+`self-hosted`, `macOS`, `ARM64`, and `lcm`. Its launchd service and working
+directory are separate from dwigt's runner on the same host. Node 22 is provisioned by
 `actions/setup-node`; ripgrep must be available on the service's saved PATH
 (Homebrew installs it in `/opt/homebrew/bin`).
 
@@ -15,7 +13,7 @@ cancelled, and each run has a 30-minute timeout.
 ## Isolation
 
 Fork pull requests run on GitHub-hosted Linux. Same-repository branches execute
-on the persistent Mac mini and must be trusted. The proposed service uses the
+on the persistent Mac mini and must be trusted. The service uses the
 host's existing runner account; a temporary HOME is filesystem hygiene, not a
 security sandbox or a separate operating-system identity.
 
@@ -26,7 +24,7 @@ fixtures, npm data, and build hooks away from the interactive LCM installation.
 
 ## Operations
 
-Install the LCM instance in `~/actions-runner-lcm`. Use its own `svc.sh` to inspect
+The LCM instance lives in `~/actions-runner-lcm`. Use its own `svc.sh` to inspect
 or restart it; do not reconfigure or stop dwigt's instance. Runner credentials
 stay outside this repository. A fresh registration requires a short-lived token
 from this repository and the additional `lcm` label. Verify the service's `.path`

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -1,0 +1,48 @@
+# CI on the Mac mini
+
+The `ci` job targets the repository-scoped runner `mac-mini-m4-lcm`, with labels
+`self-hosted`, `macOS`, `ARM64`, and `lcm`. Registration and service activation
+are pending; provision the runner before merging, or jobs will remain queued.
+Its service and working directory must be separate from dwigt's runner on the
+same host. Node 22 is provisioned by
+`actions/setup-node`; ripgrep must be available on the service's saved PATH
+(Homebrew installs it in `/opt/homebrew/bin`).
+
+The job retains the `ci` check name and runs dependency installation, typecheck,
+build, tests, and workspace-artifact checks. Superseded runs for the same ref are
+cancelled, and each run has a 30-minute timeout.
+
+## Isolation
+
+Fork pull requests run on GitHub-hosted Linux. Same-repository branches execute
+on the persistent Mac mini and must be trusted. The proposed service uses the
+host's existing runner account; a temporary HOME is filesystem hygiene, not a
+security sandbox or a separate operating-system identity.
+
+Checkout cleans the job workspace and does not persist its GitHub token. Build
+and tests use HOME and temporary directories under `runner.temp`, and plugin
+cache synchronization is disabled. This keeps test databases, Codex/Claude
+fixtures, npm data, and build hooks away from the interactive LCM installation.
+
+## Operations
+
+Install the LCM instance in `~/actions-runner-lcm`. Use its own `svc.sh` to inspect
+or restart it; do not reconfigure or stop dwigt's instance. Runner credentials
+stay outside this repository. A fresh registration requires a short-lived token
+from this repository and the additional `lcm` label. Verify the service's `.path`
+contains `/opt/homebrew/bin` before starting it.
+
+```sh
+gh api repos/lossless-claude/lcm/actions/runners \
+  --jq '.runners[] | {name, status, labels: [.labels[].name]}'
+```
+
+If the host is unavailable, manually run the same job on GitHub-hosted Linux:
+
+```sh
+gh workflow run ci.yml --ref <branch> -f hosted=true
+```
+
+The runner choice changes within the same job, so the required `ci` check cannot
+pass merely because a separate self-hosted job was skipped. The dispatch entry
+becomes available after this workflow reaches the default branch.

--- a/test/daemon/project-path-safety.test.ts
+++ b/test/daemon/project-path-safety.test.ts
@@ -1,10 +1,28 @@
-import { describe, it, expect } from "vitest";
-import { homedir } from "node:os";
+import { afterAll, beforeAll, describe, it, expect, vi } from "vitest";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { isSafeTranscriptPath } from "../../src/daemon/project.js";
 
 describe("isSafeTranscriptPath", () => {
-  const cwd = "/tmp";
+  let fixture: string;
+  let cwd: string;
+
+  beforeAll(() => {
+    fixture = realpathSync(mkdtempSync(join(tmpdir(), "lcm-path-safety-")));
+    cwd = join(fixture, "project");
+    const home = join(fixture, "home");
+    for (const directory of [cwd, join(home, ".claude", "projects"),
+      join(home, ".codex", "sessions"), join(home, ".codex", "archived_sessions")]) {
+      mkdirSync(directory, { recursive: true });
+    }
+    vi.stubEnv("HOME", home);
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+    rmSync(fixture, { recursive: true, force: true });
+  });
 
   it("allows paths under ~/.claude/projects/", () => {
     const p = join(homedir(), ".claude", "projects", "test-project", "abc.jsonl");

--- a/test/daemon/routes/restore.test.ts
+++ b/test/daemon/routes/restore.test.ts
@@ -21,21 +21,25 @@ describe("POST /restore", () => {
   afterEach(async () => { if (daemon) { await daemon.stop(); daemon = undefined; } });
 
   it("returns empty context for first-ever session (orientation now lives in ~/.claude/lcm.md)", async () => {
-    daemon = await createDaemon(loadDaemonConfig("/x", { daemon: { port: 0 } }));
-    const res = await fetch(`http://127.0.0.1:${daemon.address().port}/restore`, {
-      method: "POST", headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ session_id: "new-sess", cwd: tmpdir(), hook_event_name: "SessionStart" }),
-    });
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.context).not.toContain("<memory-orientation>");
-    expect(body.context).not.toContain("<recent-session-context>");
+    const isolatedDir = mkdtempSync(join(tmpdir(), "restore-first-session-"));
+    try {
+      daemon = await createDaemon(loadDaemonConfig(isolatedDir, { daemon: { port: 0 } }));
+      const res = await fetch(`http://127.0.0.1:${daemon.address().port}/restore`, {
+        method: "POST", headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: "new-sess", cwd: isolatedDir, hook_event_name: "SessionStart" }),
+      });
+      const body = await res.json();
+      expect(res.status, JSON.stringify(body)).toBe(200);
+      expect(body.context).not.toContain("<memory-orientation>");
+      expect(body.context).not.toContain("<recent-session-context>");
+    } finally {
+      if (daemon) { await daemon.stop(); daemon = undefined; }
+      rmSync(isolatedDir, { recursive: true, force: true });
+    }
   });
 
   it("returns empty context for source=compact with no session_instructions", async () => {
-    // Use an isolated dir — shared tmpdir() gets session_instructions written by the
-    // "first-ever session" test (non-compact path captures ~/.claude/CLAUDE.md), causing
-    // this compact-restore assertion to fail due to test-order contamination.
+    // Each fixture needs its own project database and instruction snapshot.
     const isolatedDir = mkdtempSync(join(tmpdir(), "restore-compact-test-"));
     try {
       daemon = await createDaemon(loadDaemonConfig("/x", { daemon: { port: 0 } }));

--- a/test/installer/uninstall.test.ts
+++ b/test/installer/uninstall.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { removeClaudeSettings, teardownDaemonService, uninstall, type TeardownDeps } from "../../installer/uninstall.js";
-import { homedir } from "node:os";
+import { tmpdir } from "node:os";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 // ─── helpers ────────────────────────────────────────────────────────────────
@@ -205,20 +206,31 @@ describe("uninstall", () => {
 describe("uninstall with DryRunServiceDeps", () => {
   it("prints [dry-run] lines and writes no real files", async () => {
     const { DryRunServiceDeps } = await import("../../installer/dry-run-deps.js");
+    const fixtureHome = mkdtempSync(join(tmpdir(), "lcm-uninstall-dry-run-"));
+    const settingsPath = join(fixtureHome, ".claude", "settings.json");
+    const settings = JSON.stringify({ mcpServers: { lcm: {} } });
+    mkdirSync(join(fixtureHome, ".claude"));
+    writeFileSync(settingsPath, settings);
+    vi.stubEnv("HOME", fixtureHome);
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    await expect(uninstall(new DryRunServiceDeps())).resolves.not.toThrow();
+    try {
+      await expect(uninstall(new DryRunServiceDeps())).resolves.not.toThrow();
 
-    const dryRunLines = logSpy.mock.calls
-      .flatMap((c: any[]) => c)
-      .filter((s: any) => typeof s === "string" && s.includes("[dry-run]"));
+      const dryRunLines = logSpy.mock.calls
+        .flatMap((c: any[]) => c)
+        .filter((s: any) => typeof s === "string" && s.includes("[dry-run]"));
 
-    expect(dryRunLines.length).toBeGreaterThan(0);
-    // uninstall uses unload, not load — no launchctl load should appear
-    expect(dryRunLines.every((l: string) => !l.includes("would run: launchctl load"))).toBe(true);
-
-    logSpy.mockRestore();
-    warnSpy.mockRestore();
+      expect(dryRunLines).toContain(`[dry-run] would write: ${settingsPath}`);
+      expect(readFileSync(settingsPath, "utf-8")).toBe(settings);
+      // uninstall uses unload, not load — no launchctl load should appear
+      expect(dryRunLines.every((l: string) => !l.includes("would run: launchctl load"))).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+      warnSpy.mockRestore();
+      vi.unstubAllEnvs();
+      rmSync(fixtureHome, { recursive: true, force: true });
+    }
   });
 });


### PR DESCRIPTION
## Changes

Move the existing `ci` job from GitHub-hosted Linux to a dedicated LCM runner on the Mac mini, following dwigt's macOS ARM64 setup. Preserve the `ci` check name, Node 22, and the install/typecheck/build/test/artifact checks. Fork PRs stay on hosted Linux, and a manual `hosted=true` dispatch selects the same job on Linux during a host outage.

Build and tests receive an isolated HOME and temporary directories. Plugin-cache synchronization is disabled, checkout removes stale workspace files without persisting its token, and superseded runs are cancelled. Tests now create their own fixtures instead of relying on the interactive user's installed configuration or a shared project database.

## Files Touched

- `.github/workflows/ci.yml` — select the Mac mini or hosted fallback, isolate job data, and verify the macOS ripgrep prerequisite.
- `docs/ci-runner.md` — document labels, isolation limits, and the active separate service.
- `test/daemon/project-path-safety.test.ts` — create canonical temporary home/project roots for path validation.
- `test/installer/uninstall.test.ts` — seed and verify an isolated dry-run uninstall fixture.
- `test/daemon/routes/restore.test.ts` — use an isolated project for the first-session restore check.

## Issue Reference

Closes #391

## Test Evidence

- `actionlint` 1.7.12 (ShellCheck disabled): passed.
- `git diff --check`: passed.
- On the Mac mini with temporary HOME/TMP directories: `npm ci`, `npm run typecheck`, `npm run build`, and `npm test`: passed; 1,475 tests passed, 6 expected skips on `ad8551c`, rebased onto `07aaacd`.
- No additional untracked workspace artifacts after validation.
- [First real GitHub Actions run](https://github.com/lossless-claude/lcm/actions/runs/34280228291/job/102242941575): all checks passed on `mac-mini-m4-lcm`, including tests and workspace-artifact verification.

## Risks & Follow-ups

- `mac-mini-m4-lcm` is registered and online with labels `self-hosted`, `macOS`, `ARM64`, `lcm`, running as a separate launchd service under the authorized host account. The dwigt runner remains online.
- Temporary HOME is filesystem hygiene, not an OS security boundary. Same-repository branches must be trusted.
- The LCM and dwigt instances share host resources, but have separate services and workspaces.
- Manual dispatch becomes available once the workflow is on the default branch.

## AR Status

PASSED — independent bounded review checked runner routing, the stable required check, macOS prerequisites, and isolation. The isolated test-fixture changes were reviewed separately from implementation. Registration and the first remote CI run are verified.

## Introspection Findings

Tests that inspect installed configuration must seed their own fixtures. A clean HOME reveals dependencies hidden by a developer's existing installation. GitHub's `runner` context is unavailable in job-level `env`; write per-job paths through `GITHUB_ENV` from a step.

## Token Cost

Approximately 15k agent tokens (estimate, including the bounded review).
