### PR TITLE
feat(search): union promoted memory across checkouts, and measure the history union

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -252,6 +252,7 @@ export function registerBenchCommands(program: Command): void {
     .option("--k <n>", "Hit-rate cutoff (default: 5)", "5")
     .option("--bench-file <file>", "Benchmark file path (default: project memory directory)")
     .option("--json", "Output structured JSON")
+    .option("--union", "Score against every checkout of this repository, not this project alone")
     .action(async (opts) => {
       const cwd = typeof opts.project === "string" ? resolve(opts.project) : process.cwd();
       const k = parsePositiveInteger(String(opts.k ?? "5"), "--k");
@@ -261,6 +262,7 @@ export function registerBenchCommands(program: Command): void {
         k,
         benchFile: opts.benchFile,
         json: opts.json ?? false,
+        union: opts.union ?? false,
       });
       stdout.write(result.stdout);
       exit(result.exitCode);

--- a/src/bench.ts
+++ b/src/bench.ts
@@ -9,6 +9,8 @@ import { runLcmMigrations } from "./db/migration.js";
 import { ConversationStore } from "./store/conversation-store.js";
 import { PromotedStore } from "./db/promoted.js";
 import { rankNativeHistory } from "./search/native-history.js";
+import { searchHistoryGroup } from "./search/group-history.js";
+import { searchPromotedGroup } from "./search/group-promoted.js";
 import { extractQueryTerms } from "./store/fts5-query.js";
 import { ensureLanguagePack } from "./store/language-pack.js";
 import { detectLanguage, isDistinctivePrompt, LANGUAGE_SAMPLE_SIZE, MAX_PROMPT_LENGTH, parseLanguageTag } from "./search/language.js";
@@ -72,6 +74,13 @@ export type BenchOptions = {
   generator?: "llm" | "mechanical";
   /** Overrides language detection for `--generator llm`. */
   language?: string;
+  /**
+   * Score against the union of every checkout of this repository instead of
+   * this project alone. The question sets label sessions of the project they
+   * were built from, so a union can only add distractors here — this measures
+   * what the union costs, not what it finds.
+   */
+  union?: boolean;
 };
 
 export type BenchResult = {
@@ -710,13 +719,19 @@ type ScoreContext = {
   projectId: string;
   rgBaseline?: RgBaseline;
   k: number;
+  /** Set when scoring the union; the cwd whose group is searched. */
+  unionCwd?: string;
 };
 
 async function scoreQuery(query: BenchQuery, ctx: ScoreContext): Promise<QueryOutcome> {
   const start = performance.now();
   // The same ranking explicit search emits, so the bench measures what callers see.
-  const history = await rankNativeHistory(ctx.db, { query: query.question, limit: ctx.k * SESSION_ROW_BUDGET });
-  const promoted = ctx.promotedStore.search(query.question, ctx.k * SESSION_ROW_BUDGET, undefined, ctx.projectId);
+  const history = ctx.unionCwd
+    ? await searchHistoryGroup(ctx.unionCwd, { query: query.question, limit: ctx.k * SESSION_ROW_BUDGET })
+    : await rankNativeHistory(ctx.db, { query: query.question, limit: ctx.k * SESSION_ROW_BUDGET });
+  const promoted = ctx.unionCwd
+    ? searchPromotedGroup(ctx.unionCwd, { query: query.question, limit: ctx.k * SESSION_ROW_BUDGET }).hits
+    : ctx.promotedStore.search(query.question, ctx.k * SESSION_ROW_BUDGET, undefined, ctx.projectId);
   const latencyMs = performance.now() - start;
 
   const sessionIds = collectSessionIds(history, promoted);
@@ -819,7 +834,10 @@ export async function runBench(opts: BenchOptions): Promise<BenchResult> {
     runLcmMigrations(db);
     const pid = projectId(opts.cwd);
     const { baseline, warning } = await prepareRgBaseline(db, pid, rgDir);
-    const ctx: ScoreContext = { db, promotedStore: new PromotedStore(db), projectId: pid, rgBaseline: baseline, k };
+    const ctx: ScoreContext = {
+      db, promotedStore: new PromotedStore(db), projectId: pid, rgBaseline: baseline, k,
+      unionCwd: opts.union ? opts.cwd : undefined,
+    };
 
     const outcomes: QueryOutcome[] = [];
     for (const query of loaded.bench.queries) outcomes.push(await scoreQuery(query, ctx));

--- a/src/daemon/config.ts
+++ b/src/daemon/config.ts
@@ -23,6 +23,16 @@ export type DaemonConfig = {
     autoCompactMinTokens: number;
     promotionThresholds: { minDepth: number; compressionRatio: number; keywords: Record<string, string[]>; architecturePatterns: string[]; dedupBm25Threshold: number; dedupCandidateLimit: number; eventConfidence?: { decision?: number; plan?: number; errorFix?: number; batch?: number; pattern?: number }; reinforcementBoost?: number; maxConfidence?: number; insightsMaxAgeDays?: number };
   };
+  search: {
+    /**
+     * Union episodic history across every checkout of one repository.
+     *
+     * Off until the bench says otherwise: a union multiplies the candidate pool
+     * by the number of checkouts, and history is where the noise is. Promoted
+     * memory is unioned unconditionally and is not covered by this switch.
+     */
+    unionHistoryAcrossGroup: boolean;
+  };
   restoration: {
     recentSummaries: number;
     promptSearchMinScore: number;
@@ -74,6 +84,7 @@ const DEFAULTS: DaemonConfig = {
       insightsMaxAgeDays: 90,
     },
   },
+  search: { unionHistoryAcrossGroup: false },
   restoration: {
     recentSummaries: 3,
     promptSearchMinScore: 2,

--- a/src/daemon/routes/prompt-search.ts
+++ b/src/daemon/routes/prompt-search.ts
@@ -6,9 +6,10 @@ import { sendJson } from "../server.js";
 import type { RouteHandler } from "../server.js";
 import { closeLcmConnection, getLcmConnection } from "../../db/connection.js";
 import { runLcmMigrations } from "../../db/migration.js";
-import { PromotedStore, type SearchResult } from "../../db/promoted.js";
+import { type SearchResult } from "../../db/promoted.js";
 import { projectRef } from "../project-group.js";
-import { RecallStore, type RecallFeedback } from "../../db/recall.js";
+import { logGroupSurfacing, searchPromotedGroup } from "../../search/group-promoted.js";
+import { type RecallFeedback } from "../../db/recall.js";
 import { buildMemoryContext, selectMemoryHintsWithinBudget } from "../../hooks/memory-context.js";
 import { recordUserPromptEvents } from "../../hooks/user-prompt.js";
 import { safeLogError } from "../../hooks/hook-errors.js";
@@ -260,7 +261,6 @@ export function createPromptSearchHandler(config: DaemonConfig): RouteHandler {
       openedDbPath = dbPath;
       runLcmMigrations(db);
 
-      const store = new PromotedStore(db);
       const maxResults = config.restoration.promptSearchMaxResults;
       const minScore = config.restoration.promptSearchMinScore;
       const snippetLength = config.restoration.promptSnippetLength;
@@ -282,11 +282,15 @@ export function createPromptSearchHandler(config: DaemonConfig): RouteHandler {
 
       const targetHintCount = Math.max(maxResults, maxInjectedMemoryItems);
       const candidateLimit = Math.max(targetHintCount * CANDIDATE_LIMIT_MULTIPLIER, MIN_CANDIDATE_LIMIT);
-      const results = store.search(query, candidateLimit);
-      const recallStore = new RecallStore(db);
+      // Promoted memory is unioned across every checkout of this repository,
+      // and each hit's recall feedback is read from the database that holds it.
+      const { hits: results, feedback: feedbackById } = searchPromotedGroup(validatedCwd, {
+        query,
+        limit: candidateLimit,
+        withFeedback: true,
+      });
 
       const now = Date.now();
-      const feedbackById = recallStore.getFeedback(results.map((result) => result.id));
       const ranked = rankResults(results, feedbackById, {
           querySessionId: session_id,
           now,
@@ -366,10 +370,7 @@ export function createPromptSearchHandler(config: DaemonConfig): RouteHandler {
 
       // Log surfacing events (best-effort, never throws)
       try {
-        if (logSurfacing) {
-          const promotedIds = new Set(results.map(result => result.id));
-          recallStore.logSurfacing(ids.filter(id => promotedIds.has(id)), session_id ?? null);
-        }
+        if (logSurfacing) logGroupSurfacing(results, ids, session_id ?? null);
       } catch { /* non-fatal */ }
 
       const context = format === "context" ? buildMemoryContext(hints, ids) : null;

--- a/src/daemon/routes/search.ts
+++ b/src/daemon/routes/search.ts
@@ -1,11 +1,13 @@
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import type { DaemonConfig } from "../config.js";
 import { projectDbPath } from "../project.js";
 import { sendJson } from "../server.js";
 import type { RouteHandler } from "../server.js";
 import { closeLcmConnection, getLcmConnection } from "../../db/connection.js";
 import { runLcmMigrations } from "../../db/migration.js";
 import { searchNativeHistory } from "../../search/native-history.js";
+import { searchHistoryGroup } from "../../search/group-history.js";
 import { searchPromotedGroup } from "../../search/group-promoted.js";
 import { validateCwd } from "../validate-cwd.js";
 import { projectRef } from "../project-group.js";
@@ -14,7 +16,7 @@ function describeError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-export function createSearchHandler(): RouteHandler {
+export function createSearchHandler(config: DaemonConfig): RouteHandler {
   return async (_req, res, body) => {
     const input = JSON.parse(body || "{}");
     const { query, limit = 5, layers, tags } = input;
@@ -56,7 +58,12 @@ export function createSearchHandler(): RouteHandler {
           if (activeLayers.includes("episodic")) {
             try {
               // History records do not carry promoted-memory tags.
-              episodic = filterTags ? [] : await searchNativeHistory(db, { query, limit, project: projectRef(cwd) });
+              // Episodic union is gated: see search.unionHistoryAcrossGroup.
+              episodic = filterTags
+                ? []
+                : config.search.unionHistoryAcrossGroup
+                  ? await searchHistoryGroup(cwd, { query, limit })
+                  : await searchNativeHistory(db, { query, limit, project: projectRef(cwd) });
             } catch (err) {
               // Non-fatal for the response, but never silent: a real failure
               // (malformed FTS5 syntax, missing table, corrupt index) must be

--- a/src/daemon/routes/search.ts
+++ b/src/daemon/routes/search.ts
@@ -6,7 +6,7 @@ import type { RouteHandler } from "../server.js";
 import { closeLcmConnection, getLcmConnection } from "../../db/connection.js";
 import { runLcmMigrations } from "../../db/migration.js";
 import { searchNativeHistory } from "../../search/native-history.js";
-import { PromotedStore } from "../../db/promoted.js";
+import { searchPromotedGroup } from "../../search/group-promoted.js";
 import { validateCwd } from "../validate-cwd.js";
 import { projectRef } from "../project-group.js";
 
@@ -66,12 +66,12 @@ export function createSearchHandler(): RouteHandler {
             }
           }
 
-          // Promoted: FTS5 search across promoted memories
+          // Promoted: FTS5 across every checkout of this repository. Promoted
+          // memory is always unioned; only the episodic union is gated on
+          // measurement.
           if (activeLayers.includes("promoted")) {
             try {
-              const promotedStore = new PromotedStore(db);
-              promoted = promotedStore.search(query, limit, filterTags)
-                .map(result => ({ ...result, project: projectRef(cwd) }));
+              promoted = searchPromotedGroup(cwd, { query, limit, tags: filterTags }).hits;
             } catch (err) {
               console.warn(`[lcm] /search promoted layer failed: ${describeError(err)}`);
               errors.push(`promoted: ${describeError(err)}`);

--- a/src/daemon/server.ts
+++ b/src/daemon/server.ts
@@ -107,7 +107,7 @@ export async function createDaemon(config: DaemonConfig, options?: DaemonOptions
   routes.set("POST /promote", createPromoteHandler(config));
   routes.set("POST /restore", createRestoreHandler(config));
   routes.set("POST /grep", createGrepHandler(config));
-  routes.set("POST /search", createSearchHandler());
+  routes.set("POST /search", createSearchHandler(config));
   routes.set("POST /expand", createExpandHandler(config));
   routes.set("POST /describe", createDescribeHandler(config));
   routes.set("POST /store", createStoreHandler(config));

--- a/src/search/group-history.ts
+++ b/src/search/group-history.ts
@@ -1,0 +1,69 @@
+import { existsSync } from "node:fs";
+import { closeLcmConnection } from "../db/connection.js";
+import { projectDbPath } from "../daemon/project.js";
+import { projectGroup, projectRef } from "../daemon/project-group.js";
+import { openMigrated } from "./migrated-connection.js";
+import { searchNativeHistory, type NativeHistoryHit } from "./native-history.js";
+
+/**
+ * Episodic history read across every checkout of one repository.
+ *
+ * Unlike promoted memory, which the design unions unconditionally, this is
+ * gated: history is where the noise is, and a union multiplies the candidate
+ * pool by the number of checkouts. `lcm bench run --union` measures the cost
+ * against the same question sets, so the gate is opened on a number.
+ */
+
+/** Reciprocal-rank offset, matching the one used to fuse within a project. */
+const FUSION_RANK_OFFSET = 10;
+
+/**
+ * Fuse per-database lists by reciprocal rank.
+ *
+ * Never by score: bm25 numbers from different databases rank the same text
+ * differently because each database is its own corpus, so only positions are
+ * comparable.
+ */
+function fuseByReciprocalRank(lists: NativeHistoryHit[][], limit: number): NativeHistoryHit[] {
+  const scored = new Map<NativeHistoryHit, number>();
+  for (const list of lists) {
+    list.forEach((hit, position) => scored.set(hit, 1 / (FUSION_RANK_OFFSET + position)));
+  }
+  return [...scored.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, limit)
+    .map(([hit]) => hit);
+}
+
+/**
+ * Searches episodic history across `cwd`'s group.
+ *
+ * A group of one takes the single-database path unchanged, so a project that
+ * shares its repository with nothing keeps exactly the ranking it had.
+ */
+export async function searchHistoryGroup(
+  cwd: string,
+  input: { query: string; limit: number },
+): Promise<NativeHistoryHit[]> {
+  const lists: NativeHistoryHit[][] = [];
+
+  for (const member of projectGroup(cwd)) {
+    const dbPath = projectDbPath(member.cwd);
+    if (!existsSync(dbPath)) continue;
+    const db = openMigrated(dbPath);
+    try {
+      const found = await searchNativeHistory(db, {
+        query: input.query,
+        limit: input.limit,
+        project: projectRef(member.cwd),
+      });
+      if (found.length > 0) lists.push(found);
+    } finally {
+      closeLcmConnection(dbPath);
+    }
+  }
+
+  return lists.length <= 1
+    ? (lists[0] ?? []).slice(0, input.limit)
+    : fuseByReciprocalRank(lists, input.limit);
+}

--- a/src/search/group-promoted.ts
+++ b/src/search/group-promoted.ts
@@ -1,0 +1,152 @@
+import { existsSync } from "node:fs";
+import { closeLcmConnection, getLcmConnection } from "../db/connection.js";
+import { runLcmMigrations } from "../db/migration.js";
+import { PromotedStore, type SearchResult } from "../db/promoted.js";
+import { RecallStore, type RecallFeedback } from "../db/recall.js";
+import { projectDbPath } from "../daemon/project.js";
+import { projectGroup, projectRef } from "../daemon/project-group.js";
+import type { ProjectRef } from "./native-history.js";
+
+/**
+ * Promoted memory read across every checkout of one repository.
+ *
+ * Storage stays per-cwd, so the same repository checked out twice holds two
+ * sets of promoted memories. Recall unions them at read time. A physical merge
+ * was rejected: bm25 scores from different databases are not comparable, so
+ * results are fused by reciprocal rank instead.
+ */
+
+export type GroupPromotedHit = SearchResult & { project: ProjectRef };
+
+/**
+ * Reciprocal-rank offset. Large enough that a top hit in a small database does
+ * not automatically outrank a strong hit further down a large one.
+ */
+const FUSION_RANK_OFFSET = 10;
+
+/**
+ * Databases this process has already brought up to date.
+ *
+ * The migration sweep is idempotent DDL with no version marker, so it costs
+ * ~80 ms per database however little there is to do. Measured on the lcm group:
+ * unioning five checkouts spends 4 ms searching and 394 ms migrating, against a
+ * 500 ms budget for the whole prompt hook. Schema is per-file and the daemon
+ * holds the only writer, so once per path per process is enough.
+ */
+const migrated = new Set<string>();
+
+function openMigrated(dbPath: string) {
+  const db = getLcmConnection(dbPath);
+  if (!migrated.has(dbPath)) {
+    runLcmMigrations(db);
+    migrated.add(dbPath);
+  }
+  return db;
+}
+
+export interface GroupPromotedSearch {
+  hits: GroupPromotedHit[];
+  /** Recall feedback for every hit, read from the database that holds it. */
+  feedback: Map<string, RecallFeedback>;
+}
+
+/**
+ * Fuses per-database result lists into one.
+ *
+ * Order comes from reciprocal rank. The `rank` field then gets re-drawn from
+ * the magnitudes the members actually produced, largest first: downstream
+ * scoring multiplies `rank` and compares the product against a configured
+ * threshold, so the union has to land on the same scale the single-project
+ * path does or that threshold changes meaning.
+ */
+function fuseByReciprocalRank(lists: GroupPromotedHit[][], limit: number): GroupPromotedHit[] {
+  const scored = new Map<GroupPromotedHit, number>();
+  for (const list of lists) {
+    list.forEach((hit, position) => scored.set(hit, 1 / (FUSION_RANK_OFFSET + position)));
+  }
+  const ordered = [...scored.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([hit]) => hit)
+    .slice(0, limit);
+
+  const magnitudes = [...scored.keys()]
+    .map(hit => Math.abs(hit.rank))
+    .sort((a, b) => b - a);
+  return ordered.map((hit, position) => ({ ...hit, rank: magnitudes[position] ?? hit.rank }));
+}
+
+interface GroupSearchInput {
+  query: string;
+  limit: number;
+  tags?: string[];
+  /** Read recall feedback alongside the hits. Only the prompt hook needs it. */
+  withFeedback?: boolean;
+}
+
+/**
+ * Searches promoted memory across `cwd`'s group.
+ *
+ * A group of one takes the single-database path unchanged, so a project that
+ * shares its repository with nothing keeps exactly the ranking it had.
+ */
+export function searchPromotedGroup(cwd: string, input: GroupSearchInput): GroupPromotedSearch {
+  const members = projectGroup(cwd);
+  const lists: GroupPromotedHit[][] = [];
+  const feedback = new Map<string, RecallFeedback>();
+
+  for (const member of members) {
+    const dbPath = projectDbPath(member.cwd);
+    if (!existsSync(dbPath)) continue;
+    const db = openMigrated(dbPath);
+    try {
+      const found = new PromotedStore(db).search(input.query, input.limit, input.tags);
+      if (found.length === 0) continue;
+      lists.push(found.map(result => ({ ...result, project: projectRef(member.cwd) })));
+      if (input.withFeedback) {
+        for (const [id, entry] of new RecallStore(db).getFeedback(found.map(r => r.id))) {
+          feedback.set(id, entry);
+        }
+      }
+    } finally {
+      closeLcmConnection(dbPath);
+    }
+  }
+
+  const hits = lists.length <= 1
+    ? (lists[0] ?? []).slice(0, input.limit)
+    : fuseByReciprocalRank(lists, input.limit);
+  return { hits, feedback };
+}
+
+/**
+ * Records which memories were surfaced, each in the database that holds it.
+ *
+ * Surfacing drives the cooldown that keeps the same memory from being injected
+ * every prompt. Writing it all to the requesting project would split that state
+ * from the memory it describes, and the sibling would go on resurfacing.
+ */
+export function logGroupSurfacing(
+  hits: GroupPromotedHit[],
+  surfacedIds: string[],
+  sessionId: string | null,
+): void {
+  const surfaced = new Set(surfacedIds);
+  const byProject = new Map<string, string[]>();
+  for (const hit of hits) {
+    if (!surfaced.has(hit.id)) continue;
+    const ids = byProject.get(hit.project.cwd) ?? [];
+    ids.push(hit.id);
+    byProject.set(hit.project.cwd, ids);
+  }
+
+  for (const [memberCwd, ids] of byProject) {
+    const dbPath = projectDbPath(memberCwd);
+    if (!existsSync(dbPath)) continue;
+    const db = openMigrated(dbPath);
+    try {
+      new RecallStore(db).logSurfacing(ids, sessionId);
+    } finally {
+      closeLcmConnection(dbPath);
+    }
+  }
+}

--- a/src/search/group-promoted.ts
+++ b/src/search/group-promoted.ts
@@ -1,10 +1,10 @@
 import { existsSync } from "node:fs";
-import { closeLcmConnection, getLcmConnection } from "../db/connection.js";
-import { runLcmMigrations } from "../db/migration.js";
+import { closeLcmConnection } from "../db/connection.js";
 import { PromotedStore, type SearchResult } from "../db/promoted.js";
 import { RecallStore, type RecallFeedback } from "../db/recall.js";
 import { projectDbPath } from "../daemon/project.js";
 import { projectGroup, projectRef } from "../daemon/project-group.js";
+import { openMigrated } from "./migrated-connection.js";
 import type { ProjectRef } from "./native-history.js";
 
 /**
@@ -23,26 +23,6 @@ export type GroupPromotedHit = SearchResult & { project: ProjectRef };
  * not automatically outrank a strong hit further down a large one.
  */
 const FUSION_RANK_OFFSET = 10;
-
-/**
- * Databases this process has already brought up to date.
- *
- * The migration sweep is idempotent DDL with no version marker, so it costs
- * ~80 ms per database however little there is to do. Measured on the lcm group:
- * unioning five checkouts spends 4 ms searching and 394 ms migrating, against a
- * 500 ms budget for the whole prompt hook. Schema is per-file and the daemon
- * holds the only writer, so once per path per process is enough.
- */
-const migrated = new Set<string>();
-
-function openMigrated(dbPath: string) {
-  const db = getLcmConnection(dbPath);
-  if (!migrated.has(dbPath)) {
-    runLcmMigrations(db);
-    migrated.add(dbPath);
-  }
-  return db;
-}
 
 export interface GroupPromotedSearch {
   hits: GroupPromotedHit[];

--- a/src/search/migrated-connection.ts
+++ b/src/search/migrated-connection.ts
@@ -1,0 +1,33 @@
+import type { DatabaseSync } from "node:sqlite";
+import { getLcmConnection } from "../db/connection.js";
+import { runLcmMigrations } from "../db/migration.js";
+
+/**
+ * Databases this process has already brought up to date.
+ *
+ * The migration sweep is idempotent DDL with no version marker, so it costs
+ * ~80 ms per database however little there is to do. Measured on the lcm group:
+ * unioning five checkouts spends 4 ms searching and 394 ms migrating, against a
+ * 500 ms budget for the whole prompt hook. Schema is per-file and the daemon
+ * holds the only writer, so once per path per process is enough.
+ *
+ * The assumption is that a database file is not deleted and recreated at the
+ * same path within one process. Project paths are derived from cwd, so that
+ * only happens when a project is wiped and rebuilt while the daemon runs.
+ */
+const migrated = new Set<string>();
+
+/** Opens a pooled connection, migrating that database the first time only. */
+export function openMigrated(dbPath: string): DatabaseSync {
+  const db = getLcmConnection(dbPath);
+  if (!migrated.has(dbPath)) {
+    runLcmMigrations(db);
+    migrated.add(dbPath);
+  }
+  return db;
+}
+
+/** Forgets what has been migrated. For tests that rebuild a store in place. */
+export function resetMigrationMemo(): void {
+  migrated.clear();
+}

--- a/src/search/native-history.ts
+++ b/src/search/native-history.ts
@@ -27,7 +27,9 @@ export interface ProjectRef {
   cwd: string;
 }
 
-export type NativeHistoryHit = HistoryHit & SourceContext & { project: ProjectRef };
+// The ranked hit, not the bare one: `searchNativeHistory` carries the session
+// id through, and callers group by it.
+export type NativeHistoryHit = RankedHistoryHit & SourceContext & { project: ProjectRef };
 
 function anchorSpan(content: string, hint: string): { start: number; length: number } {
   const fragments = hint.split("...").map(part => part.trim()).filter(Boolean);

--- a/test/search/group-promoted.test.ts
+++ b/test/search/group-promoted.test.ts
@@ -1,0 +1,128 @@
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+
+/** An isolated base dir, so these tests never touch the developer's own store. */
+const base = realpathSync(mkdtempSync(join(tmpdir(), "lcm-union-base-")));
+vi.mock("../../src/daemon/project.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../../src/daemon/project.js")>();
+  const dirOf = (cwd: string) => join(base, "projects", original.projectId(cwd));
+  return {
+    ...original,
+    BASE_DIR: base,
+    projectDir: dirOf,
+    projectDbPath: (cwd: string) => join(dirOf(cwd), "db.sqlite"),
+    projectMetaPath: (cwd: string) => join(dirOf(cwd), "meta.json"),
+    ensureProjectDir: (cwd: string) => { mkdirSync(dirOf(cwd), { recursive: true }); return dirOf(cwd); },
+  };
+});
+
+const { searchPromotedGroup, logGroupSurfacing } = await import("../../src/search/group-promoted.js");
+const { openProject } = await import("../../src/daemon/project-group.js");
+const { projectDbPath, projectId } = await import("../../src/daemon/project.js");
+const { runLcmMigrations } = await import("../../src/db/migration.js");
+const { PromotedStore } = await import("../../src/db/promoted.js");
+const { RecallStore } = await import("../../src/db/recall.js");
+
+const tempDirs: string[] = [];
+afterEach(() => { for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+afterAll(() => rmSync(base, { recursive: true, force: true }));
+
+/** A checkout of `remote` whose promoted memory holds `contents`. */
+function checkout(remote: string, contents: string[]): string {
+  const cwd = realpathSync(mkdtempSync(join(tmpdir(), "lcm-union-repo-")));
+  tempDirs.push(cwd);
+  execFileSync("git", ["init", "-q"], { cwd, stdio: "ignore" });
+  execFileSync("git", ["remote", "add", "origin", remote], { cwd, stdio: "ignore" });
+  openProject(cwd);
+
+  const dbPath = projectDbPath(cwd);
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
+  try {
+    runLcmMigrations(db);
+    const store = new PromotedStore(db);
+    for (const content of contents) store.insert({ content, tags: ["decision"], projectId: "p1" });
+  } finally { db.close(); }
+  return cwd;
+}
+
+const LCM = "git@github.com:lossless-claude/lcm.git";
+
+describe("searchPromotedGroup", () => {
+  it("returns memories held by a sibling checkout of the same repository", () => {
+    const here = checkout(LCM, ["compaction runs lazily"]);
+    const sibling = checkout("https://github.com/lossless-claude/lcm.git", ["compaction is the only LLM step"]);
+
+    const contents = searchPromotedGroup(here, { query: "compaction", limit: 10 }).hits.map(h => h.content);
+    expect(contents).toHaveLength(2);
+    expect(contents).toContain("compaction runs lazily");
+    expect(contents).toContain("compaction is the only LLM step");
+    expect(sibling).toBeTruthy();
+  });
+
+  it("names the checkout each memory came from", () => {
+    const here = checkout(LCM, ["compaction runs lazily"]);
+    const sibling = checkout(LCM, ["compaction is the only LLM step"]);
+
+    const byContent = new Map(
+      searchPromotedGroup(here, { query: "compaction", limit: 10 }).hits.map(h => [h.content, h.project]),
+    );
+    expect(byContent.get("compaction runs lazily")).toEqual({ id: projectId(here), cwd: here });
+    expect(byContent.get("compaction is the only LLM step")).toEqual({ id: projectId(sibling), cwd: sibling });
+  });
+
+  it("leaves a lone project's own ranking untouched", () => {
+    const alone = checkout("git@github.com:lossless-claude/only-me.git", ["compaction runs lazily", "compaction of nothing"]);
+
+    const db = new DatabaseSync(projectDbPath(alone));
+    const expected = new PromotedStore(db).search("compaction", 10);
+    db.close();
+
+    const hits = searchPromotedGroup(alone, { query: "compaction", limit: 10 }).hits;
+    expect(hits.map(h => h.id)).toEqual(expected.map(r => r.id));
+    expect(hits.map(h => h.rank)).toEqual(expected.map(r => r.rank));
+  });
+
+  it("does not reach a checkout of a different repository", () => {
+    const here = checkout(LCM, ["compaction runs lazily"]);
+    checkout("git@github.com:lossless-claude/magi.git", ["compaction elsewhere"]);
+
+    const contents = searchPromotedGroup(here, { query: "compaction", limit: 10 }).hits.map(h => h.content);
+    expect(contents).toEqual(["compaction runs lazily"]);
+  });
+
+  it("reads each memory's recall feedback from the database that holds it", () => {
+    const here = checkout(LCM, ["compaction runs lazily"]);
+    const sibling = checkout(LCM, ["compaction is the only LLM step"]);
+
+    const siblingDb = new DatabaseSync(projectDbPath(sibling));
+    const siblingId = new PromotedStore(siblingDb).search("compaction", 1)[0].id;
+    new RecallStore(siblingDb).logSurfacing([siblingId], "session-1");
+    siblingDb.close();
+
+    const { feedback } = searchPromotedGroup(here, { query: "compaction", limit: 10, withFeedback: true });
+    expect(feedback.get(siblingId)?.surfacingCount).toBe(1);
+  });
+});
+
+describe("logGroupSurfacing", () => {
+  it("writes a sibling's surfacing into the sibling's own database", () => {
+    const here = checkout(LCM, ["compaction runs lazily"]);
+    const sibling = checkout(LCM, ["compaction is the only LLM step"]);
+
+    const hits = searchPromotedGroup(here, { query: "compaction", limit: 10 }).hits;
+    const fromSibling = hits.find(h => h.project.cwd === sibling)!;
+    logGroupSurfacing(hits, [fromSibling.id], "session-1");
+
+    const siblingDb = new DatabaseSync(projectDbPath(sibling));
+    const hereDb = new DatabaseSync(projectDbPath(here));
+    try {
+      expect(new RecallStore(siblingDb).getFeedback([fromSibling.id]).get(fromSibling.id)?.surfacingCount).toBe(1);
+      expect(new RecallStore(hereDb).getFeedback([fromSibling.id]).get(fromSibling.id)?.surfacingCount).toBe(0);
+    } finally { siblingDb.close(); hereDb.close(); }
+  });
+});


### PR DESCRIPTION
## Changes

Third slice of #399. Stacked on #403. Two commits: union promoted memory, then measure the episodic union and leave it off.

### Promoted memory is unioned

The design settles that promoted memories are always unioned. Until now the lcm group's own promoted memory sat in five databases and every search saw one of them.

- `searchPromotedGroup(cwd, …)` reads from every member of the group and fuses by **reciprocal rank**. Never by score: bm25 numbers from different databases are not comparable, which is why a physical merge was rejected in the first place.
- The fused `rank` is re-drawn from the magnitudes the members actually produced, largest first. Downstream scoring multiplies `rank` and compares the product against `promptSearchMinScore`, so the union has to land on the same scale the single-project path does or that threshold quietly changes meaning.
- **A group of one takes the single-database path unchanged**, pinned hit-for-hit by a test.
- Recall feedback is read from the database that holds each memory, and surfacing is written back to it. Keeping that state on the requesting project would split cooldown from the memory it describes, and the sibling would go on resurfacing every prompt.

### The episodic union is measured, and stays off

`lcm bench run --union` scores against the group instead of the project alone. Run over every question set in a copy of the real store, k=5:

| set | alone | union |
|---|---|---|
| pooled (8 sets, n=179) | 0.458 | 0.385 |
| grouped only (2 sets, n=60) | **0.333** | **0.117** |
| `lcm` (n=30, 7 members) | 0.233 | 0.033 |

So `search.unionHistoryAcrossGroup` ships `false`.

The cause is the fusion, not the idea: reciprocal rank across members gives every checkout an equal claim on the top five, and with seven members the project actually asked about keeps one slot in seven. Weighting the requesting project is the obvious next thing to measure; it is not shipped on a guess.

The question sets label sessions of the project they were built from, so this measures what the union **costs**, never what it finds. That asymmetry is exactly why the gate needed a number rather than an argument.

On the pooled figure: the recorded baseline is 0.521 over n=194. This run reaches n=179 because one project's folder no longer exists and the single-question sets are skipped; those account for the difference. The `--union false` path is byte-identical to what shipped before, so the two numbers describe different question pools, not a regression.

## Latency

The prompt hook has a 500 ms budget, so the promoted union was measured against a copy of the real store (5 members, 66k messages):

| | median | max |
|---|---|---|
| before memoising migrations | 163 ms | 230 ms |
| after | **8.6 ms** | 31 ms |

The split says why: a prompt spent **4 ms searching** the five databases and **394 ms migrating** them. The migration sweep is idempotent DDL with no version marker, so it costs ~80 ms per database whatever the state. Schema is per-file and the daemon holds the only writer, so it now runs once per path per process.

## Files Touched

- `src/search/group-promoted.ts` — new: the promoted union, the fusion, per-member feedback and surfacing.
- `src/search/group-history.ts` — new: the episodic union, behind the gate.
- `src/search/migrated-connection.ts` — new: migrate each database once per process.
- `src/search/native-history.ts` — `NativeHistoryHit` now says it carries `sessionId`, which it always did.
- `src/daemon/config.ts` — `search.unionHistoryAcrossGroup`, default false.
- `src/daemon/routes/{search,prompt-search}.ts` — read through the group.
- `src/bench.ts`, `bin/lcm.ts` — `lcm bench run --union`.
- `test/search/group-promoted.test.ts` — new: 6 tests over real temp repositories.

## Issue Reference

Part of #399

## Test Evidence

```
npx vitest run
Test Files  155 passed | 2 skipped (157)
     Tests  1575 passed | 6 skipped (1581)
```

Both the union and the bench were run against a copy of the real store with `HOME` redirected. Nothing was written to `~/.lossless-claude`.

## Risks & Follow-ups

- The migration memo assumes a database file is not deleted and recreated at the same path inside one daemon process.
- A five-member group opens five connections per prompt. Search is 4 ms of that; skipping members with no promoted rows is the next lever if a group grows much larger.
- The promoted union has **no** equivalent measurement — the question sets score sessions, not promoted memories, so the bench cannot grade it. It ships on the design decision, not on a number.

## AR Status

[SKIP_AR: no adversarial review run this session]

## Introspection Findings

The union was never the expensive part — 4 ms out of 400. Measuring the phases separately instead of the whole call found that, and the fix was one `Set`. On the history side the measurement was worth more than the feature: an equal-weight fusion across seven checkouts looks obviously right and is obviously wrong once a number is put on it.

## Token Cost

~330k tokens cumulative this session (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1wwybhXYEnbZVqA4SvJ83