### PR TITLE
feat(retag): re-label legacy rows from the transcripts still on disk

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -1068,6 +1068,37 @@ async function main() {
       exit(r.exitCode);
     });
 
+  // ─── retag ────────────────────────────────────────────────────────────────
+  program
+    .command("retag")
+    .description("Re-label rows an older parser stored, using the transcripts still on disk")
+    .option("--project <path>", "Only this project (default: every project)")
+    .option("--dry-run", "Report what would change without writing")
+    .option("--verbose", "Show per-project detail")
+    .action(async (opts) => {
+      const { resolve } = await import("node:path");
+      const { retagAll } = await import("../src/retag-run.js");
+      const cwd = typeof opts.project === "string" ? resolve(opts.project) : undefined;
+      const dryRun: boolean = opts.dryRun ?? false;
+      const verbose: boolean = opts.verbose ?? false;
+
+      const totals = retagAll({
+        cwd,
+        dryRun,
+        onProject: (projectCwd, projectTotals) => {
+          if (verbose && projectTotals.rows > 0) {
+            console.log(`  ${projectTotals.rows} rows in ${projectTotals.retaggedConversations} conversations  ${projectCwd}`);
+          }
+        },
+      });
+
+      const prefix = dryRun ? "  [dry-run]" : " ";
+      console.log(`${prefix} ${totals.rows} rows re-labelled across ${totals.retaggedConversations} conversations (${totals.conversations} examined).`);
+      const skipped = Object.entries(totals.skipped).sort((a, b) => b[1] - a[1]);
+      for (const [reason, n] of skipped) console.log(`  ${String(n).padStart(7)} left alone: ${reason}`);
+      if (dryRun) console.log("  Nothing was written.");
+    });
+
   // ─── import ────────────────────────────────────────────────────────────────
   program
     .command("import")

