### PR TITLE
refactor(paths): derive every location from one LcmPaths object

### DIFF
--- a/.changeset/lcm-paths-object.md
+++ b/.changeset/lcm-paths-object.md
@@ -1,0 +1,7 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+`LCM_HOME` now reaches every path lcm resolves. Three sites spelled the root through an aliased import (`hd()`, `deps.homedir`, `_homedir2()`) and kept pointing at `~/.lossless-claude` regardless of the variable: purging all projects, one of the session-snapshot config reads, and `lcm doctor`, which now takes the lcm home as an injected dependency like it already took the user's home.
+
+Adds `LcmPaths`, one object holding every location derived from a single root, and a test that fails when the root is named outside the factory.

--- a/src/daemon/project.ts
+++ b/src/daemon/project.ts
@@ -2,13 +2,14 @@ import { createHash } from "node:crypto";
 import { existsSync, lstatSync, mkdirSync, realpathSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, resolve, normalize, join as pathJoin, dirname, basename } from "node:path";
-import { lcmHome } from "../lcm-home.js";
+import { defaultLcmPaths } from "../lcm-paths.js";
 
 /**
  * Resolved once, at load: `LCM_HOME` has to be set before the process starts, which is how
- * it is meant to be used. Tests that need another root mock this export.
+ * it is meant to be used. Tests that need another root mock this export — until #409
+ * threads an LcmPaths through and this export goes away.
  */
