### PR TITLE
feat(search): every result names the project it was read from

### DIFF
--- a/src/daemon/project-group.ts
+++ b/src/daemon/project-group.ts
@@ -33,6 +33,23 @@ export interface GroupMember {
   cwd: string;
 }
 
+/** How a project is named on a result that leaves the daemon. */
+export const projectRef = (cwd: string) => ({ id: projectId(cwd), cwd });
+
+/**
+ * The cwd whose database an id from a search result should be read against:
+ * the request's own project when no project is named, otherwise the group
+ * member that owns it. Null when the id names no member of the group.
+ *
+ * Callers must go through here rather than trusting the id. `conversation_id`
+ * and `message_id` are `AUTOINCREMENT` per database, so an id resolved against
+ * the wrong project silently returns a different message.
+ */
+export function resolveSourceCwd(requestCwd: string, id: unknown): string | null {
+  if (typeof id !== "string" || id === "" || id === projectId(requestCwd)) return requestCwd;
+  return projectGroup(requestCwd).find(member => member.projectId === id)?.cwd ?? null;
+}
+
 function openIndex(): DatabaseSync {
   mkdirSync(BASE_DIR, { recursive: true });
   const db = new DatabaseSync(groupIndexPath());

--- a/src/daemon/routes/describe.ts
+++ b/src/daemon/routes/describe.ts
@@ -10,6 +10,7 @@ import { ConversationStore } from "../../store/conversation-store.js";
 import { SummaryStore } from "../../store/summary-store.js";
 import { RetrievalEngine } from "../../retrieval.js";
 import { validateCwd } from "../validate-cwd.js";
+import { resolveSourceCwd } from "../project-group.js";
 
 export function createDescribeHandler(_config: DaemonConfig): RouteHandler {
   return async (_req, res, body) => {
@@ -36,8 +37,16 @@ export function createDescribeHandler(_config: DaemonConfig): RouteHandler {
       return;
     }
 
+    // Ids are AUTOINCREMENT per database, so a node named by a search result
+    // must be read from the project that result came from.
+    const source = resolveSourceCwd(cwd, input.projectId);
+    if (!source) {
+      sendJson(res, 200, { node: null, error: "project not in group" });
+      return;
+    }
+
     try {
-      const dbPath = projectDbPath(cwd);
+      const dbPath = projectDbPath(source);
       mkdirSync(dirname(dbPath), { recursive: true });
       const db = new DatabaseSync(dbPath);
       runLcmMigrations(db);

--- a/src/daemon/routes/expand.ts
+++ b/src/daemon/routes/expand.ts
@@ -11,6 +11,7 @@ import { SummaryStore } from "../../store/summary-store.js";
 import { RetrievalEngine } from "../../retrieval.js";
 import { ExpansionOrchestrator } from "../../expansion.js";
 import { validateCwd } from "../validate-cwd.js";
+import { resolveSourceCwd } from "../project-group.js";
 
 export function createExpandHandler(_config: DaemonConfig): RouteHandler {
   return async (_req, res, body) => {
@@ -37,8 +38,17 @@ export function createExpandHandler(_config: DaemonConfig): RouteHandler {
       return;
     }
 
+    // A search result carries the project it was read from. Ids are
+    // AUTOINCREMENT per database, so expanding one against the request's own
+    // project would silently return a different node.
+    const source = resolveSourceCwd(cwd, input.projectId);
+    if (!source) {
+      sendJson(res, 200, { expanded: null, error: "project not in group" });
+      return;
+    }
+
     try {
-      const dbPath = projectDbPath(cwd);
+      const dbPath = projectDbPath(source);
       mkdirSync(dirname(dbPath), { recursive: true });
       const db = new DatabaseSync(dbPath);
       runLcmMigrations(db);

--- a/src/daemon/routes/prompt-search.ts
+++ b/src/daemon/routes/prompt-search.ts
@@ -7,6 +7,7 @@ import type { RouteHandler } from "../server.js";
 import { closeLcmConnection, getLcmConnection } from "../../db/connection.js";
 import { runLcmMigrations } from "../../db/migration.js";
 import { PromotedStore, type SearchResult } from "../../db/promoted.js";
+import { projectRef } from "../project-group.js";
 import { RecallStore, type RecallFeedback } from "../../db/recall.js";
 import { buildMemoryContext, selectMemoryHintsWithinBudget } from "../../hooks/memory-context.js";
 import { recordUserPromptEvents } from "../../hooks/user-prompt.js";
@@ -310,7 +311,7 @@ export function createPromptSearchHandler(config: DaemonConfig): RouteHandler {
       // Keep promoted ranking intact, and fill the same bounded hint budget
       // with native episodic matches rather than requiring a manual import.
       const history = input.client === "codex"
-        ? await searchNativeHistory(db, { query, limit: targetHintCount })
+        ? await searchNativeHistory(db, { query, limit: targetHintCount, project: projectRef(cwd) })
         : [];
       const candidates = filtered.map((result) => ({
         id: result.id,

--- a/src/daemon/routes/search.ts
+++ b/src/daemon/routes/search.ts
@@ -8,6 +8,7 @@ import { runLcmMigrations } from "../../db/migration.js";
 import { searchNativeHistory } from "../../search/native-history.js";
 import { PromotedStore } from "../../db/promoted.js";
 import { validateCwd } from "../validate-cwd.js";
+import { projectRef } from "../project-group.js";
 
 function describeError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -55,7 +56,7 @@ export function createSearchHandler(): RouteHandler {
           if (activeLayers.includes("episodic")) {
             try {
               // History records do not carry promoted-memory tags.
-              episodic = filterTags ? [] : await searchNativeHistory(db, { query, limit });
+              episodic = filterTags ? [] : await searchNativeHistory(db, { query, limit, project: projectRef(cwd) });
             } catch (err) {
               // Non-fatal for the response, but never silent: a real failure
               // (malformed FTS5 syntax, missing table, corrupt index) must be
@@ -69,7 +70,8 @@ export function createSearchHandler(): RouteHandler {
           if (activeLayers.includes("promoted")) {
             try {
               const promotedStore = new PromotedStore(db);
-              promoted = promotedStore.search(query, limit, filterTags);
+              promoted = promotedStore.search(query, limit, filterTags)
+                .map(result => ({ ...result, project: projectRef(cwd) }));
             } catch (err) {
               console.warn(`[lcm] /search promoted layer failed: ${describeError(err)}`);
               errors.push(`promoted: ${describeError(err)}`);

--- a/src/mcp/tools/lcm-describe.ts
+++ b/src/mcp/tools/lcm-describe.ts
@@ -5,6 +5,7 @@ export const lcmDescribeTool = {
     type: "object" as const,
     properties: {
       nodeId: { type: "string", description: "Node ID to describe" },
+      projectId: { type: "string", description: "The `project.id` of the search result the node came from. Required whenever the node did not come from this project, since node ids are only unique within one project." },
     },
     required: ["nodeId"],
   },

--- a/src/mcp/tools/lcm-expand.ts
+++ b/src/mcp/tools/lcm-expand.ts
@@ -6,6 +6,7 @@ export const lcmExpandTool = {
     properties: {
       nodeId: { type: "string", description: "Summary node ID to expand" },
       depth: { type: "number", description: "How many levels of the DAG to traverse (default: 1)" },
+      projectId: { type: "string", description: "The `project.id` of the search result the node came from. Required whenever the node did not come from this project, since node ids are only unique within one project." },
     },
     required: ["nodeId"],
   },

--- a/src/search/native-history.ts
+++ b/src/search/native-history.ts
@@ -16,7 +16,18 @@ type SourceContext = {
   sourceHash: string;
   snippetTruncated: boolean;
 };
-export type NativeHistoryHit = HistoryHit & SourceContext;
+/**
+ * Which project a hit was read from. Required, not optional: `conversationId`
+ * and `messageId` are `AUTOINCREMENT` per database, so once results from
+ * several projects share one list, an unlabelled hit resolves against the wrong
+ * database and silently returns a different message.
+ */
+export interface ProjectRef {
+  id: string;
+  cwd: string;
+}
+
+export type NativeHistoryHit = HistoryHit & SourceContext & { project: ProjectRef };
 
 function anchorSpan(content: string, hint: string): { start: number; length: number } {
   const fragments = hint.split("...").map(part => part.trim()).filter(Boolean);
@@ -296,7 +307,7 @@ function sessionSizes(
 /** Read one request's ranked history and bounded source context inside a savepoint on the caller's connection. */
 export async function searchNativeHistory(
   db: DatabaseSync,
-  input: { query: string; limit: number },
+  input: { query: string; limit: number; project: ProjectRef },
 ): Promise<NativeHistoryHit[]> {
   const messages = new ConversationStore(db);
   const summaries = new SummaryStore(db);
@@ -310,7 +321,13 @@ export async function searchNativeHistory(
       const source = "messageId" in hit
         ? messages.getMessageByIdSync(hit.messageId)
         : summaries.getSummarySync(hit.summaryId);
-      if (source) matches.push({ ...hit, ...sourceContext(source.content, matchedAnchor(db, hit, input.query, source.content)) });
+      if (source) {
+        matches.push({
+          ...hit,
+          ...sourceContext(source.content, matchedAnchor(db, hit, input.query, source.content)),
+          project: input.project,
+        });
+      }
     }
     return matches;
   } finally {

--- a/test/daemon/project-group.test.ts
+++ b/test/daemon/project-group.test.ts
@@ -24,7 +24,7 @@ vi.mock("../../src/daemon/project.js", async (importOriginal) => {
   };
 });
 
-const { backfillProjectIdentities, openProject, projectGroup, recordProjectIdentity, groupIndexPath } =
+const { backfillProjectIdentities, openProject, projectGroup, recordProjectIdentity, resolveSourceCwd, groupIndexPath } =
   await import("../../src/daemon/project-group.js");
 const { projectId, projectMetaPath } = await import("../../src/daemon/project.js");
 
@@ -133,6 +133,33 @@ describe("backfillProjectIdentities", () => {
     legacyProject(gone);
     await backfillProjectIdentities();
     expect(readMeta(gone).git).toBeUndefined();
+  });
+});
+
+describe("resolveSourceCwd", () => {
+  it("falls back to the request's own project when no project is named", () => {
+    const repo = makeRepo("git@github.com:lossless-claude/lcm.git");
+    openProject(repo);
+    expect(resolveSourceCwd(repo, undefined)).toBe(repo);
+    expect(resolveSourceCwd(repo, "")).toBe(repo);
+    expect(resolveSourceCwd(repo, projectId(repo))).toBe(repo);
+  });
+
+  it("resolves a sibling in the group to that sibling's own directory", () => {
+    const a = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const b = makeRepo("git@github.com:lossless-claude/lcm.git");
+    openProject(a);
+    openProject(b);
+    expect(resolveSourceCwd(a, projectId(b))).toBe(b);
+  });
+
+  it("refuses a project outside the group", () => {
+    const a = makeRepo("git@github.com:lossless-claude/lcm.git");
+    const other = makeRepo("git@github.com:lossless-claude/magi.git");
+    openProject(a);
+    openProject(other);
+    expect(resolveSourceCwd(a, projectId(other))).toBeNull();
+    expect(resolveSourceCwd(a, "0".repeat(64))).toBeNull();
   });
 });
 

--- a/test/daemon/routes/project-scoped-results.test.ts
+++ b/test/daemon/routes/project-scoped-results.test.ts
@@ -1,0 +1,91 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDaemon, type DaemonInstance } from "../../../src/daemon/server.js";
+import { loadDaemonConfig } from "../../../src/daemon/config.js";
+import { runLcmMigrations } from "../../../src/db/migration.js";
+import { PromotedStore } from "../../../src/db/promoted.js";
+import { projectDbPath, projectId } from "../../../src/daemon/project.js";
+
+/**
+ * A result that does not say which project it came from cannot be followed up
+ * on once several projects share one list: `conversation_id` and `message_id`
+ * are AUTOINCREMENT per database, so the same id names a different row in each.
+ */
+
+const tempDirs: string[] = [];
+let daemon: DaemonInstance | undefined;
+
+afterEach(async () => {
+  if (daemon) { await daemon.stop(); daemon = undefined; }
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function makeProject(): string {
+  const dir = realpathSync(mkdtempSync(join(tmpdir(), "lcm-scoped-")));
+  tempDirs.push(dir);
+  const dbPath = projectDbPath(dir);
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  runLcmMigrations(db);
+  new PromotedStore(db).insert({
+    content: "We decided to union memory at read time",
+    tags: ["decision"],
+    projectId: "p1",
+  });
+  db.close();
+  return dir;
+}
+
+async function start(): Promise<number> {
+  const config = loadDaemonConfig("/nonexistent");
+  config.daemon.port = 0;
+  daemon = await createDaemon(config);
+  return daemon.address().port;
+}
+
+const post = (port: number, route: string, body: unknown) =>
+  fetch(`http://127.0.0.1:${port}/${route}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  }).then(res => res.json() as Promise<Record<string, any>>);
+
+describe("results carry the project they came from", () => {
+  it("names the project on every promoted hit", async () => {
+    const cwd = makeProject();
+    const port = await start();
+    const data = await post(port, "search", { query: "union", cwd });
+    expect(data.promoted.length).toBeGreaterThan(0);
+    for (const hit of data.promoted) {
+      expect(hit.project).toEqual({ id: projectId(cwd), cwd });
+    }
+  });
+});
+
+describe("a node id is resolved against the project that produced it", () => {
+  it("expands a node named with this project's own id", async () => {
+    const cwd = makeProject();
+    const port = await start();
+    const data = await post(port, "expand", { nodeId: "sum_missing", cwd, projectId: projectId(cwd) });
+    expect(data.error).not.toBe("project not in group");
+  });
+
+  it("refuses to expand a node from a project outside the group", async () => {
+    const cwd = makeProject();
+    const stranger = makeProject();
+    const port = await start();
+    const data = await post(port, "expand", { nodeId: "sum_1", cwd, projectId: projectId(stranger) });
+    expect(data).toEqual({ expanded: null, error: "project not in group" });
+  });
+
+  it("refuses to describe a node from a project outside the group", async () => {
+    const cwd = makeProject();
+    const stranger = makeProject();
+    const port = await start();
+    const data = await post(port, "describe", { nodeId: "sum_1", cwd, projectId: projectId(stranger) });
+    expect(data).toEqual({ node: null, error: "project not in group" });
+  });
+});


### PR DESCRIPTION
## Changes

Second slice of #399. Stacked on #400.

`conversation_id` and `message_id` are `AUTOINCREMENT` **per database**. The moment results from several projects share one list — which is exactly what unioning a group at read time produces — an unlabelled hit resolves against the wrong database and silently answers with a different message. That has to be impossible before any union ships, so it lands first.

- Every episodic and promoted hit carries `project: { id, cwd }`. `cwd` is for the reader; `id` is what goes back on a follow-up, because a folder rename is precisely the case #399 exists for.
- `project` is a **required** field on `NativeHistoryHit`, not an optional one. `tsc` then names every producer that forgets it — it found both of them, `/search` and `/prompt-search`.
- `/expand` and `/describe` accept that id back and resolve it through `projectGroup`. An id from outside the group is refused (`project not in group`) rather than quietly read from the request's own database, which would answer with a real but wrong node.
- `lcm_expand` and `lcm_describe` gain a `projectId` parameter so the id can actually make the round trip.

Nothing unions yet. This is the guardrail that makes the union safe to add.

## Files Touched

- `src/search/native-history.ts` — `ProjectRef`; `project` required on `NativeHistoryHit`; `searchNativeHistory` takes and stamps it.
- `src/daemon/project-group.ts` — `projectRef`, and `resolveSourceCwd` as the single gate.
- `src/daemon/routes/search.ts` — stamp both layers.
- `src/daemon/routes/prompt-search.ts` — stamp the Codex episodic path.
- `src/daemon/routes/{expand,describe}.ts` — resolve `projectId` through the group.
- `src/mcp/tools/{lcm-expand,lcm-describe}.ts` — expose `projectId`.
- `test/daemon/project-group.test.ts` — 3 tests over `resolveSourceCwd`.
- `test/daemon/routes/project-scoped-results.test.ts` — new: the stamp and both refusals, against a real daemon.

## Issue Reference

Part of #399

## Test Evidence

```
npx vitest run
Test Files  149 passed | 2 skipped (151)
     Tests  1531 passed | 6 skipped (1537)
```

## Risks & Follow-ups

- `/grep` and `/recent` are single-project and unchanged; they will need the same stamp when the union reaches them.
- `/restore` takes a `session_id`, which is a UUID rather than a per-database counter, so it cannot collide and is left alone.
- The wire shape of `/search` grows a field. Anything parsing it strictly would need updating; nothing in this repo does.

## AR Status

[SKIP_AR: no adversarial review run this session]

## Introspection Findings

Making the field required rather than optional is what did the work here. `tsc` enumerated the producers in one pass — two, not the handful a grep for `searchNativeHistory` would have suggested chasing.

## Token Cost

~140k tokens cumulative this session (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1wwybhXYEnbZVqA4SvJ83