--- a/src/retag-run.ts
+++ b/src/retag-run.ts
@@ -1,0 +1,130 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { BASE_DIR, claudeTranscriptPath, projectDbPath } from "./daemon/project.js";
+import { runLcmMigrations } from "./db/migration.js";
+import { retagConversation, type RetagOutcome } from "./retag.js";
+
+export interface RetagRunOptions {
+  /** Limit to one project; otherwise every project on disk. */
+  cwd?: string;
+  /** Report what would change without writing. */
+  dryRun?: boolean;
+  onProject?: (cwd: string, totals: RetagTotals) => void;
+}
+
+export interface RetagTotals {
+  conversations: number;
+  retaggedConversations: number;
+  rows: number;
+  skipped: Record<string, number>;
+}
+
+const emptyTotals = (): RetagTotals => ({
+  conversations: 0,
+  retaggedConversations: 0,
+  rows: 0,
+  skipped: {},
+});
+
+function add(into: RetagTotals, from: RetagTotals): void {
+  into.conversations += from.conversations;
+  into.retaggedConversations += from.retaggedConversations;
+  into.rows += from.rows;
+  for (const [reason, n] of Object.entries(from.skipped)) {
+    into.skipped[reason] = (into.skipped[reason] ?? 0) + n;
+  }
+}
+
+function record(totals: RetagTotals, outcome: RetagOutcome): void {
+  totals.conversations++;
+  if (outcome.skipped) {
+    totals.skipped[outcome.skipped] = (totals.skipped[outcome.skipped] ?? 0) + 1;
+    return;
+  }
+  if (outcome.retagged > 0) {
+    totals.retaggedConversations++;
+    totals.rows += outcome.retagged;
+  }
+}
+
+/**
+ * Re-labels one project's untagged conversations from the transcripts that
+ * still exist on disk.
+ *
+ * A session with no transcript is never touched: its rows cannot be checked
+ * against anything, so they keep the labels they have and the conversation
+ * stays unknown.
+ */
+export function retagProject(cwd: string, options: { dryRun?: boolean } = {}): RetagTotals {
+  const totals = emptyTotals();
+  const dbPath = projectDbPath(cwd);
+  if (!existsSync(dbPath)) return totals;
+
+  const db = new DatabaseSync(dbPath);
+  try {
+    db.exec("PRAGMA busy_timeout = 5000");
+    runLcmMigrations(db);
+    const conversations = db
+      .prepare("SELECT conversation_id, session_id FROM conversations WHERE role_tagging IS NULL")
+      .all() as unknown as Array<{ conversation_id: number; session_id: string }>;
+
+    for (const conversation of conversations) {
+      const transcript = claudeTranscriptPath(cwd, conversation.session_id);
+      if (!transcript || !existsSync(transcript)) {
+        totals.conversations++;
+        totals.skipped["no-transcript"] = (totals.skipped["no-transcript"] ?? 0) + 1;
+        continue;
+      }
+      if (options.dryRun) {
+        // A dry run answers the only question that matters — how many rows
+        // would change — so it does the same comparison inside a rolled-back
+        // transaction rather than a weaker one outside it.
+        db.exec("SAVEPOINT retag_dry_run");
+        try {
+          record(totals, retagConversation(db, conversation.conversation_id, transcript));
+        } finally {
+          db.exec("ROLLBACK TO retag_dry_run");
+          db.exec("RELEASE retag_dry_run");
+        }
+        continue;
+      }
+      record(totals, retagConversation(db, conversation.conversation_id, transcript));
+    }
+  } finally {
+    db.close();
+  }
+  return totals;
+}
+
+/** Re-labels every project on disk, or the one named. */
+export function retagAll(options: RetagRunOptions = {}): RetagTotals {
+  const overall = emptyTotals();
+  const cwds = options.cwd ? [options.cwd] : projectCwds();
+
+  for (const cwd of cwds) {
+    const totals = retagProject(cwd, { dryRun: options.dryRun });
+    if (totals.conversations === 0) continue;
+    options.onProject?.(cwd, totals);
+    add(overall, totals);
+  }
+  return overall;
+}
+
+function projectCwds(): string[] {
+  const projectsDir = join(BASE_DIR, "projects");
+  if (!existsSync(projectsDir)) return [];
+  const cwds: string[] = [];
+  for (const entry of readdirSync(projectsDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const metaPath = join(projectsDir, entry.name, "meta.json");
+    if (!existsSync(metaPath)) continue;
+    try {
+      const cwd = JSON.parse(readFileSync(metaPath, "utf-8")).cwd;
+      if (typeof cwd === "string" && cwd) cwds.push(cwd);
+    } catch {
+      // A corrupt meta.json skips that project, never the whole run.
+    }
+  }
+  return cwds;
+}

--- a/src/retag.ts
+++ b/src/retag.ts
@@ -1,0 +1,147 @@
+import { readFileSync } from "node:fs";
+import type { DatabaseSync } from "node:sqlite";
+
+/**
+ * Re-labelling the rows an older parser already stored.
+ *
+ * Before role tagging, a tool result was stored under `user` — the turn Claude
+ * Code puts it in — so most of the "user" corpus was never a person talking.
+ * The text is right; only the label is wrong.
+ *
+ * Nothing is deleted and nothing is inserted. `summary_messages` and
+ * `context_items` reference `message_id` with `ON DELETE RESTRICT`, so a
+ * compacted conversation cannot have its rows replaced at all; and appending
+ * the tool calls the old parser dropped would renumber `seq` under every
+ * summary that points into it. Only `messages.role` changes, and only where
+ * the stored text still matches the transcript.
+ */
+
+interface ContentBlock {
+  type?: string;
+  text?: string;
+  content?: string | ContentBlock[];
+}
+
+/** One row as the old parser would have stored it, with the role it should carry. */
+export interface RetagEntry {
+  content: string;
+  role: string;
+}
+
+function extractText(content: string | ContentBlock[] | unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((b: ContentBlock) => {
+        if (b.type === "text" && typeof b.text === "string") return b.text;
+        if (b.type === "tool_result") return extractText(b.content);
+        return "";
+      })
+      .filter(Boolean)
+      .join("\n");
+  }
+  return "";
+}
+
+/**
+ * Replays a transcript the way the pre-tagging parser read it — same entries
+ * kept, same text extracted, same order — and states the role each row should
+ * carry under the tagging rules.
+ *
+ * Entries the old parser dropped stay dropped. A tool call extracted to an
+ * empty string back then and was skipped; adding it now would shift every
+ * later `seq`.
+ */
+export function retagEntries(transcriptPath: string): RetagEntry[] {
+  let raw: string;
+  try {
+    raw = readFileSync(transcriptPath, "utf-8");
+  } catch {
+    return [];
+  }
+
+  const entries: RetagEntry[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let parsed: { message?: { role?: string; content?: string | ContentBlock[] } };
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      continue;
+    }
+    const entryRole = parsed.message?.role;
+    if (!entryRole || !["user", "assistant", "system"].includes(entryRole)) continue;
+    const content = extractText(parsed.message?.content);
+    if (!content.trim()) continue;
+
+    const blocks = Array.isArray(parsed.message?.content) ? parsed.message!.content as ContentBlock[] : [];
+    const prose = blocks.some(b => b.type === "text" && typeof b.text === "string" && b.text.trim() !== "");
+    const isTool = blocks.length > 0 && !prose && blocks.some(b => b.type === "tool_result");
+    entries.push({ content, role: isTool ? "tool" : entryRole });
+  }
+  return entries;
+}
+
+export interface RetagOutcome {
+  /** Rows whose role changed. */
+  retagged: number;
+  /** Rows the transcript agreed with, left as they were. */
+  unchanged: number;
+  /** Why the conversation was left alone, when it was. */
+  skipped?: "no-transcript" | "length-mismatch" | "content-mismatch" | "already-tagged";
+}
+
+interface StoredMessage {
+  message_id: number;
+  seq: number;
+  role: string;
+  content: string;
+}
+
+/**
+ * Re-labels one conversation's rows from its transcript.
+ *
+ * Refuses on any disagreement rather than guessing: if the transcript no
+ * longer lines up with what was stored, the rows keep the labels they have and
+ * the conversation stays unknown. Guessing a tag from text alone was measured
+ * at 89.3% precision, which calls the user a log 240 times — the exact failure
+ * this exists to end.
+ */
+export function retagConversation(
+  db: DatabaseSync,
+  conversationId: number,
+  transcriptPath: string,
+): RetagOutcome {
+  const tagging = db
+    .prepare("SELECT role_tagging FROM conversations WHERE conversation_id = ?")
+    .get(conversationId) as { role_tagging?: string | null } | undefined;
+  if (tagging?.role_tagging === "tagged") return { retagged: 0, unchanged: 0, skipped: "already-tagged" };
+
+  const entries = retagEntries(transcriptPath);
+  if (entries.length === 0) return { retagged: 0, unchanged: 0, skipped: "no-transcript" };
+
+  const stored = db
+    .prepare("SELECT message_id, seq, role, content FROM messages WHERE conversation_id = ? ORDER BY seq")
+    .all(conversationId) as unknown as StoredMessage[];
+  // A transcript that kept growing after the session was ingested still holds
+  // the stored rows as its prefix, so it can label them. A transcript with
+  // fewer rows than the store has diverged and is not trusted at all.
+  if (stored.length > entries.length) return { retagged: 0, unchanged: 0, skipped: "length-mismatch" };
+
+  for (let i = 0; i < stored.length; i++) {
+    if (stored[i].content !== entries[i].content) {
+      return { retagged: 0, unchanged: 0, skipped: "content-mismatch" };
+    }
+  }
+
+  const update = db.prepare("UPDATE messages SET role = ? WHERE message_id = ?");
+  let retagged = 0;
+  for (let i = 0; i < stored.length; i++) {
+    if (stored[i].role === entries[i].role) continue;
+    update.run(entries[i].role, stored[i].message_id);
+    retagged++;
+  }
+  db.prepare("UPDATE conversations SET role_tagging = 'tagged' WHERE conversation_id = ?").run(conversationId);
+  return { retagged, unchanged: stored.length - retagged };
+}