-export const BASE_DIR = lcmHome();
+export const BASE_DIR = defaultLcmPaths.home;
 
 function canonicalizeCwd(cwd: string): string {
   try { return realpathSync(cwd); } catch { return cwd; }

--- a/src/db/events-path.ts
+++ b/src/db/events-path.ts
@@ -1,11 +1,9 @@
 import { join } from "node:path";
 import { projectId } from "../daemon/project.js";
-import { lcmHome } from "../lcm-home.js";
-
-const BASE = lcmHome();
+import { defaultLcmPaths } from "../lcm-paths.js";
 
 export function eventsDir(): string {
-  return join(BASE, "events");
+  return defaultLcmPaths.eventsDir;
 }
 
 export function eventsDbPath(cwd: string): string {

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { homedir, platform } from "node:os";
+import { lcmHome } from "../lcm-home.js";
 import { join, dirname } from "node:path";
 import { spawnSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
@@ -33,6 +34,7 @@ function defaultDeps(): DoctorDeps {
     },
     fetch: globalThis.fetch,
     homedir: homedir(),
+    lcmHome: lcmHome(),
     platform: platform(),
   };
 }
@@ -43,7 +45,7 @@ interface DoctorConfig {
 }
 
 function loadConfig(deps: DoctorDeps): DoctorConfig {
-  const configPath = join(deps.homedir, ".lossless-claude", "config.json");
+  const configPath = join(deps.lcmHome, "config.json");
   let config: Record<string, unknown> = {};
   try {
     config = JSON.parse(deps.readFileSync(configPath, "utf-8"));
@@ -233,7 +235,7 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>, verbose = false
   }
 
   // ── 2. config.json ──
-  const configPath = join(deps.homedir, ".lossless-claude", "config.json");
+  const configPath = join(deps.lcmHome, "config.json");
   if (deps.existsSync(configPath)) {
     results.push({ name: "config", category: "Stack", status: "pass", message: configPath });
   } else {
@@ -255,7 +257,7 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>, verbose = false
   } catch {}
 
   if (daemonHealthy) {
-    const pidFilePath = join(deps.homedir, ".lossless-claude", "daemon.pid");
+    const pidFilePath = join(deps.lcmHome, "daemon.pid");
     const versionMismatch = Boolean(pkgVersion && daemonVersion && daemonVersion !== pkgVersion);
     const buildMismatch = Boolean(BUILD_ID && daemonBuild && daemonBuild !== BUILD_ID);
     if (versionMismatch || buildMismatch) {
@@ -320,7 +322,7 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>, verbose = false
       const { ensureDaemon } = await import("../daemon/lifecycle.js");
       const { connected } = await ensureDaemon({
         port: config.port,
-        pidFilePath: join(deps.homedir, ".lossless-claude", "daemon.pid"),
+        pidFilePath: join(deps.lcmHome, "daemon.pid"),
         spawnTimeoutMs: 10000,
       });
       if (connected) {
@@ -524,7 +526,7 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>, verbose = false
   let globalUserPatternCount = 0;
   try {
     const { loadDaemonConfig } = await import("../daemon/config.js");
-    const globalConfigPath = join(deps.homedir, ".lossless-claude", "config.json");
+    const globalConfigPath = join(deps.lcmHome, "config.json");
     const config = loadDaemonConfig(globalConfigPath);
     globalUserPatternCount = config.security?.sensitivePatterns?.length ?? 0;
   } catch {

--- a/src/doctor/types.ts
+++ b/src/doctor/types.ts
@@ -14,6 +14,8 @@ export interface DoctorDeps {
   spawnSync: (cmd: string, args: string[], opts?: object) => { status: number | null; stdout: string; stderr: string };
   fetch: typeof globalThis.fetch;
   homedir: string;
+  /** Where lcm stores things: `~/.lossless-claude`, or wherever LCM_HOME points. */
+  lcmHome: string;
   platform: string;
   cwd?: string;
 }

--- a/src/hooks/session-snapshot.ts
+++ b/src/hooks/session-snapshot.ts
@@ -99,8 +99,7 @@ export async function handleSessionSnapshot(
     // Best-effort promote-events flush
     try {
       const { loadDaemonConfig: _loadConfig } = await import("../daemon/config.js");
-      const { homedir: _homedir2 } = await import("node:os");
-      const _config = _loadConfig(join(_homedir2(), ".lossless-claude", "config.json"));
+      const _config = _loadConfig(lcmPath("config.json"));
       const port = _config.daemon?.port ?? 3737;
       const { firePromoteEventsRequest } = await import("./session-end.js");
       firePromoteEventsRequest(port, { cwd: input.cwd });

--- a/src/import.ts
+++ b/src/import.ts
@@ -7,6 +7,7 @@ import { formatNumber, formatRatio } from "./stats.js";
 import { findAllCodexTranscripts } from "./codex-transcript.js";
 import type { ProgressState } from "./cli/progress-state.js";
 import { projectDbPath, projectId } from "./daemon/project.js";
+import { defaultLcmPaths } from "./lcm-paths.js";
 import {
   appendReplayManifestSessions,
   clearReplayState,
@@ -78,7 +79,7 @@ export function cwdToProjectHash(cwd: string): string {
 }
 
 function buildProjectMap(lcmDir?: string): Map<string, string> {
-  const lcmProjectsDir = join(lcmDir ?? join(homedir(), '.lossless-claude'), 'projects');
+  const lcmProjectsDir = lcmDir ? join(lcmDir, 'projects') : defaultLcmPaths.projectsDir;
   const map = new Map<string, string>();
   if (!existsSync(lcmProjectsDir)) return map;
   for (const entry of readdirSync(lcmProjectsDir, { withFileTypes: true })) {

--- a/src/lcm-paths.ts
+++ b/src/lcm-paths.ts
@@ -1,0 +1,46 @@
+import { join } from "node:path";
+import { lcmHome } from "./lcm-home.js";
+
+/**
+ * Every location lcm owns, derived from one root.
+ *
+ * The point of the object is that the root arrives as an argument. Code that holds an
+ * `LcmPaths` cannot read the environment behind your back, and a test builds one over a
+ * temp directory instead of mocking a module or setting a variable — so two tests can run
+ * against two roots at once.
+ *
+ * Paths derived from a project's cwd stay in `daemon/project.ts`, which owns the hashing.
+ */
+export type LcmPaths = {
+  readonly home: string;
+  readonly projectsDir: string;
+  readonly eventsDir: string;
+  readonly logsDir: string;
+  readonly tmpDir: string;
+  readonly configPath: string;
+  readonly tokenPath: string;
+  readonly pidPath: string;
+};
+
+export function createLcmPaths(home: string): LcmPaths {
+  return {
+    home,
+    projectsDir: join(home, "projects"),
+    eventsDir: join(home, "events"),
+    logsDir: join(home, "logs"),
+    tmpDir: join(home, "tmp"),
+    configPath: join(home, "config.json"),
+    tokenPath: join(home, "daemon.token"),
+    pidPath: join(home, "daemon.pid"),
+  };
+}
+
+/**
+ * The process-wide instance, for code that has not been given one yet.
+ *
+ * Resolved once, so every caller agrees on the root even though some read it at load and
+ * others per call. It is scaffolding for the migration in #409, not the destination: the
+ * last step there deletes it, and after that the type system is what stops a path from
+ * being read out of the ambient environment.
+ */
+export const defaultLcmPaths: LcmPaths = createLcmPaths(lcmHome());

--- a/src/sensitive.ts
+++ b/src/sensitive.ts
@@ -7,6 +7,7 @@ import { GITLEAKS_PATTERNS } from "./generated-patterns.js";
 import { projectDir } from "./daemon/project.js";
 import { loadDaemonConfig } from "./daemon/config.js";
 import { lcmPath } from "./lcm-home.js";
+import { defaultLcmPaths } from "./lcm-paths.js";
 
 function defaultConfigPath(): string {
   return lcmPath("config.json");
@@ -315,10 +316,9 @@ async function sensitivePurge(
   }
 
   const { join: pathJoin } = await import("node:path");
-  const { homedir: hd } = await import("node:os");
 
   if (purgeAll) {
-    const allProjectsDir = pathJoin(hd(), ".lossless-claude", "projects");
+    const allProjectsDir = defaultLcmPaths.projectsDir;
     if (existsSync(allProjectsDir)) {
       rmSync(allProjectsDir, { recursive: true, force: true });
       return {

--- a/test/doctor/doctor-hooks.test.ts
+++ b/test/doctor/doctor-hooks.test.ts
@@ -30,6 +30,7 @@ function depsFor(settings: string, registry: string = INSTALLED_LCM, writeFileSy
     spawnSync: () => ({ status: 0, stdout: "", stderr: "" }),
     fetch: vi.fn().mockResolvedValue({ ok: false }),
     homedir: "/tmp/test-home",
+    lcmHome: "/tmp/test-home/.lossless-claude",
     platform: "darwin",
   };
 }
@@ -144,6 +145,7 @@ describe("doctor hook validation", () => {
       spawnSync: () => ({ status: 0, stdout: "", stderr: "" }),
       fetch: vi.fn().mockResolvedValue({ ok: false }),
       homedir: "/tmp/test-home",
+    lcmHome: "/tmp/test-home/.lossless-claude",
       platform: "darwin",
     });
     const mcpResult = results.find(r => r.name === "mcp-lcm");
@@ -162,6 +164,7 @@ describe("doctor hook validation", () => {
       spawnSync: () => ({ status: 0, stdout: "", stderr: "" }),
       fetch: vi.fn().mockResolvedValue({ ok: false }),
       homedir: "/tmp/test-home",
+    lcmHome: "/tmp/test-home/.lossless-claude",
       platform: "darwin",
     });
     const mcpResult = results.find(r => r.name === "mcp-lcm");

--- a/test/doctor/doctor.test.ts
+++ b/test/doctor/doctor.test.ts
@@ -49,6 +49,7 @@ function minimalDeps(overrides: Partial<Parameters<typeof runDoctor>[0]> = {}) {
     spawnSync: vi.fn(() => ({ status: 0, stdout: "", stderr: "" })),
     fetch: vi.fn().mockResolvedValue({ ok: false }),
     homedir: "/tmp/test-home",
+    lcmHome: "/tmp/test-home/.lossless-claude",
     platform: "darwin",
     ...overrides,
   };
@@ -189,6 +190,7 @@ describe("runDoctor summarizer modes", () => {
       }),
       fetch: vi.fn().mockResolvedValue({ ok: false }),
       homedir: "/tmp/test-home",
+    lcmHome: "/tmp/test-home/.lossless-claude",
       platform: "darwin",
     });
 

--- a/test/lcm-paths-guard.test.ts
+++ b/test/lcm-paths-guard.test.ts
@@ -13,8 +13,25 @@ import { execFileSync } from "node:child_process";
 
 const ROOT_LITERAL = ".lossless-claude";
 
+/**
+ * The root used to *build a path*, in either language: a quoted segment handed to `join`,
+ * or the shell's own expansion. Prose that mentions `~/.lossless-claude` in an error
+ * message or a comment is left alone — that is documentation, not a second resolution.
+ */
+const BUILDS_A_PATH = [
+  /["'`]\.lossless-claude["'`]/,   // join(x, ".lossless-claude", …)
+  /\$HOME\/\.lossless-claude/,     // "$HOME/.lossless-claude"
+];
+
 /** The only files allowed to name the root: the factory and the object built from it. */
 const FACTORY = ["src/lcm-home.ts", "src/lcm-paths.ts"];
+
+/**
+ * The hooks module is the one exception: it runs with no imports, so it spells the
+ * fallback inside the host command it sends to `sh`. The assertion below fails if that
+ * stops being true, rather than leaving a dead exception behind.
+ */
+const HOST_COMMAND = "hooks/lcm-hooks.ts";
 
 function sourceFiles(): string[] {
   const out = execFileSync("git", ["ls-files", "src", "bin", "hooks"], { encoding: "utf-8" });
@@ -25,9 +42,17 @@ describe("the storage root is resolved in one place", () => {
   it("names ~/.lossless-claude only in the factory", () => {
     const offenders = sourceFiles()
       .filter((file) => !FACTORY.includes(file))
-      .filter((file) => readFileSync(file, "utf-8").includes(`"${ROOT_LITERAL}`));
+      .filter((file) => file !== HOST_COMMAND)
+      .filter((file) => {
+        const source = readFileSync(file, "utf-8");
+        return BUILDS_A_PATH.some((pattern) => pattern.test(source));
+      });
     expect(offenders, `use lcmPath()/defaultLcmPaths instead of naming ${ROOT_LITERAL}`)
       .toEqual([]);
+  });
+
+  it("still needs its one exception, so the allowance is not dead", () => {
+    expect(readFileSync(HOST_COMMAND, "utf-8")).toContain(`$HOME/${ROOT_LITERAL}`);
   });
 
   it("reads LCM_HOME only in the factory", () => {

--- a/test/lcm-paths-guard.test.ts
+++ b/test/lcm-paths-guard.test.ts
@@ -1,0 +1,43 @@
+// test/lcm-paths-guard.test.ts
+//
+// The storage root has to be resolved in one place. Four separate bugs came from it being
+// read wherever it was needed: lcm could not be sandboxed, the override depended on import
+// order, tests had to mock a constant, and two readers could disagree about the root.
+//
+// This test holds the line while #409 threads an LcmPaths through the call sites. It is a
+// grep, not an analysis: it catches the literal, which is how every one of those sites was
+// written. Delete it once the default instance is gone and the types do the work.
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+
+const ROOT_LITERAL = ".lossless-claude";
+
+/** The only files allowed to name the root: the factory and the object built from it. */
+const FACTORY = ["src/lcm-home.ts", "src/lcm-paths.ts"];
+
+function sourceFiles(): string[] {
+  const out = execFileSync("git", ["ls-files", "src", "bin", "hooks"], { encoding: "utf-8" });
+  return out.split("\n").filter((f) => f.endsWith(".ts") || f.endsWith(".mjs"));
+}
+
+describe("the storage root is resolved in one place", () => {
+  it("names ~/.lossless-claude only in the factory", () => {
+    const offenders = sourceFiles()
+      .filter((file) => !FACTORY.includes(file))
+      .filter((file) => readFileSync(file, "utf-8").includes(`"${ROOT_LITERAL}`));
+    expect(offenders, `use lcmPath()/defaultLcmPaths instead of naming ${ROOT_LITERAL}`)
+      .toEqual([]);
+  });
+
+  it("reads LCM_HOME only in the factory", () => {
+    const offenders = sourceFiles()
+      .filter((file) => !FACTORY.includes(file))
+      // The read, not the name: a doc comment may mention the variable.
+      .filter((file) => /\benv\.LCM_HOME\b/.test(readFileSync(file, "utf-8")))
+      // The hooks module has no imports: it reads the variable in a host command instead.
+      .filter((file) => file !== "hooks/lcm-hooks.ts");
+    expect(offenders, "resolve the root through lcmHome() instead of reading LCM_HOME")
+      .toEqual([]);
+  });
+});


### PR DESCRIPTION
Stacked on #408. Second step of #409.

## What the first step missed

#408 rewrote every `join(homedir(), ".lossless-claude", ...)` it could find. Three sites spelled the root through an aliased import and the grep never saw them:

| Site | Spelling | Effect |
|---|---|---|
| `src/sensitive.ts:321` | `pathJoin(hd(), ...)` | `--purge-all` deleted from the real home even under `LCM_HOME` |
| `src/hooks/session-snapshot.ts:104` | `_homedir2()` | the promote-events flush read the real config |
| `src/doctor/doctor.ts` ×5 | `deps.homedir` | `lcm doctor` diagnosed the wrong install |

That is the argument for the guard test below: a rule nobody can check is a rule that decays. This is the same class of miss twice in one afternoon.

## Doctor takes the home as a dependency

`doctor` already injected the *user's* home. It now injects the *lcm* home the same way — which is exactly the shape the rest of #409 is heading for, so it is worth doing here rather than later.

Its tests were passing while feeding it `undefined`: `join(undefined, "config.json")` throws straight into a `catch`, so the assertions held without the code ever reading the path they named. The fixtures now say which home they mean.

## The guard

`test/lcm-paths-guard.test.ts` fails when a file outside `src/lcm-home.ts` / `src/lcm-paths.ts` names `".lossless-claude"` or reads `env.LCM_HOME`. It matches the read, not the name, so a doc comment may still mention the variable.

It is a grep, not an analysis — deliberately, because a grep is what every one of these sites would have failed. It holds the line while #409 threads the object through; step 4 deletes the default instance and the type system takes over.

## LcmPaths

```ts
type LcmPaths = {
  home; projectsDir; eventsDir; logsDir; tmpDir;
  configPath; tokenPath; pidPath;
};
```

`createLcmPaths(home)` builds one; `defaultLcmPaths` is the process-wide instance for code that has not been given one yet, and is scaffolding rather than the destination. Paths derived from a project's cwd stay in `daemon/project.ts`, which owns the hashing — moving them here would make the import circular.

## Tests

Full suite green: 1600 passed. The doctor suite (25) exercises injected paths for the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ga2dD8xzcqyoXuq6NkZB6L