### PR TITLE
feat(daemon): group projects by git remote and path in the repository

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -361,7 +361,7 @@ async function main() {
       const { ensureAuthToken } = await import("../src/daemon/auth.js");
       ensureAuthToken(tokenPath);
       try {
-        const daemon = await createDaemon(config, { tokenPath });
+        const daemon = await createDaemon(config, { tokenPath, backfillIdentities: true });
         console.log(`lcm daemon started on port ${daemon.address().port}`);
       } catch (err) {
         const code = (err as NodeJS.ErrnoException)?.code;

--- a/src/daemon/git-identity.ts
+++ b/src/daemon/git-identity.ts
@@ -1,0 +1,96 @@
+import { execFileSync } from "node:child_process";
+import { realpathSync } from "node:fs";
+import { relative } from "node:path";
+
+/**
+ * A project's git coordinates: the repository it belongs to, expressed as the
+ * set of remotes that identify it, and where inside that repository it sits.
+ *
+ * The remote set is a set, not a scalar, so an org transfer or an `git@` to
+ * `https` switch adds an alias instead of losing the grouping.
+ */
+export interface GitIdentity {
+  /** Normalised remotes, sorted and deduplicated. Empty for a repo with no remote. */
+  remotes: string[];
+  /** Absolute path of the working tree root. */
+  root: string;
+  /** Path of the project relative to the root; "" at the root itself. */
+  relPath: string;
+}
+
+/**
+ * Normalises a remote URL to `host/path`, so that the same repository reached
+ * over ssh, https or the scp-like syntax yields one identity.
+ *
+ * Returns null for anything that does not parse as a remote (a local path, a
+ * malformed URL).
+ */
+export function normaliseRemote(url: string): string | null {
+  const trimmed = url.trim();
+  if (trimmed === "") return null;
+
+  // scp-like syntax: [user@]host:path
+  const scp = /^(?:[^@/\s]+@)?([^:/\s]+):(?!\/)(.+)$/.exec(trimmed);
+  const parsed = scp
+    ? { host: scp[1], path: scp[2] }
+    : parseUrlRemote(trimmed);
+  if (!parsed) return null;
+
+  const host = parsed.host.toLowerCase();
+  const path = parsed.path.replace(/^\/+/, "").replace(/\/+$/, "").replace(/\.git$/i, "");
+  if (host === "" || path === "") return null;
+  return `${host}/${path}`;
+}
+
+function parseUrlRemote(url: string): { host: string; path: string } | null {
+  try {
+    const { hostname, pathname, protocol } = new URL(url);
+    if (protocol === "file:" || hostname === "") return null;
+    return { host: hostname, path: pathname };
+  } catch {
+    return null;
+  }
+}
+
+function git(cwd: string, args: string[]): string | null {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf-8",
+      stdio: ["ignore", "pipe", "ignore"],
+      timeout: 5000,
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Reads the git identity of `cwd`, or null when it is not inside a working tree
+ * (or git is unavailable). A linked worktree reports its own root, which shares
+ * its remotes with the main checkout, so the two land in the same group.
+ */
+export function discoverGitIdentity(cwd: string): GitIdentity | null {
+  const root = git(cwd, ["rev-parse", "--show-toplevel"]);
+  if (!root) return null;
+
+  const remoteOutput = git(cwd, ["remote", "-v"]) ?? "";
+  const remotes = new Set<string>();
+  for (const line of remoteOutput.split("\n")) {
+    const url = line.split(/\s+/)[1];
+    if (!url) continue;
+    const normalised = normaliseRemote(url);
+    if (normalised) remotes.add(normalised);
+  }
+
+  // `--show-toplevel` reports a canonicalised path; canonicalise `cwd` too so a
+  // symlinked ancestor does not turn into a spurious `../..` relative path.
+  let here = cwd;
+  try { here = realpathSync(cwd); } catch { /* keep cwd */ }
+  const relPath = relative(root, here).split("\\").join("/");
+  return {
+    remotes: [...remotes].sort(),
+    root,
+    relPath: relPath === "." ? "" : relPath,
+  };
+}

--- a/src/daemon/project-group.ts
+++ b/src/daemon/project-group.ts
@@ -1,0 +1,203 @@
+import { DatabaseSync } from "node:sqlite";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { BASE_DIR, ensureProjectDir, projectId, projectMetaPath } from "./project.js";
+import { discoverGitIdentity, type GitIdentity } from "./git-identity.js";
+
+/**
+ * Projects are stored by cwd — one directory, one database. That key is right
+ * for storage and wrong for recall: the same repository checked out twice, or a
+ * worktree beside its main checkout, becomes several unrelated memories.
+ *
+ * This module records the second dimension. A project's git remotes and its
+ * path inside the repository go into its `meta.json` and into one global index,
+ * so recall can union the databases that describe the same place in the same
+ * repository. Nothing is ever merged physically, and a project whose folder has
+ * vanished simply stops matching at read time.
+ */
+
+/** Remotes recorded so far are re-checked no more often than this. */
+const REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+export const groupIndexPath = (): string => join(BASE_DIR, "group-index.sqlite");
+
+interface ProjectGitMeta {
+  remotes: string[];
+  relPath: string;
+  checkedAt: string;
+}
+
+/** One project in a group, as the index knows it. */
+export interface GroupMember {
+  projectId: string;
+  cwd: string;
+}
+
+function openIndex(): DatabaseSync {
+  mkdirSync(BASE_DIR, { recursive: true });
+  const db = new DatabaseSync(groupIndexPath());
+  db.exec("PRAGMA journal_mode = WAL");
+  db.exec("PRAGMA busy_timeout = 5000");
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS project_identity (
+      project_id TEXT PRIMARY KEY,
+      cwd        TEXT NOT NULL,
+      rel_path   TEXT NOT NULL DEFAULT '',
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS project_remote (
+      project_id TEXT NOT NULL,
+      remote     TEXT NOT NULL,
+      PRIMARY KEY (project_id, remote)
+    );
+    CREATE INDEX IF NOT EXISTS project_remote_by_remote ON project_remote(remote);
+  `);
+  return db;
+}
+
+function readGitMeta(cwd: string): ProjectGitMeta | null {
+  const path = projectMetaPath(cwd);
+  if (!existsSync(path)) return null;
+  try {
+    const git = JSON.parse(readFileSync(path, "utf-8")).git;
+    if (!git || !Array.isArray(git.remotes)) return null;
+    return {
+      remotes: git.remotes.filter((r: unknown): r is string => typeof r === "string"),
+      relPath: typeof git.relPath === "string" ? git.relPath : "",
+      checkedAt: typeof git.checkedAt === "string" ? git.checkedAt : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeGitMeta(cwd: string, git: ProjectGitMeta): void {
+  const path = projectMetaPath(cwd);
+  let meta: Record<string, unknown> = { cwd };
+  if (existsSync(path)) {
+    try { meta = JSON.parse(readFileSync(path, "utf-8")); } catch { /* keep default */ }
+  }
+  writeFileSync(path, JSON.stringify({ ...meta, git }, null, 2));
+}
+
+function isFresh(checkedAt: string): boolean {
+  const at = Date.parse(checkedAt);
+  return Number.isFinite(at) && Date.now() - at < REFRESH_INTERVAL_MS;
+}
+
+/**
+ * Merges a freshly discovered identity into what was recorded before. Remotes
+ * only ever accumulate: a repository that moved host or changed protocol keeps
+ * grouping with the sessions recorded under its old address.
+ */
+function mergeIdentity(previous: ProjectGitMeta | null, found: GitIdentity | null): ProjectGitMeta {
+  const remotes = new Set(previous?.remotes ?? []);
+  for (const remote of found?.remotes ?? []) remotes.add(remote);
+  return {
+    remotes: [...remotes].sort(),
+    relPath: found?.relPath ?? previous?.relPath ?? "",
+    checkedAt: new Date().toISOString(),
+  };
+}
+
+function indexIdentity(cwd: string, git: ProjectGitMeta): void {
+  // A project with no remote can group with nothing; keep it out of the index.
+  if (git.remotes.length === 0) return;
+  const id = projectId(cwd);
+  const db = openIndex();
+  try {
+    db.prepare(
+      `INSERT INTO project_identity (project_id, cwd, rel_path, updated_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(project_id) DO UPDATE SET cwd = excluded.cwd,
+                                             rel_path = excluded.rel_path,
+                                             updated_at = excluded.updated_at`,
+    ).run(id, cwd, git.relPath, git.checkedAt);
+    const insert = db.prepare(
+      "INSERT OR IGNORE INTO project_remote (project_id, remote) VALUES (?, ?)",
+    );
+    for (const remote of git.remotes) insert.run(id, remote);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Records `cwd`'s git identity in its `meta.json` and in the global index,
+ * re-running git at most once a day per project. Returns what is now recorded.
+ *
+ * Never throws: a project outside a repository, or a machine without git, keeps
+ * working with an empty remote set and simply groups with nothing.
+ */
+export function recordProjectIdentity(cwd: string): ProjectGitMeta {
+  const previous = readGitMeta(cwd);
+  if (previous && isFresh(previous.checkedAt)) return previous;
+
+  let git: ProjectGitMeta;
+  try {
+    git = mergeIdentity(previous, discoverGitIdentity(cwd));
+  } catch {
+    git = mergeIdentity(previous, null);
+  }
+  try {
+    writeGitMeta(cwd, git);
+    indexIdentity(cwd, git);
+  } catch {
+    // Identity is an optimisation for recall; failing to record it must never
+    // fail the ingest or compaction that happened to trigger it.
+  }
+  return git;
+}
+
+/**
+ * Ensures the project directory exists and its git identity is up to date.
+ * Every route that writes to a project goes through here, so the index tracks
+ * whatever the daemon has actually seen.
+ */
+export function openProject(cwd: string): string {
+  const dir = ensureProjectDir(cwd);
+  recordProjectIdentity(cwd);
+  return dir;
+}
+
+/**
+ * The projects that describe the same place in the same repository as `cwd`:
+ * any project sharing at least one remote and sitting at the same path relative
+ * to the repository root. `cwd` itself is always the first member.
+ *
+ * A member whose directory no longer exists is dropped here rather than deleted
+ * from the index, so a temporarily unmounted checkout comes back on its own.
+ */
+export function projectGroup(cwd: string): GroupMember[] {
+  const self: GroupMember = { projectId: projectId(cwd), cwd };
+  const git = readGitMeta(cwd);
+  if (!git || git.remotes.length === 0) return [self];
+
+  let rows: GroupMember[] = [];
+  try {
+    const db = openIndex();
+    try {
+      const placeholders = git.remotes.map(() => "?").join(", ");
+      rows = db.prepare(
+        `SELECT DISTINCT i.project_id AS projectId, i.cwd AS cwd
+           FROM project_identity i
+           JOIN project_remote r ON r.project_id = i.project_id
+          WHERE r.remote IN (${placeholders})
+            AND i.rel_path = ?
+          ORDER BY i.cwd`,
+      ).all(...git.remotes, git.relPath) as unknown as GroupMember[];
+    } finally {
+      db.close();
+    }
+  } catch {
+    return [self];
+  }
+
+  const members = [self];
+  for (const row of rows) {
+    if (row.projectId === self.projectId) continue;
+    if (!existsSync(row.cwd)) continue;
+    members.push(row);
+  }
+  return members;
+}

--- a/src/daemon/project-group.ts
+++ b/src/daemon/project-group.ts
@@ -154,15 +154,22 @@ export function recordProjectIdentity(cwd: string): ProjectGitMeta {
  * never written to again still joins its group. The daily refresh interval
  * makes every run after the first one nearly free.
  *
+ * Yields to the event loop as it goes: a store of ~9000 projects takes seconds
+ * to walk, and the daemon must keep answering while it does.
+ *
  * Returns how many projects were visited.
  */
-export function backfillProjectIdentities(): number {
+const BACKFILL_YIELD_EVERY = 50;
+
+export async function backfillProjectIdentities(): Promise<number> {
   const projectsDir = join(BASE_DIR, "projects");
   if (!existsSync(projectsDir)) return 0;
 
+  let seen = 0;
   let visited = 0;
   for (const entry of readdirSync(projectsDir, { withFileTypes: true })) {
     if (!entry.isDirectory()) continue;
+    if (++seen % BACKFILL_YIELD_EVERY === 0) await new Promise(setImmediate);
     const metaPath = join(projectsDir, entry.name, "meta.json");
     if (!existsSync(metaPath)) continue;
     try {

--- a/src/daemon/project-group.ts
+++ b/src/daemon/project-group.ts
@@ -131,7 +131,14 @@ function indexIdentity(cwd: string, git: ProjectGitMeta): void {
  */
 export function recordProjectIdentity(cwd: string): ProjectGitMeta {
   const previous = readGitMeta(cwd);
-  if (previous && isFresh(previous.checkedAt)) return previous;
+  if (previous && isFresh(previous.checkedAt)) {
+    // The index is derived state and `meta.json` is the record. Re-assert the
+    // row even when discovery is skipped, so an index that was deleted, moved
+    // or never built fills back in instead of staying empty until every
+    // project's day is up.
+    try { indexIdentity(cwd, previous); } catch { /* non-fatal, as below */ }
+    return previous;
+  }
 
   let git: ProjectGitMeta;
   try {

--- a/src/daemon/project-group.ts
+++ b/src/daemon/project-group.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from "node:sqlite";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { BASE_DIR, ensureProjectDir, projectId, projectMetaPath } from "./project.js";
 import { discoverGitIdentity, type GitIdentity } from "./git-identity.js";
@@ -147,6 +147,36 @@ export function recordProjectIdentity(cwd: string): ProjectGitMeta {
     // fail the ingest or compaction that happened to trigger it.
   }
   return git;
+}
+
+/**
+ * Records the identity of every project already on disk, so a checkout that is
+ * never written to again still joins its group. The daily refresh interval
+ * makes every run after the first one nearly free.
+ *
+ * Returns how many projects were visited.
+ */
+export function backfillProjectIdentities(): number {
+  const projectsDir = join(BASE_DIR, "projects");
+  if (!existsSync(projectsDir)) return 0;
+
+  let visited = 0;
+  for (const entry of readdirSync(projectsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const metaPath = join(projectsDir, entry.name, "meta.json");
+    if (!existsSync(metaPath)) continue;
+    try {
+      const cwd = JSON.parse(readFileSync(metaPath, "utf-8")).cwd;
+      // A project whose folder is gone cannot be asked for its remotes; leave
+      // whatever was recorded before untouched.
+      if (typeof cwd !== "string" || !existsSync(cwd)) continue;
+      recordProjectIdentity(cwd);
+      visited += 1;
+    } catch {
+      // A corrupt meta.json skips that project, never the whole backfill.
+    }
+  }
+  return visited;
 }
 
 /**

--- a/src/daemon/routes/compact.ts
+++ b/src/daemon/routes/compact.ts
@@ -3,7 +3,8 @@ import { readFileSync, writeFileSync, existsSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { getLcmConnection, closeLcmConnection } from "../../db/connection.js";
 import type { DaemonConfig } from "../config.js";
-import { projectId, projectDbPath, projectDir, projectMetaPath, ensureProjectDir, isSafeTranscriptPath } from "../project.js";
+import { projectId, projectDbPath, projectDir, projectMetaPath, isSafeTranscriptPath } from "../project.js";
+import { openProject } from "../project-group.js";
 import { enqueue } from "../project-queue.js";
 import { sendJson } from "../server.js";
 import type { RouteHandler } from "../server.js";
@@ -251,7 +252,7 @@ export function createCompactHandler(config: DaemonConfig, jobs?: SummarizeJobSt
       const pid = projectId(cwd);
       const result = await enqueue(pid, async () => {
         const dbPath = projectDbPath(cwd);
-        ensureProjectDir(cwd);
+        openProject(cwd);
         const llmUsage = createCompactLlmUsage(effectiveProvider, config.llm.model);
         const usageByProvider = new Map<string, CompactLlmUsage>();
 

--- a/src/daemon/routes/ingest.ts
+++ b/src/daemon/routes/ingest.ts
@@ -2,7 +2,8 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import type { DatabaseSync } from "node:sqlite";
 import { getLcmConnection, closeLcmConnection } from "../../db/connection.js";
 import type { DaemonConfig } from "../config.js";
-import { projectDbPath, projectDir, projectId, ensureProjectDir, projectMetaPath, isSafeTranscriptPath, claudeTranscriptPath } from "../project.js";
+import { projectDbPath, projectDir, projectId, projectMetaPath, isSafeTranscriptPath, claudeTranscriptPath } from "../project.js";
+import { openProject } from "../project-group.js";
 import { sendJson } from "../server.js";
 import type { RouteHandler } from "../server.js";
 import { runLcmMigrations } from "../../db/migration.js";
@@ -156,7 +157,7 @@ export function createIngestHandler(config: DaemonConfig): RouteHandler {
         projectDir(cwd),
       );
       const result = await enqueue(pid, async () => {
-        ensureProjectDir(cwd);
+        openProject(cwd);
         const db = getLcmConnection(dbPath);
         try {
           runLcmMigrations(db);

--- a/src/daemon/routes/session-complete.ts
+++ b/src/daemon/routes/session-complete.ts
@@ -1,5 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
-import { projectDbPath, ensureProjectDir } from "../project.js";
+import { projectDbPath } from "../project.js";
+import { openProject } from "../project-group.js";
 import { sendJson } from "../server.js";
 import type { RouteHandler } from "../server.js";
 import { runLcmMigrations } from "../../db/migration.js";
@@ -20,7 +21,7 @@ export function createSessionCompleteHandler(): RouteHandler {
       sendJson(res, 400, { error: err instanceof Error ? err.message : "invalid cwd" });
       return;
     }
-    ensureProjectDir(cwd);
+    openProject(cwd);
     const db = new DatabaseSync(projectDbPath(cwd));
     try {
       db.exec("PRAGMA busy_timeout = 5000");

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -172,7 +172,7 @@ export async function createDaemon(config: DaemonConfig, options?: DaemonOptions
   // only the first run after an upgrade does real work.
   const IDENTITY_BACKFILL_DELAY_MS = 5_000;
   const identityBackfill = setTimeout(() => {
-    try { backfillProjectIdentities(); } catch { /* non-fatal */ }
+    void backfillProjectIdentities().catch(() => { /* non-fatal */ });
   }, IDENTITY_BACKFILL_DELAY_MS);
   identityBackfill.unref();
 

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -31,7 +31,18 @@ export { PKG_VERSION };
 
 export type RouteHandler = (req: IncomingMessage, res: ServerResponse, body: string) => Promise<void>;
 export type DaemonInstance = { address: () => AddressInfo; stop: () => Promise<void>; registerRoute: (method: string, path: string, handler: RouteHandler) => void; idleTriggered: boolean };
-export type DaemonOptions = { proxyManager?: ProxyManager; onIdle?: () => void; tokenPath?: string };
+export type DaemonOptions = {
+  proxyManager?: ProxyManager;
+  onIdle?: () => void;
+  tokenPath?: string;
+  /**
+   * Walk every project on disk and record its git identity, shortly after the
+   * daemon starts serving. Only the long-lived daemon wants this: it spawns
+   * `git` once per surviving project, which a short-lived instance would pay
+   * for and never use.
+   */
+  backfillIdentities?: boolean;
+};
 
 const MAX_BODY_BYTES = 10 * 1024 * 1024; // 10 MB
 
@@ -171,10 +182,10 @@ export async function createDaemon(config: DaemonConfig, options?: DaemonOptions
   // the git calls never delay startup. Refreshes are throttled per project, so
   // only the first run after an upgrade does real work.
   const IDENTITY_BACKFILL_DELAY_MS = 5_000;
-  const identityBackfill = setTimeout(() => {
-    void backfillProjectIdentities().catch(() => { /* non-fatal */ });
-  }, IDENTITY_BACKFILL_DELAY_MS);
-  identityBackfill.unref();
+  const identityBackfill = options?.backfillIdentities
+    ? setTimeout(() => { void backfillProjectIdentities().catch(() => { /* non-fatal */ }); }, IDENTITY_BACKFILL_DELAY_MS)
+    : undefined;
+  identityBackfill?.unref();
 
   const server: Server = createServer(async (req, res) => {
     resetIdleTimer();
@@ -211,7 +222,7 @@ export async function createDaemon(config: DaemonConfig, options?: DaemonOptions
   return new Promise((resolve, reject) => {
     server.once("error", (err) => {
       clearInterval(ingestInterval);
-      clearTimeout(identityBackfill);
+      if (identityBackfill) clearTimeout(identityBackfill);
       if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
       reject(err);
     });
@@ -228,7 +239,7 @@ export async function createDaemon(config: DaemonConfig, options?: DaemonOptions
         stop: async () => {
           summarizeJobs.close();
           clearInterval(ingestInterval);
-          clearTimeout(identityBackfill);
+          if (identityBackfill) clearTimeout(identityBackfill);
           if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
           if (proxyManager) {
             try { await proxyManager.stop(); } catch { /* non-fatal */ }

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -25,6 +25,7 @@ import { createPoolStatsHandler } from "./routes/pool-stats.js";
 import { createReviewStaleHandler } from "./routes/review-stale.js";
 import { createToolEventHandler } from "./routes/tool-event.js";
 import { createSessionScavengeHandler } from "./routes/session-scavenge.js";
+import { backfillProjectIdentities } from "./project-group.js";
 import { PKG_VERSION, BUILD_ID } from "./version.js";
 export { PKG_VERSION };
 
@@ -166,6 +167,15 @@ export async function createDaemon(config: DaemonConfig, options?: DaemonOptions
   const ingestInterval = setInterval(scanForTranscripts, INGEST_INTERVAL_MS);
   ingestInterval.unref(); // don't prevent process exit
 
+  // Group every project already on disk, shortly after the daemon is serving so
+  // the git calls never delay startup. Refreshes are throttled per project, so
+  // only the first run after an upgrade does real work.
+  const IDENTITY_BACKFILL_DELAY_MS = 5_000;
+  const identityBackfill = setTimeout(() => {
+    try { backfillProjectIdentities(); } catch { /* non-fatal */ }
+  }, IDENTITY_BACKFILL_DELAY_MS);
+  identityBackfill.unref();
+
   const server: Server = createServer(async (req, res) => {
     resetIdleTimer();
     const key = `${req.method} ${req.url?.split("?")[0]}`;
@@ -201,6 +211,7 @@ export async function createDaemon(config: DaemonConfig, options?: DaemonOptions
   return new Promise((resolve, reject) => {
     server.once("error", (err) => {
       clearInterval(ingestInterval);
+      clearTimeout(identityBackfill);
       if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
       reject(err);
     });
@@ -217,6 +228,7 @@ export async function createDaemon(config: DaemonConfig, options?: DaemonOptions
         stop: async () => {
           summarizeJobs.close();
           clearInterval(ingestInterval);
+          clearTimeout(identityBackfill);
           if (idleTimer) { clearTimeout(idleTimer); idleTimer = null; }
           if (proxyManager) {
             try { await proxyManager.stop(); } catch { /* non-fatal */ }

--- a/test/daemon/git-identity.test.ts
+++ b/test/daemon/git-identity.test.ts
@@ -1,0 +1,77 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { discoverGitIdentity, normaliseRemote } from "../../src/daemon/git-identity.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeRepo(remote?: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "lcm-git-identity-")));
+  tempDirs.push(dir);
+  const git = (...args: string[]) =>
+    execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+  git("init", "-q");
+  if (remote) git("remote", "add", "origin", remote);
+  return dir;
+}
+
+describe("normaliseRemote", () => {
+  it("gives ssh, https and scp forms of one repository the same identity", () => {
+    const expected = "github.com/lossless-claude/lcm";
+    expect(normaliseRemote("git@github.com:lossless-claude/lcm.git")).toBe(expected);
+    expect(normaliseRemote("https://github.com/lossless-claude/lcm.git")).toBe(expected);
+    expect(normaliseRemote("https://github.com/lossless-claude/lcm")).toBe(expected);
+    expect(normaliseRemote("ssh://git@github.com/lossless-claude/lcm.git")).toBe(expected);
+  });
+
+  it("lowercases the host but keeps the path's case", () => {
+    expect(normaliseRemote("git@GitHub.com:Lossless-Claude/LCM.git"))
+      .toBe("github.com/Lossless-Claude/LCM");
+  });
+
+  it("rejects what is not a remote", () => {
+    expect(normaliseRemote("")).toBeNull();
+    expect(normaliseRemote("   ")).toBeNull();
+    expect(normaliseRemote("/Users/pedro/Developer/lcm")).toBeNull();
+    expect(normaliseRemote("file:///Users/pedro/Developer/lcm")).toBeNull();
+    expect(normaliseRemote("git@github.com:")).toBeNull();
+  });
+});
+
+describe("discoverGitIdentity", () => {
+  it("returns null outside a working tree", () => {
+    const dir = realpathSync(mkdtempSync(join(tmpdir(), "lcm-not-a-repo-")));
+    tempDirs.push(dir);
+    // A temp dir can still sit inside someone's repo; only assert when it doesn't.
+    const identity = discoverGitIdentity(dir);
+    if (identity !== null) expect(identity.root).not.toBe(dir);
+  });
+
+  it("reports normalised remotes and an empty relative path at the root", () => {
+    const dir = makeRepo("git@github.com:lossless-claude/lcm.git");
+    expect(discoverGitIdentity(dir)).toEqual({
+      remotes: ["github.com/lossless-claude/lcm"],
+      root: dir,
+      relPath: "",
+    });
+  });
+
+  it("reports the path relative to the root for a subdirectory", () => {
+    const dir = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const nested = join(dir, "packages", "core");
+    mkdirSync(nested, { recursive: true });
+    const identity = discoverGitIdentity(nested);
+    expect(identity?.relPath).toBe("packages/core");
+    expect(identity?.root).toBe(dir);
+  });
+
+  it("reports an empty remote set for a repository with no remote", () => {
+    expect(discoverGitIdentity(makeRepo())?.remotes).toEqual([]);
+  });
+});

--- a/test/daemon/project-group.test.ts
+++ b/test/daemon/project-group.test.ts
@@ -24,7 +24,7 @@ vi.mock("../../src/daemon/project.js", async (importOriginal) => {
   };
 });
 
-const { openProject, projectGroup, recordProjectIdentity, groupIndexPath } =
+const { backfillProjectIdentities, openProject, projectGroup, recordProjectIdentity, groupIndexPath } =
   await import("../../src/daemon/project-group.js");
 const { projectId, projectMetaPath } = await import("../../src/daemon/project.js");
 
@@ -92,6 +92,32 @@ describe("recordProjectIdentity", () => {
     openProject(plain);
     expect(readMeta(plain).git.remotes).toEqual([]);
     expect(projectGroup(plain)).toEqual([{ projectId: projectId(plain), cwd: plain }]);
+  });
+});
+
+describe("backfillProjectIdentities", () => {
+  /** A project recorded before this feature existed: a meta.json with only a cwd. */
+  function legacyProject(cwd: string): void {
+    mkdirSync(join(base, "projects", projectId(cwd)), { recursive: true });
+    writeFileSync(projectMetaPath(cwd), JSON.stringify({ cwd }, null, 2));
+  }
+
+  it("groups projects that were never opened again", () => {
+    const a = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const b = makeRepo("git@github.com:lossless-claude/lcm.git");
+    legacyProject(a);
+    legacyProject(b);
+
+    expect(projectGroup(a).map(m => m.cwd)).toEqual([a]);
+    backfillProjectIdentities();
+    expect(projectGroup(a).map(m => m.cwd).sort()).toEqual([a, b].sort());
+  });
+
+  it("leaves a project whose folder is gone untouched", () => {
+    const gone = join(base, "no-such-checkout");
+    legacyProject(gone);
+    backfillProjectIdentities();
+    expect(readMeta(gone).git).toBeUndefined();
   });
 });
 

--- a/test/daemon/project-group.test.ts
+++ b/test/daemon/project-group.test.ts
@@ -86,6 +86,21 @@ describe("recordProjectIdentity", () => {
     expect(recordProjectIdentity(repo).remotes).toEqual(["github.com/lossless-claude/lcm"]);
   });
 
+  it("rebuilds the index from meta.json when the index is gone", () => {
+    const a = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const b = makeRepo("git@github.com:lossless-claude/lcm.git");
+    openProject(a);
+    openProject(b);
+    rmSync(groupIndexPath(), { force: true });
+    expect(projectGroup(a).map(m => m.cwd)).toEqual([a]);
+
+    // Both identities are still fresh, so no discovery runs — the index must
+    // fill back in from what meta.json already records.
+    recordProjectIdentity(a);
+    recordProjectIdentity(b);
+    expect(projectGroup(a).map(m => m.cwd).sort()).toEqual([a, b].sort());
+  });
+
   it("records an empty remote set outside any repository and stays out of the index", () => {
     const plain = realpathSync(mkdtempSync(join(tmpdir(), "lcm-group-plain-")));
     tempDirs.push(plain);

--- a/test/daemon/project-group.test.ts
+++ b/test/daemon/project-group.test.ts
@@ -1,0 +1,145 @@
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The index and every meta.json live under a temp base dir, so these tests
+ * never read or write the developer's own ~/.lossless-claude.
+ */
+const base = realpathSync(mkdtempSync(join(tmpdir(), "lcm-group-base-")));
+vi.mock("../../src/daemon/project.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/daemon/project.js")>();
+  return {
+    ...original,
+    BASE_DIR: base,
+    projectDir: (cwd: string) => join(base, "projects", original.projectId(cwd)),
+    projectMetaPath: (cwd: string) => join(base, "projects", original.projectId(cwd), "meta.json"),
+    ensureProjectDir: (cwd: string) => {
+      const dir = join(base, "projects", original.projectId(cwd));
+      mkdirSync(dir, { recursive: true });
+      return dir;
+    },
+  };
+});
+
+const { openProject, projectGroup, recordProjectIdentity, groupIndexPath } =
+  await import("../../src/daemon/project-group.js");
+const { projectId, projectMetaPath } = await import("../../src/daemon/project.js");
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+afterAll(() => rmSync(base, { recursive: true, force: true }));
+
+function makeRepo(remote?: string): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "lcm-group-repo-")));
+  tempDirs.push(dir);
+  const git = (...args: string[]) => execFileSync("git", args, { cwd: dir, stdio: "ignore" });
+  git("init", "-q");
+  if (remote) git("remote", "add", "origin", remote);
+  return dir;
+}
+
+const readMeta = (cwd: string) => JSON.parse(readFileSync(projectMetaPath(cwd), "utf-8"));
+
+describe("recordProjectIdentity", () => {
+  it("writes the normalised remotes and relative path into meta.json", () => {
+    const repo = makeRepo("git@github.com:lossless-claude/lcm.git");
+    openProject(repo);
+    expect(readMeta(repo).git).toMatchObject({
+      remotes: ["github.com/lossless-claude/lcm"],
+      relPath: "",
+    });
+  });
+
+  it("keeps the project's cwd alongside the new git block", () => {
+    const repo = makeRepo("git@github.com:lossless-claude/lcm.git");
+    openProject(repo);
+    expect(readMeta(repo).cwd).toBe(repo);
+  });
+
+  it("accumulates remotes instead of replacing them when the repository moves", () => {
+    const repo = makeRepo("git@github.com:old-org/lcm.git");
+    openProject(repo);
+    execFileSync("git", ["remote", "set-url", "origin", "git@github.com:lossless-claude/lcm.git"],
+      { cwd: repo, stdio: "ignore" });
+    // Age the recorded check so the refresh actually runs.
+    const meta = readMeta(repo);
+    meta.git.checkedAt = new Date(Date.now() - 48 * 60 * 60 * 1000).toISOString();
+    writeFileSync(projectMetaPath(repo), JSON.stringify(meta, null, 2));
+
+    expect(recordProjectIdentity(repo).remotes).toEqual([
+      "github.com/lossless-claude/lcm",
+      "github.com/old-org/lcm",
+    ]);
+  });
+
+  it("does not re-run discovery while the recorded identity is fresh", () => {
+    const repo = makeRepo("git@github.com:lossless-claude/lcm.git");
+    openProject(repo);
+    execFileSync("git", ["remote", "set-url", "origin", "git@github.com:other/lcm.git"],
+      { cwd: repo, stdio: "ignore" });
+    expect(recordProjectIdentity(repo).remotes).toEqual(["github.com/lossless-claude/lcm"]);
+  });
+
+  it("records an empty remote set outside any repository and stays out of the index", () => {
+    const plain = realpathSync(mkdtempSync(join(tmpdir(), "lcm-group-plain-")));
+    tempDirs.push(plain);
+    openProject(plain);
+    expect(readMeta(plain).git.remotes).toEqual([]);
+    expect(projectGroup(plain)).toEqual([{ projectId: projectId(plain), cwd: plain }]);
+  });
+});
+
+describe("projectGroup", () => {
+  it("groups two checkouts of the same repository", () => {
+    const a = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const b = makeRepo("https://github.com/lossless-claude/lcm.git");
+    openProject(a);
+    openProject(b);
+    expect(projectGroup(a).map(m => m.cwd).sort()).toEqual([a, b].sort());
+  });
+
+  it("keeps the queried project first", () => {
+    const a = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const b = makeRepo("git@github.com:lossless-claude/lcm.git");
+    openProject(a);
+    openProject(b);
+    expect(projectGroup(b)[0]).toEqual({ projectId: projectId(b), cwd: b });
+  });
+
+  it("keeps a subdirectory separate from the repository root", () => {
+    const root = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const nested = join(root, "packages", "core");
+    mkdirSync(nested, { recursive: true });
+    openProject(root);
+    openProject(nested);
+    expect(projectGroup(root).map(m => m.cwd)).toEqual([root]);
+    expect(projectGroup(nested).map(m => m.cwd)).toEqual([nested]);
+  });
+
+  it("keeps unrelated repositories apart", () => {
+    const a = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const b = makeRepo("git@github.com:lossless-claude/magi.git");
+    openProject(a);
+    openProject(b);
+    expect(projectGroup(a).map(m => m.cwd)).toEqual([a]);
+  });
+
+  it("drops a member whose directory has vanished without forgetting it", () => {
+    const a = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const gone = makeRepo("git@github.com:lossless-claude/lcm.git");
+    openProject(a);
+    openProject(gone);
+    rmSync(gone, { recursive: true, force: true });
+
+    expect(projectGroup(a).map(m => m.cwd)).toEqual([a]);
+    expect(existsSync(groupIndexPath())).toBe(true);
+    mkdirSync(gone, { recursive: true });
+    expect(projectGroup(a).map(m => m.cwd).sort()).toEqual([a, gone].sort());
+  });
+});

--- a/test/daemon/project-group.test.ts
+++ b/test/daemon/project-group.test.ts
@@ -102,21 +102,21 @@ describe("backfillProjectIdentities", () => {
     writeFileSync(projectMetaPath(cwd), JSON.stringify({ cwd }, null, 2));
   }
 
-  it("groups projects that were never opened again", () => {
+  it("groups projects that were never opened again", async () => {
     const a = makeRepo("git@github.com:lossless-claude/lcm.git");
     const b = makeRepo("git@github.com:lossless-claude/lcm.git");
     legacyProject(a);
     legacyProject(b);
 
     expect(projectGroup(a).map(m => m.cwd)).toEqual([a]);
-    backfillProjectIdentities();
+    await backfillProjectIdentities();
     expect(projectGroup(a).map(m => m.cwd).sort()).toEqual([a, b].sort());
   });
 
-  it("leaves a project whose folder is gone untouched", () => {
+  it("leaves a project whose folder is gone untouched", async () => {
     const gone = join(base, "no-such-checkout");
     legacyProject(gone);
-    backfillProjectIdentities();
+    await backfillProjectIdentities();
     expect(readMeta(gone).git).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Changes

First slice of the two-dimension identity in #399. The storage key stays `cwd`; a second dimension is recorded beside it so recall can later union the databases that describe the same place in the same repository.

- Remote URLs are normalised to `host/path`, so `git@github.com:lossless-claude/lcm.git`, `https://github.com/lossless-claude/lcm.git` and `ssh://…` land on one identity. Without this the two largest lcm databases (55 834 and 6 514 messages) group with nothing, because they reach the same repo over different protocols.
- Remotes are stored as an accumulating **list**, so an org transfer or a protocol switch adds an alias rather than dropping the grouping.
- The grouping key is remote **plus** the path relative to the git root. A linked worktree reports its own root and joins the main checkout; a package inside someone else's repo stays separate.
- The global index is a separate SQLite file, not a column in any project database — a project must be findable without opening every other one.
- Discovery is throttled to once a day per project, so the three routes that open a project do not pay a `git` call each time.
- A member whose folder has vanished is dropped at read time and kept in the index, so an unmounted checkout returns on its own.
- Identity is otherwise only recorded when a project is written to, which never happens again for a checkout that has gone quiet. A backfill walks every project on disk 5 s after the daemon starts serving; 338 of the 8 811 projects here still exist, and the daily throttle makes every later boot free.

Nothing reads the group yet — that is the next slice.

## Files Touched

- `src/daemon/git-identity.ts` — new: remote normalisation and `git` discovery.
- `src/daemon/project-group.ts` — new: `meta.json` merge, the global index, `projectGroup`, `openProject`, `backfillProjectIdentities`.
- `src/daemon/routes/{ingest,compact,session-complete}.ts` — `ensureProjectDir` → `openProject`.
- `src/daemon/server.ts` — schedule the backfill after `listen`, clear it on stop.
- `test/daemon/git-identity.test.ts` — new: 7 tests over normalisation and discovery.
- `test/daemon/project-group.test.ts` — new: 12 tests over recording, backfill and grouping, against real temp repositories and an isolated base dir.

## Issue Reference

Part of #399

## Test Evidence

```
npx vitest run
Test Files  148 passed | 2 skipped (150)
     Tests  1524 passed | 6 skipped (1530)
```

Verified against the real store: the five live lcm checkouts all normalise to `github.com/lossless-claude/lcm`, and the three that git reports as their own root share `relPath = ""`.

## Risks & Follow-ups

- A **deleted worktree** leaves an empty folder; git then reports it as a plain subdirectory, so its relative path is non-empty and it leaves the group. One such folder here holds 1 111 messages. Recorded as the known gap in #399.
- `discoverGitIdentity` returns null both for "not a repository" and for "git not on `PATH`". A daemon launched with a minimal `PATH` would silently group nothing and retry the next day.
- The backfill runs the first time on a real store of 8 811 projects; 8 473 of them no longer exist on disk and are skipped without a `git` call.

## AR Status

[SKIP_AR: no adversarial review run this session]

## Introspection Findings

`git rev-parse --show-toplevel` is what separates a real linked worktree from a leftover folder — a registered worktree reports itself, a deleted one reports its parent. That distinction is the whole grouping rule, and it is only visible against a real repository, so both test files build actual `git init` fixtures rather than mocking `git`.

## Token Cost

~90k tokens (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1wwybhXYEnbZVqA4SvJ83