--- a/test/retag.test.ts
+++ b/test/retag.test.ts
@@ -1,0 +1,150 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it } from "vitest";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { retagConversation, retagEntries } from "../src/retag.js";
+
+const tempDirs: string[] = [];
+afterEach(() => { for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+
+const entry = (role: string, content: unknown) => ({ type: "message", message: { role, content } });
+
+function transcript(entries: unknown[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "lcm-retag-"));
+  tempDirs.push(dir);
+  const path = join(dir, "session.jsonl");
+  writeFileSync(path, entries.map(e => JSON.stringify(e)).join("\n") + "\n");
+  return path;
+}
+
+/** A conversation as the pre-tagging parser stored it: every row under user/assistant. */
+function legacyConversation(rows: Array<{ role: string; content: string }>): { db: DatabaseSync; id: number } {
+  const db = new DatabaseSync(":memory:");
+  runLcmMigrations(db);
+  db.prepare("INSERT INTO conversations (session_id, title) VALUES (?, ?)").run("s1", null);
+  const id = Number((db.prepare("SELECT conversation_id FROM conversations").get() as any).conversation_id);
+  db.prepare("UPDATE conversations SET role_tagging = NULL WHERE conversation_id = ?").run(id);
+  const insert = db.prepare(
+    "INSERT INTO messages (conversation_id, seq, role, content, token_count) VALUES (?, ?, ?, ?, ?)",
+  );
+  rows.forEach((row, seq) => insert.run(id, seq, row.role, row.content, 1));
+  return { db, id };
+}
+
+const rolesOf = (db: DatabaseSync, id: number) =>
+  (db.prepare("SELECT role FROM messages WHERE conversation_id = ? ORDER BY seq").all(id) as any[])
+    .map(r => r.role);
+
+describe("retagEntries", () => {
+  it("keeps exactly the rows the old parser stored, in order", () => {
+    const path = transcript([
+      entry("user", [{ type: "text", text: "roda os testes" }]),
+      entry("assistant", [{ type: "tool_use", name: "Bash", input: { command: "npm test" } }]),
+      entry("user", [{ type: "tool_result", content: "2 passed" }]),
+      entry("assistant", [{ type: "text", text: "passou" }]),
+    ]);
+    // The tool call extracted to nothing back then and was skipped; adding it
+    // now would shift every later seq.
+    expect(retagEntries(path)).toEqual([
+      { content: "roda os testes", role: "user" },
+      { content: "2 passed", role: "tool" },
+      { content: "passou", role: "assistant" },
+    ]);
+  });
+});
+
+describe("retagConversation", () => {
+  it("re-labels a tool result that was stored as the user speaking", () => {
+    const path = transcript([
+      entry("user", [{ type: "text", text: "roda os testes" }]),
+      entry("user", [{ type: "tool_result", content: "2 passed" }]),
+    ]);
+    const { db, id } = legacyConversation([
+      { role: "user", content: "roda os testes" },
+      { role: "user", content: "2 passed" },
+    ]);
+    try {
+      expect(retagConversation(db, id, path)).toEqual({ retagged: 1, unchanged: 1 });
+      expect(rolesOf(db, id)).toEqual(["user", "tool"]);
+    } finally { db.close(); }
+  });
+
+  it("marks the conversation tagged once it has been checked", () => {
+    const path = transcript([entry("user", [{ type: "tool_result", content: "2 passed" }])]);
+    const { db, id } = legacyConversation([{ role: "user", content: "2 passed" }]);
+    try {
+      retagConversation(db, id, path);
+      const row = db.prepare("SELECT role_tagging FROM conversations WHERE conversation_id = ?").get(id) as any;
+      expect(row.role_tagging).toBe("tagged");
+    } finally { db.close(); }
+  });
+
+  it("labels the stored rows when the transcript kept growing after ingest", () => {
+    const path = transcript([
+      entry("user", [{ type: "tool_result", content: "2 passed" }]),
+      entry("assistant", [{ type: "text", text: "a turn recorded after the ingest" }]),
+    ]);
+    const { db, id } = legacyConversation([{ role: "user", content: "2 passed" }]);
+    try {
+      expect(retagConversation(db, id, path)).toEqual({ retagged: 1, unchanged: 0 });
+      expect(rolesOf(db, id)).toEqual(["tool"]);
+    } finally { db.close(); }
+  });
+
+  it("refuses when the store holds rows the transcript does not", () => {
+    const path = transcript([entry("user", [{ type: "tool_result", content: "2 passed" }])]);
+    const { db, id } = legacyConversation([
+      { role: "user", content: "2 passed" },
+      { role: "assistant", content: "an extra row the transcript does not have" },
+    ]);
+    try {
+      expect(retagConversation(db, id, path).skipped).toBe("length-mismatch");
+      expect(rolesOf(db, id)).toEqual(["user", "assistant"]);
+    } finally { db.close(); }
+  });
+
+  it("refuses when the text disagrees, rather than guessing from position", () => {
+    const path = transcript([entry("user", [{ type: "tool_result", content: "2 passed" }])]);
+    const { db, id } = legacyConversation([{ role: "user", content: "something else entirely" }]);
+    try {
+      expect(retagConversation(db, id, path).skipped).toBe("content-mismatch");
+      expect(rolesOf(db, id)).toEqual(["user"]);
+    } finally { db.close(); }
+  });
+
+  it("reports a missing transcript instead of touching the rows", () => {
+    const { db, id } = legacyConversation([{ role: "user", content: "2 passed" }]);
+    try {
+      expect(retagConversation(db, id, "/no/such/transcript.jsonl").skipped).toBe("no-transcript");
+      expect(rolesOf(db, id)).toEqual(["user"]);
+    } finally { db.close(); }
+  });
+
+  it("leaves an already tagged conversation alone", () => {
+    const path = transcript([entry("user", [{ type: "tool_result", content: "2 passed" }])]);
+    const { db, id } = legacyConversation([{ role: "user", content: "2 passed" }]);
+    try {
+      db.prepare("UPDATE conversations SET role_tagging = 'tagged' WHERE conversation_id = ?").run(id);
+      expect(retagConversation(db, id, path).skipped).toBe("already-tagged");
+      expect(rolesOf(db, id)).toEqual(["user"]);
+    } finally { db.close(); }
+  });
+
+  it("does not delete or insert a single row", () => {
+    const path = transcript([
+      entry("user", [{ type: "text", text: "oi" }]),
+      entry("user", [{ type: "tool_result", content: "2 passed" }]),
+    ]);
+    const { db, id } = legacyConversation([
+      { role: "user", content: "oi" },
+      { role: "user", content: "2 passed" },
+    ]);
+    try {
+      const before = db.prepare("SELECT message_id FROM messages ORDER BY seq").all();
+      retagConversation(db, id, path);
+      expect(db.prepare("SELECT message_id FROM messages ORDER BY seq").all()).toEqual(before);
+    } finally { db.close(); }
+  });
+});


### PR DESCRIPTION
## Draft on purpose

Step 3 of the plan, **and the measurement that argues against running it**. It is here so the number is reproducible and the option stays open, not because it should merge on this evidence.

## The number

Measured against a copy of the real store — 379 projects, 229 317 messages:

| outcome | conversations |
|---|---|
| left alone: **no transcript on disk** | 2 761 (95%) |
| left alone: the store holds rows the transcript does not | 74 |
| left alone: the text disagrees | 14 |
| **re-labelled** | **46** (665 rows) |

**665 of 229 317 messages — 0.29% of the corpus.**

The estimate that rejected this idea earlier put the reach at 21%. The real number is two orders of magnitude worse, because 95% of ingested sessions no longer have a transcript, not the 75% assumed.

## Why it cannot delete and re-ingest

That was the obvious shape, and the schema forbids it: `summary_messages.message_id` and `context_items.message_id` are `ON DELETE RESTRICT`, so a compacted conversation's rows cannot be replaced at all. Appending the tool calls the old parser dropped would renumber `seq` under every summary pointing into the conversation.

So this re-labels **in place**. Nothing is deleted, nothing is inserted, and a test pins that every `message_id` survives untouched.

## Where it refuses

- **No transcript** — the rows cannot be checked against anything, so they keep their labels and the conversation stays unknown. This is step 4 of the plan, enforced by construction.
- **The store holds rows the transcript does not** — the two have diverged; nothing is trusted.
- **The text disagrees anywhere** — refuse the whole conversation rather than align by position. Guessing a tag from text was measured at 89.3% precision, which calls the user a log 240 times; that is the failure this exists to end.
- A transcript that simply **grew** after ingest still labels the rows it does hold, since the store is its prefix. That alone lifted the reach from 529 rows to 665.

## Files Touched

- `src/retag.ts` — replay a transcript as the old parser read it, and state the role each row should carry.
- `src/retag-run.ts` — walk projects and conversations; dry-run inside a rolled-back savepoint so it measures the same thing the real run does.
- `bin/lcm.ts` — `lcm retag [--project <path>] [--dry-run] [--verbose]`.
- `test/retag.test.ts` — 9 tests, including one that pins no row is deleted or inserted.

## Issue Reference

Part of #399

## Test Evidence

```
npx vitest run
Test Files  158 passed | 2 skipped (160)
     Tests  1600 passed | 6 skipped (1606)
```

Plus the dry run above, against a copy of the real store. **Nothing was run against `~/.lossless-claude`.**

## Risks & Follow-ups

- Legacy tool **calls** stay missing whatever happens here. Only results can be re-labelled; the calls were never stored, and inserting them now would renumber `seq`.
- A conversation this marks `tagged` is tagged only as far as the rows it holds. That is accurate, not optimistic.
- If it is ever run, it should be run once, after the tagging parser has landed, and never on a store that is being written to.

## AR Status

[SKIP_AR: no adversarial review run this session]

## Introspection Findings

The schema answered the design question before any measurement did: `ON DELETE RESTRICT` on two foreign keys rules out delete-and-re-ingest entirely, which is what "re-ingest with the new parser" would have meant. Reading the constraints first turned a risky rewrite into an in-place update that cannot lose data.

## Token Cost

~480k tokens cumulative this session (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1wwybhXYEnbZVqA4SvJ83