### PR TITLE
fix(daemon): a stop that holds, and a CLI that runs from source

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -327,7 +327,7 @@ async function main() {
     .option("-h, --help", "Show help")
     .action(async (opts) => {
       if (opts.help) { await withCustomHelp(daemonCmd, "daemon"); return; }
-      const { ensureDaemon, checkDaemonHealth, isStaleDaemon, registerDaemonStartup } = await import("../src/daemon/lifecycle.js");
+      const { ensureDaemon, checkDaemonHealth, isStaleDaemon, registerDaemonActivity } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { PKG_VERSION, BUILD_ID } = await import("../src/daemon/version.js");
       const { clearHold, readHold } = await import("../src/daemon/hold.js");
@@ -377,7 +377,7 @@ async function main() {
       const { createDaemon } = await import("../src/daemon/server.js");
       const { ensureAuthToken } = await import("../src/daemon/auth.js");
       const { writeFileSync } = await import("node:fs");
-      const unregisterStartup = registerDaemonStartup(pidFilePath);
+      const unregisterStartup = registerDaemonActivity(pidFilePath);
       try {
         // Register before checking: a concurrent held stop either sees this
         // process or has already published the hold that prevents startup.

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -212,7 +212,14 @@ async function createDaemonClientOrExit(): Promise<DaemonClient> {
   const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs: 5000 });
 
   if (!connected) {
-    console.error("  Daemon not available. Start it with: lcm daemon start --detach");
+    // A held daemon is down on purpose; saying so keeps it from reading as a fault.
+    const { readHold } = await import("../src/daemon/hold.js");
+    const hold = readHold(pidFilePath);
+    if (hold) {
+      console.error(`  Daemon held down until ${hold.until}${hold.reason ? ` (${hold.reason})` : ""}. Release it with: lcm daemon start`);
+    } else {
+      console.error("  Daemon not available. Start it with: lcm daemon start --detach");
+    }
     exit(1);
   }
 
@@ -273,17 +280,15 @@ export function registerBenchCommands(program: Command): void {
 }
 
 async function main() {
-  const { readFileSync } = await import("node:fs");
-  const { join, dirname } = await import("node:path");
-  const { fileURLToPath } = await import("node:url");
-  const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "package.json");
-  const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+  // PKG_VERSION resolves the package root for both dist/ and source layouts;
+  // a hand-rolled `../../package.json` here only worked from dist/.
+  const { PKG_VERSION } = await import("../src/daemon/version.js");
 
   const program = new Command();
   program
     .name("lcm")
     .description("lossless context management for coding agents")
-    .version(pkg.version, "-V, --version")
+    .version(PKG_VERSION ?? "unknown", "-V, --version")
     .helpCommand(false)
     .addHelpCommand(false)
     .configureOutput({
@@ -324,9 +329,13 @@ async function main() {
       const { ensureDaemon, checkDaemonHealth, isStaleDaemon } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { PKG_VERSION, BUILD_ID } = await import("../src/daemon/version.js");
+      const { clearHold } = await import("../src/daemon/hold.js");
       const { lcDir, pidFilePath, tokenPath, configPath } = daemonPaths();
       const config = loadDaemonConfig(configPath);
       const port = config.daemon?.port ?? 3737;
+
+      // Starting is the release gesture: an explicit start always wins over a hold.
+      if (clearHold(pidFilePath)) console.log("released the daemon hold");
 
       const running = await checkDaemonHealth(port);
       if (running?.status === "ok") {
@@ -381,20 +390,37 @@ async function main() {
 
   daemonCmd.command("stop")
     .description("Stop the background daemon")
+    .option("--hold", "Keep it down until `lcm daemon start`, so session hooks cannot respawn it")
+    .option("--minutes <n>", "How long the hold lasts before expiring", (v) => parseInt(v, 10))
+    .option("--reason <text>", "Why the daemon is held down")
     .option("-h, --help", "Show help")
     .action(async (opts) => {
       if (opts.help) { await withCustomHelp(daemonCmd, "daemon"); return; }
       const { stopDaemon, checkDaemonHealth } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
+      const { writeHold, DEFAULT_HOLD_MINUTES } = await import("../src/daemon/hold.js");
       const { pidFilePath, configPath } = daemonPaths();
       const port = loadDaemonConfig(configPath).daemon?.port ?? 3737;
+      if (opts.minutes !== undefined && (!Number.isInteger(opts.minutes) || opts.minutes <= 0)) {
+        console.error("--minutes must be a positive integer");
+        exit(1);
+      }
       const before = await checkDaemonHealth(port);
+      // The hold goes down first: between the kill and the marker, a hook that
+      // fires would spawn the daemon straight back.
+      let held: { until: string } | undefined;
+      if (opts.hold) {
+        held = writeHold(pidFilePath, { minutes: opts.minutes, reason: opts.reason });
+      }
       const { stopped, pid } = await stopDaemon({ port, pidFilePath });
       if (!stopped) {
         console.error(`lcm daemon on port ${port} is still up (pid ${pid ?? "?"}) — stop it manually`);
         exit(1);
       }
       console.log(before ? `lcm daemon stopped (pid ${pid ?? before.pid ?? "?"})` : "lcm daemon was not running");
+      if (held) {
+        console.log(`  held down until ${held.until} (${opts.minutes ?? DEFAULT_HOLD_MINUTES} min) — release with: lcm daemon start`);
+      }
     });
 
   daemonCmd.command("restart")
@@ -405,8 +431,11 @@ async function main() {
       const { stopDaemon, ensureDaemon, checkDaemonHealth } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { PKG_VERSION, BUILD_ID } = await import("../src/daemon/version.js");
+      const { clearHold } = await import("../src/daemon/hold.js");
       const { lcDir, pidFilePath, configPath } = daemonPaths();
       const port = loadDaemonConfig(configPath).daemon?.port ?? 3737;
+      // A restart ends with the daemon up, so it releases a hold the same way start does.
+      if (clearHold(pidFilePath)) console.log("released the daemon hold");
       const { stopped, pid } = await stopDaemon({ port, pidFilePath });
       if (!stopped) {
         console.error(`lcm daemon on port ${port} is still up (pid ${pid ?? "?"}) — stop it manually`);

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -202,8 +202,26 @@ function printJson(value: unknown): void {
 
 let cliDaemonActivity: (() => void) | undefined;
 
+async function admitCliDatabaseWork(): Promise<void> {
+  const { registerDaemonActivity } = await import("../src/daemon/lifecycle.js");
+  const { readHold } = await import("../src/daemon/hold.js");
+  const pidFilePath = lcmPath("daemon.pid");
+  // Admission covers the whole CLI operation, including offline migrations and
+  // replay writes. Exit cleanup also covers explicit exits and action failures.
+  if (!cliDaemonActivity) {
+    cliDaemonActivity = registerDaemonActivity(pidFilePath);
+    process.once("exit", cliDaemonActivity);
+  }
+  const hold = readHold(pidFilePath);
+  if (hold) {
+    console.error(`  Daemon held down until ${hold.until}${hold.reason ? ` (${hold.reason})` : ""}. Release it with: lcm daemon start`);
+    exit(1);
+  }
+}
+
 async function createDaemonClientOrExit(spawnTimeoutMs = 5000): Promise<DaemonClient> {
-  const { ensureDaemon, registerDaemonActivity } = await import("../src/daemon/lifecycle.js");
+  await admitCliDatabaseWork();
+  const { ensureDaemon } = await import("../src/daemon/lifecycle.js");
   const { loadDaemonConfig } = await import("../src/daemon/config.js");
 
   const config = loadDaemonConfig(lcmPath("config.json"));
@@ -211,12 +229,6 @@ async function createDaemonClientOrExit(spawnTimeoutMs = 5000): Promise<DaemonCl
   const lcDir = lcmHome();
   const pidFilePath = join(lcDir, "daemon.pid");
   const tokenPath = join(lcDir, "daemon.token");
-  // Admission covers the whole CLI operation, including local migrations/replay
-  // writes after daemon requests. Exit cleanup also covers action failures.
-  if (!cliDaemonActivity) {
-    cliDaemonActivity = registerDaemonActivity(pidFilePath);
-    process.once("exit", cliDaemonActivity);
-  }
   const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs });
 
   if (!connected) {
@@ -255,6 +267,7 @@ export function registerBenchCommands(program: Command): void {
       const n = parsePositiveInteger(String(opts.n ?? "20"), "--n");
       const seed = parsePositiveInteger(String(opts.seed ?? "42"), "--seed");
       if (!["llm", "mechanical"].includes(opts.generator)) throw new Error("--generator must be llm or mechanical");
+      await admitCliDatabaseWork();
       const { buildBench } = await import("../src/bench.js");
       const result = await buildBench({ cwd, n, seed, out: opts.out, generator: opts.generator, language: opts.language });
       stdout.write(result.stdout);
@@ -272,6 +285,7 @@ export function registerBenchCommands(program: Command): void {
     .action(async (opts) => {
       const cwd = typeof opts.project === "string" ? resolve(opts.project) : process.cwd();
       const k = parsePositiveInteger(String(opts.k ?? "5"), "--k");
+      await admitCliDatabaseWork();
       const { runBench } = await import("../src/bench.js");
       const result = await runBench({
         cwd,
@@ -1330,6 +1344,7 @@ async function main() {
         printHelp("export"); exit(0);
       }
 
+      await admitCliDatabaseWork();
       const { exportKnowledge } = await import("../src/portable-knowledge.js");
       const { homedir } = await import("node:os");
       const { join } = await import("node:path");
@@ -1399,6 +1414,7 @@ async function main() {
         printHelp("import-knowledge"); exit(0);
       }
 
+      await admitCliDatabaseWork();
       const { importKnowledge } = await import("../src/portable-knowledge.js");
       const { readFileSync } = await import("node:fs");
 

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -335,9 +335,10 @@ async function main() {
       const config = loadDaemonConfig(configPath);
       const port = config.daemon?.port ?? 3737;
 
+      // Automatic starts report an active hold with EX_TEMPFAIL (75), without consuming hook cooldown.
       // Starting is the release gesture: an explicit start always wins over a hold.
       if (opts.automatic) {
-        if (readHold(pidFilePath)) return;
+        if (readHold(pidFilePath)) { process.exitCode = 75; return; }
       } else if (clearHold(pidFilePath)) console.log("released the daemon hold");
 
       const running = await checkDaemonHealth(port);
@@ -364,6 +365,7 @@ async function main() {
         mkdirSync(lcDir, { recursive: true });
         const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs: 10000 });
         if (!connected) {
+          if (opts.automatic && readHold(pidFilePath)) { process.exitCode = 75; return; }
           console.error(`lcm daemon did not answer on port ${port} within 10s — check ~/.lossless-claude/daemon.log`);
           exit(1);
         }
@@ -374,7 +376,7 @@ async function main() {
 
       const { createDaemon } = await import("../src/daemon/server.js");
       const { ensureAuthToken } = await import("../src/daemon/auth.js");
-      if (opts.automatic && readHold(pidFilePath)) return;
+      if (opts.automatic && readHold(pidFilePath)) { process.exitCode = 75; return; }
       ensureAuthToken(tokenPath);
       try {
         const daemon = await createDaemon(config, { tokenPath, backfillIdentities: true });

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -391,7 +391,7 @@ async function main() {
   daemonCmd.command("stop")
     .description("Stop the background daemon")
     .option("--hold", "Keep it down until `lcm daemon start`, so session hooks cannot respawn it")
-    .option("--minutes <n>", "How long the hold lasts before expiring", (v) => parseInt(v, 10))
+    .option("--minutes <n>", "How long the hold lasts before expiring", (v) => Number(v))
     .option("--reason <text>", "Why the daemon is held down")
     .option("-h, --help", "Show help")
     .action(async (opts) => {

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -327,7 +327,7 @@ async function main() {
     .option("-h, --help", "Show help")
     .action(async (opts) => {
       if (opts.help) { await withCustomHelp(daemonCmd, "daemon"); return; }
-      const { ensureDaemon, checkDaemonHealth, isStaleDaemon } = await import("../src/daemon/lifecycle.js");
+      const { ensureDaemon, checkDaemonHealth, isStaleDaemon, registerDaemonStartup } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { PKG_VERSION, BUILD_ID } = await import("../src/daemon/version.js");
       const { clearHold, readHold } = await import("../src/daemon/hold.js");
@@ -376,10 +376,20 @@ async function main() {
 
       const { createDaemon } = await import("../src/daemon/server.js");
       const { ensureAuthToken } = await import("../src/daemon/auth.js");
-      if (opts.automatic && readHold(pidFilePath)) { process.exitCode = 75; return; }
-      ensureAuthToken(tokenPath);
+      const { writeFileSync } = await import("node:fs");
+      const unregisterStartup = registerDaemonStartup(pidFilePath);
       try {
+        // Register before checking: a concurrent held stop either sees this
+        // process or has already published the hold that prevents startup.
+        if (readHold(pidFilePath)) { process.exitCode = 75; return; }
+        ensureAuthToken(tokenPath);
         const daemon = await createDaemon(config, { tokenPath, backfillIdentities: true });
+        if (readHold(pidFilePath)) {
+          await daemon.stop();
+          process.exitCode = 75;
+          return;
+        }
+        writeFileSync(pidFilePath, String(process.pid));
         console.log(`lcm daemon started on port ${daemon.address().port}`);
       } catch (err) {
         const code = (err as NodeJS.ErrnoException)?.code;
@@ -389,6 +399,8 @@ async function main() {
           console.error(`lcm daemon failed to start: ${err instanceof Error ? err.message : String(err)}`);
         }
         exit(1);
+      } finally {
+        unregisterStartup();
       }
       process.on("SIGTERM", () => exit(0));
       process.on("SIGINT", () => exit(0));

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -323,19 +323,22 @@ async function main() {
   daemonCmd.command("start")
     .description("Start the context daemon")
     .option("--detach", "Run in the background")
+    .addOption(new Option("--automatic").hideHelp())
     .option("-h, --help", "Show help")
     .action(async (opts) => {
       if (opts.help) { await withCustomHelp(daemonCmd, "daemon"); return; }
       const { ensureDaemon, checkDaemonHealth, isStaleDaemon } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { PKG_VERSION, BUILD_ID } = await import("../src/daemon/version.js");
-      const { clearHold } = await import("../src/daemon/hold.js");
+      const { clearHold, readHold } = await import("../src/daemon/hold.js");
       const { lcDir, pidFilePath, tokenPath, configPath } = daemonPaths();
       const config = loadDaemonConfig(configPath);
       const port = config.daemon?.port ?? 3737;
 
       // Starting is the release gesture: an explicit start always wins over a hold.
-      if (clearHold(pidFilePath)) console.log("released the daemon hold");
+      if (opts.automatic) {
+        if (readHold(pidFilePath)) return;
+      } else if (clearHold(pidFilePath)) console.log("released the daemon hold");
 
       const running = await checkDaemonHealth(port);
       if (running?.status === "ok") {
@@ -371,6 +374,7 @@ async function main() {
 
       const { createDaemon } = await import("../src/daemon/server.js");
       const { ensureAuthToken } = await import("../src/daemon/auth.js");
+      if (opts.automatic && readHold(pidFilePath)) return;
       ensureAuthToken(tokenPath);
       try {
         const daemon = await createDaemon(config, { tokenPath, backfillIdentities: true });

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -200,8 +200,10 @@ function printJson(value: unknown): void {
   stdout.write(JSON.stringify(value, null, 2) + "\n");
 }
 
-async function createDaemonClientOrExit(): Promise<DaemonClient> {
-  const { ensureDaemon } = await import("../src/daemon/lifecycle.js");
+let cliDaemonActivity: (() => void) | undefined;
+
+async function createDaemonClientOrExit(spawnTimeoutMs = 5000): Promise<DaemonClient> {
+  const { ensureDaemon, registerDaemonActivity } = await import("../src/daemon/lifecycle.js");
   const { loadDaemonConfig } = await import("../src/daemon/config.js");
 
   const config = loadDaemonConfig(lcmPath("config.json"));
@@ -209,7 +211,13 @@ async function createDaemonClientOrExit(): Promise<DaemonClient> {
   const lcDir = lcmHome();
   const pidFilePath = join(lcDir, "daemon.pid");
   const tokenPath = join(lcDir, "daemon.token");
-  const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs: 5000 });
+  // Admission covers the whole CLI operation, including local migrations/replay
+  // writes after daemon requests. Exit cleanup also covers action failures.
+  if (!cliDaemonActivity) {
+    cliDaemonActivity = registerDaemonActivity(pidFilePath);
+    process.once("exit", cliDaemonActivity);
+  }
+  const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs });
 
   if (!connected) {
     // A held daemon is down on purpose; saying so keeps it from reading as a fault.
@@ -505,20 +513,13 @@ async function main() {
         const { loadDaemonConfig } = await import("../src/daemon/config.js");
         const { join } = await import("node:path");
         const { homedir } = await import("node:os");
-        const { ensureDaemon } = await import("../src/daemon/lifecycle.js");
         const config = loadDaemonConfig(lcmPath("config.json"));
         const port = config.daemon?.port ?? 3737;
-        const pidFilePath = lcmPath("daemon.pid");
-        const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs: 10000 });
-        if (!connected) {
-          console.error("Could not connect to daemon. Start it with: lcm daemon start --detach");
-          exit(1);
-        }
+        const client = await createDaemonClientOrExit(10000);
         const noPromote: boolean = !opts.promote;
         const minTokens = config.compaction.autoCompactMinTokens;
         const cwd = all ? undefined : process.cwd();
         const tokenPath = lcmPath("daemon.token");
-        const client = new DaemonClient(`http://127.0.0.1:${port}`, tokenPath);
 
         const { NinjaRenderer } = await import("../src/cli/pipeline-runner.js");
         const { makeProgressState } = await import("../src/cli/progress-state.js");
@@ -1140,7 +1141,6 @@ async function main() {
       const replay: boolean = opts.replay ?? false;
       const restart: boolean = opts.restart ?? false;
 
-      const { ensureDaemon } = await import("../src/daemon/lifecycle.js");
       const { DaemonClient } = await import("../src/daemon/client.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { NinjaRenderer } = await import("../src/cli/pipeline-runner.js");
@@ -1167,15 +1167,13 @@ async function main() {
 
       const config = loadDaemonConfig(lcmPath("config.json"));
       const port = config.daemon?.port ?? 3737;
-      const client = new DaemonClient(`http://127.0.0.1:${port}`);
-      const preview = await importSessions(client, { all, provider, dryRun: true, verbose: dryRun && verbose, replay });
+      const previewClient = new DaemonClient(`http://127.0.0.1:${port}`);
+      const preview = await importSessions(previewClient, { all, provider, dryRun: true, verbose: dryRun && verbose, replay });
       if (dryRun) {
         console.log(`  [dry-run] ${preview.imported} ${provider} sessions selected (${all ? "all projects" : "current project"})${replay ? "; would compact each session" : ""}. No changes written.`);
         return;
       }
-      const pidFilePath = lcmPath("daemon.pid");
-      const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs: 5000 });
-      if (!connected) { console.error("  Daemon not available"); exit(1); }
+      const client = await createDaemonClientOrExit();
 
       const isTTY = process.stdout.isTTY ?? false;
       const renderOpts = { isTTY, width: process.stdout.columns ?? 80, color: isTTY, verbose };
@@ -1241,21 +1239,13 @@ async function main() {
       const verbose: boolean = opts.verbose ?? false;
       const dryRun: boolean = opts.dryRun ?? false;
 
-      const { ensureDaemon } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { join } = await import("node:path");
       const { homedir } = await import("node:os");
 
       const config = loadDaemonConfig(lcmPath("config.json"));
       const port = config.daemon?.port ?? 3737;
-      const pidFilePath = lcmPath("daemon.pid");
-      const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs: 5000 });
-      if (!connected) {
-        console.error("  Daemon not available. Start it with: lcm daemon start --detach");
-        exit(1);
-      }
-
-      const client = new DaemonClient(`http://127.0.0.1:${port}`);
+      const client = await createDaemonClientOrExit();
       const { readdirSync, existsSync, readFileSync } = await import("node:fs");
 
       if (dryRun) console.log("  [dry-run] No changes will be written.\n");

--- a/hooks/lcm-hooks.ts
+++ b/hooks/lcm-hooks.ts
@@ -123,7 +123,7 @@ async function startDaemon($: EngineInterface): Promise<boolean> {
   if (now - lastDaemonStartAt < DAEMON_START_COOLDOWN_MS) return false;
   lastDaemonStartAt = now;
   const run = await $.process.run(
-    ["sh", "-c", 'command -v lcm >/dev/null 2>&1 || exit 127; exec lcm daemon start --detach'],
+    ["sh", "-c", 'command -v lcm >/dev/null 2>&1 || exit 127; exec lcm daemon start --detach --automatic'],
     { timeoutMs: DAEMON_START_TIMEOUT_MS },
   ).catch(() => null);
   if (run?.exitCode === 0) return true;

--- a/hooks/lcm-hooks.ts
+++ b/hooks/lcm-hooks.ts
@@ -113,6 +113,8 @@ const DAEMON_START_COOLDOWN_MS = 60_000;
 const DAEMON_START_TIMEOUT_MS = 15_000;
 /** POSIX exit code for "command not found": no `lcm` binary on PATH. */
 const EXIT_COMMAND_NOT_FOUND = 127;
+/** `daemon start --automatic` reports an active hold with EX_TEMPFAIL. */
+const EXIT_DAEMON_HELD = 75;
 let warnedNoLcmBinary = false;
 
 /**
@@ -129,6 +131,10 @@ async function startDaemon($: EngineInterface): Promise<boolean> {
     ["sh", "-c", 'command -v lcm >/dev/null 2>&1 || exit 127; exec lcm daemon start --detach --automatic'],
     { timeoutMs: DAEMON_START_TIMEOUT_MS },
   ).catch(() => null);
+  if (run?.exitCode === EXIT_DAEMON_HELD) {
+    if (lastDaemonStartAt === now) lastDaemonStartAt = 0;
+    return false;
+  }
   if (run?.exitCode === 0) return true;
   if (run?.exitCode === EXIT_COMMAND_NOT_FOUND && !warnedNoLcmBinary) {
     warnedNoLcmBinary = true;

--- a/src/cli-help.ts
+++ b/src/cli-help.ts
@@ -44,17 +44,21 @@ const HELP: Record<string, CommandHelp> = {
 
   daemon: {
     summary: "Start, stop or restart the context daemon that stores and processes memory.",
-    usage: "lcm daemon <start [--detach] | stop | restart>",
+    usage: "lcm daemon <start [--detach] | stop [--hold] | restart>",
     options: [
       ["--detach", "Run in the background; saves PID to ~/.lossless-claude/daemon.pid"],
+      ["--hold", "On stop: keep it down, so session hooks cannot spawn it again"],
+      ["--minutes <n>", "How long a hold lasts before it expires (default 30)"],
+      ["--reason <text>", "Why the daemon is held down; shown to whoever runs into it"],
     ],
     examples: [
       ["lcm daemon start --detach", "Start daemon in background (recommended); no-op if already running"],
       ["lcm daemon start", "Start daemon in foreground (for debugging)"],
       ["lcm daemon restart", "Stop the running daemon and start a fresh one (after an upgrade or rebuild)"],
       ["lcm daemon stop", "Stop the background daemon"],
+      ["lcm daemon stop --hold --reason \"migration\"", "Claim an offline window; release it with lcm daemon start"],
     ],
-    notes: "The daemon runs on port 3737 by default. Configure via ~/.lossless-claude/config.json.",
+    notes: "The daemon runs on port 3737 by default. Configure via ~/.lossless-claude/config.json. Without --hold a stop does not last: every session hook spawns the daemon again within seconds.",
   },
 
   status: {

--- a/src/daemon/hold.ts
+++ b/src/daemon/hold.ts
@@ -41,7 +41,15 @@ export function readHold(pidFilePath: string, now: Date = new Date()): Hold | nu
   if (!existsSync(path)) return null;
   let hold: Hold;
   try {
-    hold = JSON.parse(readFileSync(path, "utf-8")) as Hold;
+    const value: unknown = JSON.parse(readFileSync(path, "utf-8"));
+    if (typeof value !== "object" || value === null || Array.isArray(value)
+      || !("pid" in value) || !Number.isSafeInteger(value.pid) || (value.pid as number) <= 0
+      || !("until" in value) || typeof value.until !== "string"
+      || ("reason" in value && typeof value.reason !== "string")) {
+      clearHold(pidFilePath);
+      return null;
+    }
+    hold = value as Hold;
   } catch {
     clearHold(pidFilePath);
     return null;
@@ -61,10 +69,14 @@ export function writeHold(
 ): Hold {
   const now = opts.now ?? new Date();
   const minutes = opts.minutes ?? DEFAULT_HOLD_MINUTES;
+  const expiry = new Date(now.getTime() + minutes * 60_000);
+  if (!Number.isFinite(minutes) || minutes <= 0 || !Number.isFinite(expiry.getTime())) {
+    throw new RangeError("Hold minutes must be positive and finite, with a valid expiry");
+  }
   const hold: Hold = {
     reason: opts.reason,
     pid: process.pid,
-    until: new Date(now.getTime() + minutes * 60_000).toISOString(),
+    until: expiry.toISOString(),
   };
   const path = holdPath(pidFilePath);
   mkdirSync(dirname(path), { recursive: true });

--- a/src/daemon/hold.ts
+++ b/src/daemon/hold.ts
@@ -1,4 +1,5 @@
-import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
 
 /**
@@ -33,8 +34,8 @@ export function holdPath(pidFilePath: string): string {
 
 /**
  * The hold in force, or null when there is none. An expired or unreadable
- * marker counts as none and is removed, so a corrupt file cannot wedge the
- * daemon down.
+ * marker counts as none. Readers never unlink a marker: a writer may have
+ * replaced the observed snapshot with a new hold in the meantime.
  */
 export function readHold(pidFilePath: string, now: Date = new Date()): Hold | null {
   const path = holdPath(pidFilePath);
@@ -46,17 +47,14 @@ export function readHold(pidFilePath: string, now: Date = new Date()): Hold | nu
       || !("pid" in value) || !Number.isSafeInteger(value.pid) || (value.pid as number) <= 0
       || !("until" in value) || typeof value.until !== "string"
       || ("reason" in value && typeof value.reason !== "string")) {
-      clearHold(pidFilePath);
       return null;
     }
     hold = value as Hold;
   } catch {
-    clearHold(pidFilePath);
     return null;
   }
   const until = Date.parse(hold?.until ?? "");
   if (!Number.isFinite(until) || until <= now.getTime()) {
-    clearHold(pidFilePath);
     return null;
   }
   return hold;
@@ -80,7 +78,13 @@ export function writeHold(
   };
   const path = holdPath(pidFilePath);
   mkdirSync(dirname(path), { recursive: true });
-  writeFileSync(path, JSON.stringify(hold, null, 2));
+  const temporary = `${path}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(temporary, JSON.stringify(hold, null, 2), { flag: "wx" });
+    renameSync(temporary, path);
+  } finally {
+    try { unlinkSync(temporary); } catch { /* already renamed or never created */ }
+  }
   return hold;
 }
 

--- a/src/daemon/hold.ts
+++ b/src/daemon/hold.ts
@@ -1,0 +1,85 @@
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+/**
+ * A hold keeps the daemon down across hook invocations.
+ *
+ * Stopping the daemon is not enough to get an offline window: every session
+ * hook calls `ensureDaemon`, so the next prompt or tool call spawns it again
+ * within seconds. Maintenance that must not race a writer — re-labelling rows,
+ * a migration, a consistent copy of the stores — has no safe window without
+ * this marker.
+ */
+export type Hold = {
+  /** Why the daemon is held down, shown to whoever finds it. */
+  reason?: string;
+  /** Process that placed the hold; diagnostic only, never trusted for liveness. */
+  pid: number;
+  /** ISO timestamp after which the hold no longer applies. */
+  until: string;
+};
+
+/**
+ * A hold expires so a forgotten one cannot silently stop memory capture
+ * forever. Long enough for the maintenance it exists for, short enough that
+ * the worst case is one lost session.
+ */
+export const DEFAULT_HOLD_MINUTES = 30;
+
+/** The marker lives beside the PID file, so both follow the same base directory. */
+export function holdPath(pidFilePath: string): string {
+  return join(dirname(pidFilePath), "daemon.hold");
+}
+
+/**
+ * The hold in force, or null when there is none. An expired or unreadable
+ * marker counts as none and is removed, so a corrupt file cannot wedge the
+ * daemon down.
+ */
+export function readHold(pidFilePath: string, now: Date = new Date()): Hold | null {
+  const path = holdPath(pidFilePath);
+  if (!existsSync(path)) return null;
+  let hold: Hold;
+  try {
+    hold = JSON.parse(readFileSync(path, "utf-8")) as Hold;
+  } catch {
+    clearHold(pidFilePath);
+    return null;
+  }
+  const until = Date.parse(hold?.until ?? "");
+  if (!Number.isFinite(until) || until <= now.getTime()) {
+    clearHold(pidFilePath);
+    return null;
+  }
+  return hold;
+}
+
+/** Places a hold expiring `minutes` from now, replacing any hold already there. */
+export function writeHold(
+  pidFilePath: string,
+  opts: { minutes?: number; reason?: string; now?: Date } = {},
+): Hold {
+  const now = opts.now ?? new Date();
+  const minutes = opts.minutes ?? DEFAULT_HOLD_MINUTES;
+  const hold: Hold = {
+    reason: opts.reason,
+    pid: process.pid,
+    until: new Date(now.getTime() + minutes * 60_000).toISOString(),
+  };
+  const path = holdPath(pidFilePath);
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(hold, null, 2));
+  return hold;
+}
+
+/** Removes the marker. True when one was there to remove. */
+export function clearHold(pidFilePath: string): boolean {
+  const path = holdPath(pidFilePath);
+  try {
+    if (!existsSync(path)) return false;
+    unlinkSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/daemon/hold.ts
+++ b/src/daemon/hold.ts
@@ -92,10 +92,12 @@ export function writeHold(
 export function clearHold(pidFilePath: string): boolean {
   const path = holdPath(pidFilePath);
   try {
-    if (!existsSync(path)) return false;
+    // Release the current marker in one atomic operation, ordered against
+    // publication's rename. A hold published after this unlink remains active.
     unlinkSync(path);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
   }
 }

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { join, dirname } from "node:path";
 import { ensureAuthToken } from "./auth.js";
+import { readHold } from "./hold.js";
 
 export type EnsureDaemonOptions = {
   port: number;
@@ -87,6 +88,13 @@ export async function checkDaemonHealth(
 
 export async function ensureDaemon(opts: EnsureDaemonOptions): Promise<EnsureDaemonResult> {
   const fetchFn = opts._fetchOverride ?? globalThis.fetch;
+
+  // Step 0: A hold means someone claimed an offline window. Report not connected
+  // without touching the daemon at all — every caller already degrades to a
+  // no-op when it cannot connect, which is exactly the behaviour a hold wants.
+  if (readHold(opts.pidFilePath)) {
+    return { connected: false, port: opts.port, spawned: false };
+  }
 
   // Step 1: Check if daemon is already running via health check
   const health = await checkDaemonHealth(opts.port, fetchFn);

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -62,8 +62,8 @@ function cleanStalePid(pidFilePath: string): void {
   } catch { /* ignore */ }
 }
 
-/** Register before the last hold check; keep visible until the listening PID is published. */
-export function registerDaemonStartup(pidFilePath: string): () => void {
+/** Register before checking a hold; release only after startup or local database work settles. */
+export function registerDaemonActivity(pidFilePath: string): () => void {
   mkdirSync(dirname(pidFilePath), { recursive: true });
   const path = join(dirname(pidFilePath), `daemon.starting.${process.pid}.${randomUUID()}`);
   writeFileSync(path, "", { flag: "wx" });
@@ -170,7 +170,21 @@ export async function ensureDaemon(opts: EnsureDaemonOptions): Promise<EnsureDae
   ensureAuthToken(tokenPath);
 
   const spawnCommand = opts.spawnCommand ?? process.execPath;
-  const spawnArgs = opts.spawnArgs ?? [process.argv[1], "daemon", "start", "--automatic"];
+  const sourceLoaderArgs: string[] = [];
+  if (!opts.spawnArgs && spawnCommand === process.execPath && /\.(?:[cm]?ts|tsx)$/.test(process.argv[1] ?? "")) {
+    // Source entrypoints need the active TS loader, but debugger/eval flags
+    // belong to the caller and must not be inherited by a detached daemon.
+    for (let i = 0; i < process.execArgv.length; i++) {
+      const arg = process.execArgv[i];
+      if (/^(?:--import|--loader|--experimental-loader|--require)=/.test(arg)) {
+        sourceLoaderArgs.push(arg);
+      } else if (["--import", "--loader", "--experimental-loader", "--require", "-r"].includes(arg)
+          && process.execArgv[i + 1] !== undefined) {
+        sourceLoaderArgs.push(arg, process.execArgv[++i]);
+      }
+    }
+  }
+  const spawnArgs = opts.spawnArgs ?? [...sourceLoaderArgs, process.argv[1], "daemon", "start", "--automatic"];
   const spawnImpl = opts._spawnOverride ?? spawn;
   const child = spawnImpl(spawnCommand, spawnArgs, {
     detached: true,

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -138,7 +138,7 @@ export async function ensureDaemon(opts: EnsureDaemonOptions): Promise<EnsureDae
   }
 
   // Step 3: Spawn daemon (unless skipped for testing)
-  if (opts._skipSpawn || opts.noSpawn) {
+  if (opts._skipSpawn || opts.noSpawn || readHold(opts.pidFilePath)) {
     return { connected: false, port: opts.port, spawned: false };
   }
 
@@ -147,7 +147,7 @@ export async function ensureDaemon(opts: EnsureDaemonOptions): Promise<EnsureDae
   ensureAuthToken(tokenPath);
 
   const spawnCommand = opts.spawnCommand ?? process.execPath;
-  const spawnArgs = opts.spawnArgs ?? [process.argv[1], "daemon", "start"];
+  const spawnArgs = opts.spawnArgs ?? [process.argv[1], "daemon", "start", "--automatic"];
   const spawnImpl = opts._spawnOverride ?? spawn;
   const child = spawnImpl(spawnCommand, spawnArgs, {
     detached: true,

--- a/src/daemon/lifecycle.ts
+++ b/src/daemon/lifecycle.ts
@@ -1,4 +1,5 @@
-import { existsSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, unlinkSync } from "node:fs";
+import { randomUUID } from "node:crypto";
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { join, dirname } from "node:path";
 import { ensureAuthToken } from "./auth.js";
@@ -59,6 +60,28 @@ function cleanStalePid(pidFilePath: string): void {
   try {
     if (existsSync(pidFilePath)) unlinkSync(pidFilePath);
   } catch { /* ignore */ }
+}
+
+/** Register before the last hold check; keep visible until the listening PID is published. */
+export function registerDaemonStartup(pidFilePath: string): () => void {
+  mkdirSync(dirname(pidFilePath), { recursive: true });
+  const path = join(dirname(pidFilePath), `daemon.starting.${process.pid}.${randomUUID()}`);
+  writeFileSync(path, "", { flag: "wx" });
+  return () => { try { unlinkSync(path); } catch { /* already removed by stop */ } };
+}
+
+function startingDaemons(pidFilePath: string): { pid: number; path: string }[] {
+  const directory = dirname(pidFilePath);
+  let names: string[];
+  try { names = readdirSync(directory); } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  return names.flatMap((name) => {
+    const match = /^daemon\.starting\.(\d+)\.[0-9a-f-]+$/.exec(name);
+    const pid = Number(match?.[1]);
+    return Number.isSafeInteger(pid) && pid > 0 ? [{ pid, path: join(directory, name) }] : [];
+  });
 }
 
 /** PID of the process listening on 127.0.0.1:port, via lsof (macOS/Linux). Undefined when unknown. */
@@ -156,9 +179,8 @@ export async function ensureDaemon(opts: EnsureDaemonOptions): Promise<EnsureDae
   }) as ChildProcess;
   child.unref();
 
-  if (child.pid) {
-    writeFileSync(opts.pidFilePath, String(child.pid));
-  }
+  // The child registers itself before checking holds and publishes daemon.pid
+  // only after listening. A late parent write could overwrite the winning PID.
 
   if (opts._skipHealthWait) {
     return { connected: false, port: opts.port, spawned: true };
@@ -193,6 +215,10 @@ export async function stopDaemon(opts: {
   _fetchOverride?: typeof globalThis.fetch;
 }): Promise<{ stopped: boolean; pid?: number }> {
   const fetchFn = opts._fetchOverride ?? globalThis.fetch;
+  // Read startup registrations before daemon.pid: a child hands off by writing
+  // daemon.pid before removing its registration, so neither state can be missed.
+  // A child registering after this snapshot sees the hold published by the caller.
+  const starting = startingDaemons(opts.pidFilePath);
   let pid: number | undefined;
   if (existsSync(opts.pidFilePath)) {
     try {
@@ -206,14 +232,25 @@ export async function stopDaemon(opts: {
     pid = health?.pid ?? (health ? findListenerPid(opts.port) : undefined) ?? pid;
   }
   if (pid !== undefined && isProcessAlive(pid)) {
-    try { process.kill(pid, "SIGTERM"); } catch { /* ignore */ }
+    try { process.kill(pid, "SIGTERM"); } catch { /* checked below */ }
   }
   const deadline = Date.now() + (opts.timeoutMs ?? 5000);
   while (Date.now() < deadline) {
-    const alive = pid !== undefined && isProcessAlive(pid);
-    const health = alive ? await checkDaemonHealth(opts.port, fetchFn) : null;
+    // Startup registrations are only waited on, never signalled: a stale
+    // registration could refer to a PID the OS has since reused.
+    const startingAlive = starting.some((entry) => existsSync(entry.path) && isProcessAlive(entry.pid));
+    const alive = (pid !== undefined && isProcessAlive(pid)) || startingAlive;
+    const health = await checkDaemonHealth(opts.port, fetchFn);
+    // A registered child may have handed off after our initial PID read.
+    if (health?.pid !== undefined && health.pid !== pid) {
+      pid = health.pid;
+      try { process.kill(pid, "SIGTERM"); } catch { /* checked on the next iteration */ }
+    }
     if (!alive && !health) {
       cleanStalePid(opts.pidFilePath);
+      for (const entry of starting) {
+        try { unlinkSync(entry.path); } catch { /* child already removed it */ }
+      }
       return { stopped: true, pid };
     }
     await sleep(200);

--- a/src/daemon/version.ts
+++ b/src/daemon/version.ts
@@ -23,8 +23,8 @@ export const PKG_VERSION: string | undefined = (() => {
   ];
   for (const p of candidates) {
     try {
-      const pkg = JSON.parse(readFileSync(p, "utf-8")) as { version?: unknown };
-      if (typeof pkg.version === "string" && pkg.version) return pkg.version;
+      const pkg = JSON.parse(readFileSync(p, "utf-8")) as { name?: unknown; version?: unknown };
+      if (pkg.name === "@lossless-claude/lcm" && typeof pkg.version === "string" && pkg.version) return pkg.version;
     } catch { /* try next candidate */ }
   }
   return undefined;

--- a/src/db/events-stats.ts
+++ b/src/db/events-stats.ts
@@ -2,7 +2,8 @@
 import { readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { eventsDir } from "./events-path.js";
-import { EventsDb } from "../hooks/events-db.js";
+import { DatabaseSync } from "node:sqlite";
+import { readEventHealthStats } from "../hooks/events-db.js";
 
 export interface EventStats {
   captured: number;
@@ -63,11 +64,11 @@ export function collectEventStats(timeoutMs = 2000): EventStats {
   for (const file of files) {
     if (scanned >= MAX_DBS || Date.now() >= deadline) break;
     try {
-      const db = new EventsDb(join(dir, file));
+      const db = new DatabaseSync(join(dir, file), { readOnly: true });
       // Override busy_timeout for scan connections (500ms instead of default 5000ms)
-      db.raw().exec("PRAGMA busy_timeout = 500");
+      db.exec("PRAGMA busy_timeout = 500");
       try {
-        const stats = db.getHealthStats();
+        const stats = readEventHealthStats(db);
         result.captured += stats.totalEvents;
         result.unprocessed += stats.unprocessed;
         result.errors += stats.errors;
@@ -111,10 +112,10 @@ export function collectDetailedEventStats(timeoutMs = 2000): DetailedEventStats 
   for (const file of files) {
     if (scanned >= MAX_DBS || Date.now() >= deadline) break;
     try {
-      const db = new EventsDb(join(dir, file));
-      db.raw().exec("PRAGMA busy_timeout = 500");
+      const db = new DatabaseSync(join(dir, file), { readOnly: true });
+      db.exec("PRAGMA busy_timeout = 500");
       try {
-        const stats = db.getHealthStats();
+        const stats = readEventHealthStats(db);
         result.captured += stats.totalEvents;
         result.unprocessed += stats.unprocessed;
         result.errors += stats.errors;
@@ -128,7 +129,7 @@ export function collectDetailedEventStats(timeoutMs = 2000): DetailedEventStats 
           lastCapture: stats.lastCapture,
         });
         // Collect recent errors for verbose display (exclude maintenance/pruning entries)
-        const errors = db.raw().prepare(
+        const errors = db.prepare(
           "SELECT created_at, hook, error FROM error_log WHERE hook NOT LIKE 'maintenance:%' ORDER BY id DESC LIMIT 5"
         ).all() as Array<{ created_at: string; hook: string; error: string }>;
         result.recentErrors.push(...errors);

--- a/src/db/events-stats.ts
+++ b/src/db/events-stats.ts
@@ -129,10 +129,15 @@ export function collectDetailedEventStats(timeoutMs = 2000): DetailedEventStats 
           lastCapture: stats.lastCapture,
         });
         // Collect recent errors for verbose display (exclude maintenance/pruning entries)
-        const errors = db.prepare(
-          "SELECT created_at, hook, error FROM error_log WHERE hook NOT LIKE 'maintenance:%' ORDER BY id DESC LIMIT 5"
-        ).all() as Array<{ created_at: string; hook: string; error: string }>;
-        result.recentErrors.push(...errors);
+        const hasErrorLog = db.prepare(
+          "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'error_log'"
+        ).get();
+        if (hasErrorLog) {
+          const errors = db.prepare(
+            "SELECT created_at, hook, error FROM error_log WHERE hook NOT LIKE 'maintenance:%' ORDER BY id DESC LIMIT 5"
+          ).all() as Array<{ created_at: string; hook: string; error: string }>;
+          result.recentErrors.push(...errors);
+        }
       } finally {
         db.close();
       }

--- a/src/hooks/events-db.ts
+++ b/src/hooks/events-db.ts
@@ -46,9 +46,15 @@ export function readEventHealthStats(db: DatabaseSync): HealthStats {
   const unprocessedRow = db.prepare(
     "SELECT COUNT(*) as unprocessed FROM events WHERE processed_at IS NULL"
   ).get() as { unprocessed: number };
-  const errorTotals = db.prepare(
-    "SELECT COUNT(*) as errors, MAX(created_at) as lastError FROM error_log WHERE hook NOT LIKE 'maintenance:%' AND created_at >= datetime('now', '-30 days')"
-  ).get() as { errors: number; lastError: string | null };
+  // Version 1 sidecars predate error logging; inspection must not migrate them.
+  const hasErrorLog = db.prepare(
+    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'error_log'"
+  ).get();
+  const errorTotals = hasErrorLog
+    ? db.prepare(
+      "SELECT COUNT(*) as errors, MAX(created_at) as lastError FROM error_log WHERE hook NOT LIKE 'maintenance:%' AND created_at >= datetime('now', '-30 days')"
+    ).get() as { errors: number; lastError: string | null }
+    : { errors: 0, lastError: null };
 
   return { ...eventTotals, unprocessed: unprocessedRow.unprocessed, ...errorTotals };
 }

--- a/src/hooks/events-db.ts
+++ b/src/hooks/events-db.ts
@@ -38,6 +38,21 @@ export interface HealthStats {
   lastError: string | null;
 }
 
+/** Read health counters without opening, migrating, or mutating the database. */
+export function readEventHealthStats(db: DatabaseSync): HealthStats {
+  const eventTotals = db.prepare(
+    "SELECT COUNT(*) as totalEvents, MAX(created_at) as lastCapture FROM events"
+  ).get() as { totalEvents: number; lastCapture: string | null };
+  const unprocessedRow = db.prepare(
+    "SELECT COUNT(*) as unprocessed FROM events WHERE processed_at IS NULL"
+  ).get() as { unprocessed: number };
+  const errorTotals = db.prepare(
+    "SELECT COUNT(*) as errors, MAX(created_at) as lastError FROM error_log WHERE hook NOT LIKE 'maintenance:%' AND created_at >= datetime('now', '-30 days')"
+  ).get() as { errors: number; lastError: string | null };
+
+  return { ...eventTotals, unprocessed: unprocessedRow.unprocessed, ...errorTotals };
+}
+
 export interface PatternReinforcementStats {
   totalCount: number;
   distinctSessions: number;
@@ -345,23 +360,7 @@ export class EventsDb {
   }
 
   getHealthStats(): HealthStats {
-    const eventTotals = this.db.prepare(
-      "SELECT COUNT(*) as totalEvents, MAX(created_at) as lastCapture FROM events"
-    ).get() as { totalEvents: number; lastCapture: string | null };
-    const unprocessedRow = this.db.prepare(
-      "SELECT COUNT(*) as unprocessed FROM events WHERE processed_at IS NULL"
-    ).get() as { unprocessed: number };
-    const errorTotals = this.db.prepare(
-      "SELECT COUNT(*) as errors, MAX(created_at) as lastError FROM error_log WHERE hook NOT LIKE 'maintenance:%' AND created_at >= datetime('now', '-30 days')"
-    ).get() as { errors: number; lastError: string | null };
-
-    return {
-      totalEvents: eventTotals.totalEvents,
-      unprocessed: unprocessedRow.unprocessed,
-      errors: errorTotals.errors,
-      lastCapture: eventTotals.lastCapture,
-      lastError: errorTotals.lastError,
-    };
+    return readEventHealthStats(this.db);
   }
 
   pruneUnprocessed(maxRows = 10_000, maxAgeDays = 30): { pruned: number } {

--- a/src/hooks/hook-errors.ts
+++ b/src/hooks/hook-errors.ts
@@ -5,6 +5,7 @@ import { appendFileSync, mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { join } from "node:path";
 import { lcmPath } from "../lcm-home.js";
+import { withHookWrite } from "./write-admission.js";
 
 /** Returns the log path — overridable via LCM_LOG_PATH env var for test isolation. */
 export function getLogPath(): string {
@@ -29,6 +30,12 @@ export function safeLogError(
   error: unknown,
   opts: { cwd?: string; sessionId?: string },
 ): void {
+  try {
+    withHookWrite(() => writeHookError(hook, error, opts), undefined);
+  } catch { /* admission failure must not crash the hook or write outside the fence */ }
+}
+
+function writeHookError(hook: string, error: unknown, opts: { cwd?: string; sessionId?: string }): void {
   // Layer 1: Sidecar DB (skip if cwd missing or circuit open)
   if (opts.cwd && !dbCircuitOpen) {
     try {

--- a/src/hooks/post-tool.ts
+++ b/src/hooks/post-tool.ts
@@ -6,6 +6,7 @@ import { firePromoteEventsRequest } from "./session-end.js";
 import { safeLogError } from "./hook-errors.js";
 import { functionHooksOwnSession } from "./session-claim.js";
 import { lcmPath } from "../lcm-home.js";
+import { withHookWrite } from "./write-admission.js";
 
 // Back-compat re-export: some callers historically imported the function-hooks gate from this module.
 export { functionHooksActive, functionHooksOwnSession } from "./session-claim.js";
@@ -67,15 +68,16 @@ export function recordPostToolEvents(payload: PostToolPayload): RecordedPostTool
     ? payload.tool_use_id
     : undefined;
 
-  const db = new EventsDb(eventsDbPath(payload.cwd));
-  let recorded: number;
-  try {
-    // Dedup on the whole call, not each event: one call extracts several events, and a
-    // per-event check would leave a half batch when the paths raced.
-    recorded = db.insertToolCallEvents(payload.session_id, events, sourceHook, toolUseId);
-  } finally {
-    db.close();
-  }
+  const recorded = withHookWrite(() => {
+    const db = new EventsDb(eventsDbPath(payload.cwd));
+    try {
+      // Dedup on the whole call, not each event: one call extracts several events, and a
+      // per-event check would leave a half batch when the paths raced.
+      return db.insertToolCallEvents(payload.session_id, events, sourceHook, toolUseId);
+    } finally {
+      db.close();
+    }
+  }, 0);
   if (recorded === 0) return { recorded: 0, hasPriority1: false, sourceHook };
   return { recorded, hasPriority1: events.some(e => e.priority === 1), sourceHook };
 }

--- a/src/hooks/user-prompt.ts
+++ b/src/hooks/user-prompt.ts
@@ -6,6 +6,7 @@ import { buildMemoryContext } from "./memory-context.js";
 import { LEARNING_INSTRUCTION } from "./learning-instruction.js";
 import { functionHooksOwnSession } from "./session-claim.js";
 import { lcmPath } from "../lcm-home.js";
+import { withHookWrite } from "./write-admission.js";
 
 type PromptSearchResponse = {
   hints: string[];
@@ -31,12 +32,14 @@ export async function recordUserPromptEvents(prompt: string, sessionId: string, 
   // The dedup key both paths can compute: the module's prompt.submit sees the text and
   // no prompt id, so the id the command hook's stdin carries is no use here.
   const promptHash = createHash("sha256").update(prompt).digest("hex");
-  const db = new EventsDb(eventsDbPath(cwd));
-  try {
-    return db.insertPromptEvents(sessionId, events, promptHash);
-  } finally {
-    db.close();
-  }
+  return withHookWrite(() => {
+    const db = new EventsDb(eventsDbPath(cwd));
+    try {
+      return db.insertPromptEvents(sessionId, events, promptHash);
+    } finally {
+      db.close();
+    }
+  }, 0);
 }
 
 export async function handleUserPromptSubmit(

--- a/src/hooks/write-admission.ts
+++ b/src/hooks/write-admission.ts
@@ -1,0 +1,14 @@
+import { registerDaemonActivity } from "../daemon/lifecycle.js";
+import { readHold } from "../daemon/hold.js";
+import { lcmPath } from "../lcm-home.js";
+
+/** Admit synchronous hook writes before opening SQLite; held stops drain admitted work. */
+export function withHookWrite<T>(write: () => T, heldResult: T): T {
+  const pidPath = lcmPath("daemon.pid");
+  const unregister = registerDaemonActivity(pidPath);
+  try {
+    return readHold(pidPath) ? heldResult : write();
+  } finally {
+    unregister();
+  }
+}

--- a/src/import.ts
+++ b/src/import.ts
@@ -252,7 +252,7 @@ function isSessionAlreadyIngested(cwd: string, sessionId: string, lcmDir?: strin
     if (!existsSync(dbPath)) {
       return false;
     }
-    const db = new DatabaseSync(dbPath);
+    const db = new DatabaseSync(dbPath, { readOnly: true });
     try {
       db.exec("PRAGMA busy_timeout = 5000");
       const row = db.prepare("SELECT 1 FROM session_ingest_log WHERE session_id = ?").get(sessionId);

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -199,7 +199,7 @@ export async function startMcpServer(): Promise<void> {
     port, pidFilePath, spawnTimeoutMs: 10000,
     expectedVersion: PKG_VERSION,
     spawnCommand: process.execPath,
-    spawnArgs: [lcmBin, "daemon", "start"],
+    spawnArgs: [lcmBin, "daemon", "start", "--automatic"],
   });
 
   const client = new DaemonClient(`http://127.0.0.1:${port}`);
@@ -242,7 +242,7 @@ export async function startMcpServer(): Promise<void> {
     return handleDaemonRequest(client, route, body, {
       port, pidFilePath,
       spawnCommand: process.execPath,
-      spawnArgs: [lcmBin, "daemon", "start"],
+      spawnArgs: [lcmBin, "daemon", "start", "--automatic"],
       expectedVersion: PKG_VERSION,
     });
   });

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,7 +4,7 @@ import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { DaemonClient } from "../daemon/client.js";
 import { loadDaemonConfig } from "../daemon/config.js";
-import { ensureDaemon } from "../daemon/lifecycle.js";
+import { ensureDaemon, registerDaemonActivity } from "../daemon/lifecycle.js";
 import { readHold } from "../daemon/hold.js";
 import { PKG_VERSION } from "../daemon/version.js";
 import { lcmGrepTool } from "./tools/lcm-grep.js";
@@ -26,7 +26,7 @@ const TOOL_ROUTES: Record<string, string> = {
   lcm_store: "/store",
 };
 
-const LOCAL_TOOLS: Record<string, (args: Record<string, unknown>) => Promise<string>> = {
+const LOCAL_TOOLS: Partial<Record<string, (args: Record<string, unknown>) => Promise<string>>> = {
   lcm_stats: async (args) => {
     const { collectStats, formatNumber } = await import("../stats.js");
     const stats = collectStats();
@@ -225,20 +225,25 @@ export async function startMcpServer(): Promise<void> {
       void rawArgs;
     }
 
-    const hold = readHold(pidFilePath);
-    if (hold) {
-      return { content: [{ type: "text", text: `lcm daemon held down until ${hold.until}. Release it with: lcm daemon start` }], isError: true };
-    }
-
     const localHandler = LOCAL_TOOLS[req.params.name];
-    if (localHandler) {
-      try {
-        const text = await localHandler(filteredArgs);
-        return { content: [{ type: "text", text }] };
-      } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err);
-        return { content: [{ type: "text", text: `lcm error: ${msg}` }], isError: true };
+    // Register before admission so a held stop drains work that already began.
+    const unregister = localHandler ? registerDaemonActivity(pidFilePath) : undefined;
+    try {
+      const hold = readHold(pidFilePath);
+      if (hold) {
+        return { content: [{ type: "text", text: `lcm daemon held down until ${hold.until}. Release it with: lcm daemon start` }], isError: true };
       }
+      if (localHandler) {
+        try {
+          const text = await localHandler(filteredArgs);
+          return { content: [{ type: "text", text }] };
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          return { content: [{ type: "text", text: `lcm error: ${msg}` }], isError: true };
+        }
+      }
+    } finally {
+      unregister?.();
     }
 
     const route = TOOL_ROUTES[req.params.name];

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { DaemonClient } from "../daemon/client.js";
 import { loadDaemonConfig } from "../daemon/config.js";
 import { ensureDaemon } from "../daemon/lifecycle.js";
+import { readHold } from "../daemon/hold.js";
 import { PKG_VERSION } from "../daemon/version.js";
 import { lcmGrepTool } from "./tools/lcm-grep.js";
 import { lcmExpandTool } from "./tools/lcm-expand.js";
@@ -222,6 +223,11 @@ export async function startMcpServer(): Promise<void> {
       // No schema properties defined — default-deny: pass nothing through.
       // This is safer than a denylist-based approach which could miss unknown keys.
       void rawArgs;
+    }
+
+    const hold = readHold(pidFilePath);
+    if (hold) {
+      return { content: [{ type: "text", text: `lcm daemon held down until ${hold.until}. Release it with: lcm daemon start` }], isError: true };
     }
 
     const localHandler = LOCAL_TOOLS[req.params.name];

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -67,21 +67,29 @@ function queryProjectStats(dbPath: string, projectId: string, staleCfg: { staleA
   db.exec("PRAGMA busy_timeout = 5000");
 
   try {
+    const columns = (table: string) => new Set(
+      (db.prepare(`PRAGMA table_info(${table})`).all() as { name: string }[]).map((row) => row.name),
+    );
+    const summaryColumns = columns("summaries");
+    const summaryDepth = summaryColumns.has("depth") ? "depth" : "0";
+    const promotedColumns = columns("promoted");
+    const usageColumns = columns("llm_usage_stats");
+    const usageSum = (column: string, fallback = "0") => usageColumns.has(column) ? `SUM(${column})` : fallback;
     const msgStats = db.prepare(
       `SELECT COUNT(*) as count, COALESCE(SUM(token_count), 0) as tokens FROM messages`
     ).get() as { count: number; tokens: number };
 
     const sumStats = db.prepare(
-      `SELECT COUNT(*) as count, COALESCE(SUM(token_count), 0) as tokens, COALESCE(MAX(depth), 0) as maxDepth FROM summaries`
+      `SELECT COUNT(*) as count, COALESCE(SUM(token_count), 0) as tokens, COALESCE(MAX(${summaryDepth}), 0) as maxDepth FROM summaries`
     ).get() as { count: number; tokens: number; maxDepth: number };
 
-    const promoted = db.prepare(
+    const promoted = promotedColumns.size ? db.prepare(
       `SELECT COUNT(*) as count FROM promoted`
-    ).get() as { count: number };
+    ).get() as { count: number } : { count: 0 };
 
-    const redactionRows = db.prepare(
+    const redactionRows = columns("redaction_stats").size ? db.prepare(
       `SELECT category, COALESCE(SUM(count), 0) as count FROM redaction_stats WHERE project_id = ? GROUP BY category`
-    ).all(projectId) as { category: string; count: number }[];
+    ).all(projectId) as { category: string; count: number }[] : [];
     const redactionMap = Object.fromEntries(redactionRows.map((r) => [r.category, r.count]));
     const redactionCounts: RedactionCounts = {
       builtIn: redactionMap["built_in"] ?? 0,
@@ -91,22 +99,22 @@ function queryProjectStats(dbPath: string, projectId: string, staleCfg: { staleA
     };
     redactionCounts.total = redactionCounts.builtIn + redactionCounts.global + redactionCounts.project;
 
-    const llmUsageRow = db.prepare(
+    const llmUsageRow = usageColumns.size ? db.prepare(
       `SELECT
-         COALESCE(SUM(calls_total), 0) as calls,
-         COALESCE(SUM(calls_ok), 0) as okCalls,
-         COALESCE(SUM(calls_failed), 0) as failedCalls,
-         COALESCE(SUM(tokens_spent_total), 0) as tokensSpent,
-         COALESCE(SUM(tokens_input_total), 0) as tokensInput,
-         COALESCE(SUM(tokens_cached_total), 0) as tokensCached,
-         COALESCE(SUM(tokens_output_total), 0) as tokensOutput,
+         COALESCE(${usageSum("calls_total")}, 0) as calls,
+         COALESCE(${usageSum("calls_ok")}, 0) as okCalls,
+         COALESCE(${usageSum("calls_failed")}, 0) as failedCalls,
+         COALESCE(${usageSum("tokens_spent_total")}, 0) as tokensSpent,
+         COALESCE(${usageSum("tokens_input_total")}, 0) as tokensInput,
+         COALESCE(${usageSum("tokens_cached_total")}, 0) as tokensCached,
+         COALESCE(${usageSum("tokens_output_total")}, 0) as tokensOutput,
          -- Deliberately not COALESCEd: all-NULL must stay NULL, not become 0.
-         SUM(cost_usd_total) as costUsd,
-         COALESCE(SUM(calls_with_cost), 0) as callsWithCost
+         ${usageSum("cost_usd_total", "NULL")} as costUsd,
+         COALESCE(${usageSum("calls_with_cost")}, 0) as callsWithCost
        FROM llm_usage_stats`,
     ).get() as
       | { calls: number; okCalls: number; failedCalls: number; tokensSpent: number; tokensInput: number; tokensCached: number; tokensOutput: number; costUsd: number | null; callsWithCost: number }
-      | undefined;
+      | undefined : undefined;
 
     const convRows = db.prepare(`
       SELECT
@@ -122,7 +130,7 @@ function queryProjectStats(dbPath: string, projectId: string, staleCfg: { staleA
         FROM messages GROUP BY conversation_id
       ) m ON m.conversation_id = c.conversation_id
       LEFT JOIN (
-        SELECT conversation_id, COUNT(*) as sum_count, SUM(token_count) as sum_tokens, MAX(depth) as max_depth
+        SELECT conversation_id, COUNT(*) as sum_count, SUM(token_count) as sum_tokens, MAX(${summaryDepth}) as max_depth
         FROM summaries GROUP BY conversation_id
       ) s ON s.conversation_id = c.conversation_id
       ORDER BY c.conversation_id DESC
@@ -144,7 +152,9 @@ function queryProjectStats(dbPath: string, projectId: string, staleCfg: { staleA
     const compactedRaw = compacted.reduce((s, c) => s + c.rawTokens, 0);
     const compactedSum = compacted.reduce((s, c) => s + c.summaryTokens, 0);
 
-    const recallStats = new RecallStore(db).getStats();
+    const recallStats: RecallStats = columns("recall_surfacing").size && promotedColumns.has("archived_at")
+      ? new RecallStore(db).getStats()
+      : { memoriesSurfaced: 0, memoriesActedUpon: 0, recallPrecision: null, topRecalled: [] };
 
     // Count stale promoted memories (config is passed in to avoid re-reading per project)
     let staleCount = 0;

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,7 +1,6 @@
 import { DatabaseSync } from "node:sqlite";
 import { readdirSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { runLcmMigrations } from "./db/migration.js";
 import { collectEventStats } from "./db/events-stats.js";
 import { RecallStore, type RecallStats } from "./db/recall.js";
 import { PromotedStore } from "./db/promoted.js";
@@ -64,11 +63,10 @@ interface OverallStats {
 }
 
 function queryProjectStats(dbPath: string, projectId: string, staleCfg: { staleAfterDays: number; staleSurfacingWithoutUseLimit: number }): Omit<OverallStats, "projects" | "recallStats" | "staleCount"> & { recallStats: RecallStats; staleCount: number } {
-  const db = new DatabaseSync(dbPath);
+  const db = new DatabaseSync(dbPath, { readOnly: true });
   db.exec("PRAGMA busy_timeout = 5000");
 
   try {
-    runLcmMigrations(db);
     const msgStats = db.prepare(
       `SELECT COUNT(*) as count, COALESCE(SUM(token_count), 0) as tokens FROM messages`
     ).get() as { count: number; tokens: number };

--- a/test/bin/compact-hold.test.ts
+++ b/test/bin/compact-hold.test.ts
@@ -1,0 +1,96 @@
+import { expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createServer } from "node:http";
+import { DatabaseSync } from "node:sqlite";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { writeHold } from "../../src/daemon/hold.js";
+
+const execute = promisify(execFile);
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+async function waitFor(predicate: () => boolean) {
+  const deadline = Date.now() + 10000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("compact barrier timed out");
+    await delay(10);
+  }
+}
+
+it("held compact refuses admission without migrating project databases", async () => {
+  const root = mkdtempSync(join(tmpdir(), "lcm-compact-held-"));
+  const project = join(root, "projects", "legacy");
+  mkdirSync(project, { recursive: true });
+  const dbPath = join(project, "db.sqlite");
+  const db = new DatabaseSync(dbPath);
+  db.exec("CREATE TABLE sentinel (value TEXT)"); db.close();
+  writeFileSync(join(project, "meta.json"), JSON.stringify({ cwd: root }));
+  writeHold(join(root, "daemon.pid"));
+  const before = readFileSync(dbPath);
+  try {
+    await expect(execute(process.execPath, [resolve("dist/bin/lcm.js"), "compact", "--all"], {
+      cwd: root, env: { ...process.env, HOME: root, LCM_HOME: root }, timeout: 10000,
+    })).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining("held down until") });
+    expect(readFileSync(dbPath)).toEqual(before);
+    expect(readdirSync(root).some((name) => name.startsWith("daemon.starting."))).toBe(false);
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+it("held stop waits for admitted compact local migrations until the CLI exits", async () => {
+  const root = mkdtempSync(join(tmpdir(), "lcm-compact-drain-"));
+  const project = join(root, "projects", "legacy");
+  mkdirSync(project, { recursive: true });
+  const dbPath = join(project, "db.sqlite");
+  new DatabaseSync(dbPath).close();
+  writeFileSync(join(project, "meta.json"), JSON.stringify({ cwd: root }));
+  const server = createServer((_req, res) => { res.setHeader("content-type", "application/json"); res.end(JSON.stringify({ status: "ok" })); });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+  writeFileSync(join(root, "config.json"), JSON.stringify({ daemon: { port } }));
+  const preload = join(root, "pause-sqlite.mjs");
+  writeFileSync(preload, `
+    import fs from 'node:fs';
+    import { syncBuiltinESMExports } from 'node:module';
+    const root = process.env.LCM_HOME;
+    const original = fs.readFileSync;
+    fs.readFileSync = function(path, ...options) {
+      if (String(path).endsWith('/projects/legacy/meta.json')) {
+        fs.writeFileSync(root + '/ready', '');
+        while (!fs.existsSync(root + '/resume')) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+      }
+      return original.call(this, path, ...options);
+    };
+    syncBuiltinESMExports();
+  `);
+  const env = { ...process.env, HOME: root, LCM_HOME: root };
+  const cli = resolve("dist/bin/lcm.js");
+  const compact = execute(process.execPath, ["--import", preload, cli, "compact", "--all", "--no-promote"], { cwd: root, env, timeout: 15000 });
+  void compact.catch(() => {});
+  let stop: ReturnType<typeof execute> | undefined;
+  try {
+    await Promise.race([
+      waitFor(() => existsSync(join(root, "ready"))),
+      compact.then((result) => { throw new Error(`compact exited before SQLite: ${result.stdout} ${result.stderr}`); }),
+    ]);
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    stop = execute(process.execPath, [cli, "daemon", "stop", "--hold"], { env, timeout: 10000 });
+    let stopped = false;
+    void stop.then(() => { stopped = true; }, () => { stopped = true; });
+    await waitFor(() => existsSync(join(root, "daemon.hold")));
+    await delay(100);
+    expect(stopped).toBe(false);
+    writeFileSync(join(root, "resume"), "");
+    await compact;
+    await stop;
+    expect(readdirSync(root).some((name) => name.startsWith("daemon.starting."))).toBe(false);
+    const inspected = new DatabaseSync(dbPath, { readOnly: true });
+    try { expect(inspected.prepare("SELECT name FROM sqlite_master WHERE name = 'conversations'").get()).toBeDefined(); }
+    finally { inspected.close(); }
+  } finally {
+    server.close();
+    writeFileSync(join(root, "resume"), ""); compact.child.kill();
+    await Promise.allSettled([compact, ...(stop ? [stop] : [])]);
+    rmSync(root, { recursive: true, force: true });
+  }
+}, 20000);

--- a/test/bin/offline-hold.test.ts
+++ b/test/bin/offline-hold.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createHash } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { writeHold } from "../../src/daemon/hold.js";
+
+const execute = promisify(execFile);
+const cli = resolve("dist/bin/lcm.js");
+let root: string, dbPath: string, input: string;
+let env: NodeJS.ProcessEnv;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "lcm-offline-hold-"));
+  env = { ...process.env, HOME: root, LCM_HOME: root };
+  const id = createHash("sha256").update(realpathSync(root)).digest("hex");
+  const project = join(root, "projects", id);
+  mkdirSync(project, { recursive: true });
+  dbPath = join(project, "db.sqlite");
+  const db = new DatabaseSync(dbPath);
+  db.exec("CREATE TABLE sentinel (value TEXT)"); db.close();
+  writeFileSync(join(project, "meta.json"), JSON.stringify({ cwd: root }));
+  input = join(root, "knowledge.json");
+  writeFileSync(input, JSON.stringify({ version: 1, entries: [
+    { content: "Keep database operations inside the admission boundary.", tags: ["decision"], confidence: 1, sessionId: null },
+  ] }));
+  writeFileSync(join(root, "config.json"), JSON.stringify({ daemon: { port: 1 } }));
+});
+afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+const commands = [["import-knowledge", "INPUT"], ["export"], ["bench", "build"], ["bench", "run"]];
+it.each(commands)("held offline command %j refuses admission without changing SQLite", async (...args) => {
+  writeHold(join(root, "daemon.pid"));
+  const before = readFileSync(dbPath);
+  await expect(execute(process.execPath, [cli, ...args.map((arg) => arg === "INPUT" ? input : arg)], {
+    cwd: root, env, timeout: 10000,
+  })).rejects.toMatchObject({ code: 1, stderr: expect.stringContaining("held down until") });
+  expect(readFileSync(dbPath)).toEqual(before);
+  expect(readdirSync(root).some((name) => name.startsWith("daemon.starting."))).toBe(false);
+});
+
+it.each(commands)("held offline command %j still provides help", async (...args) => {
+  writeHold(join(root, "daemon.pid"));
+  const result = await execute(process.execPath, [cli, ...args.map((arg) => arg === "INPUT" ? input : arg), "--help"], { cwd: root, env, timeout: 10000 });
+  expect(result.stdout).toMatch(/Usage:|lcm .*—/);
+  expect(result.stderr).toBe("");
+  expect(readdirSync(root).some((name) => name.startsWith("daemon.starting."))).toBe(false);
+});
+
+it("held stop drains an admitted offline import without requiring a daemon", async () => {
+  const preload = join(root, "pause-input.mjs");
+  writeFileSync(preload, `
+    import fs from 'node:fs';
+    import { syncBuiltinESMExports } from 'node:module';
+    const root = process.env.LCM_HOME;
+    const original = fs.readFileSync;
+    fs.readFileSync = function(path, ...options) {
+      if (String(path) === root + '/knowledge.json') {
+        fs.writeFileSync(root + '/ready', '');
+        while (!fs.existsSync(root + '/resume')) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+      }
+      return original.call(this, path, ...options);
+    };
+    syncBuiltinESMExports();
+  `);
+  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+  async function waitFor(predicate: () => boolean) {
+    const deadline = Date.now() + 10000;
+    while (!predicate()) {
+      if (Date.now() >= deadline) throw new Error("offline import barrier timed out");
+      await delay(10);
+    }
+  }
+  const importing = execute(process.execPath, ["--import", preload, cli, "import-knowledge", input], { cwd: root, env, timeout: 15000 });
+  void importing.catch(() => {});
+  let stop: ReturnType<typeof execute> | undefined;
+  try {
+    await waitFor(() => existsSync(join(root, "ready")));
+    stop = execute(process.execPath, [cli, "daemon", "stop", "--hold"], { env, timeout: 10000 });
+    let stopped = false;
+    void stop.then(() => { stopped = true; }, () => { stopped = true; });
+    await waitFor(() => existsSync(join(root, "daemon.hold")));
+    await delay(100);
+    expect(stopped).toBe(false);
+    writeFileSync(join(root, "resume"), "");
+    const result = await importing;
+    expect(result.stdout).toContain("Imported 1 entries");
+    await stop;
+    const inspected = new DatabaseSync(dbPath, { readOnly: true });
+    try { expect(inspected.prepare("SELECT COUNT(*) AS count FROM promoted").get()).toMatchObject({ count: 1 }); }
+    finally { inspected.close(); }
+    expect(readdirSync(root).some((name) => name.startsWith("daemon.starting."))).toBe(false);
+  } finally {
+    writeFileSync(join(root, "resume"), ""); importing.child.kill();
+    await Promise.allSettled([importing, ...(stop ? [stop] : [])]);
+  }
+}, 20000);

--- a/test/daemon/hold-races.test.ts
+++ b/test/daemon/hold-races.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as fs from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { holdPath, readHold, writeHold } from "../../src/daemon/hold.js";
+
+const intercept = vi.hoisted(() => ({ writing: undefined as undefined | ((path: string) => void), reading: undefined as undefined | (() => void) }));
+vi.mock("node:fs", async (original) => {
+  const actual = await original<typeof import("node:fs")>();
+  return { ...actual,
+    writeFileSync: (path: string, data: string, options?: any) => {
+      if (intercept.writing) {
+        const callback = intercept.writing; intercept.writing = undefined;
+        actual.writeFileSync(path, "", options); callback(path);
+        options = { ...options, flag: "w" };
+      }
+      return actual.writeFileSync(path, data, options);
+    },
+    readFileSync: (...args: any[]) => {
+      const result = (actual.readFileSync as any)(...args);
+      const callback = intercept.reading; intercept.reading = undefined; callback?.();
+      return result;
+    },
+  };
+});
+let dir: string;
+let pid: string;
+beforeEach(() => { dir = fs.mkdtempSync(join(tmpdir(), "hold-race-")); pid = join(dir, "daemon.pid"); });
+afterEach(() => { intercept.writing = undefined; intercept.reading = undefined; fs.rmSync(dir, { recursive: true, force: true }); });
+describe("hold publication interleavings", () => {
+  it("keeps the previous complete marker visible while the next marker is written", () => {
+    const old = writeHold(pid, { reason: "old" });
+    intercept.writing = () => { expect(readHold(pid)).toEqual(old); };
+    const next = writeHold(pid, { reason: "next" });
+    expect(readHold(pid)).toEqual(next);
+    expect(fs.readdirSync(dir)).toEqual(["daemon.hold"]);
+  });
+  it("cleans an unpublished temporary file when writing fails", () => {
+    const old = writeHold(pid);
+    intercept.writing = () => { throw new Error("disk full"); };
+    expect(() => writeHold(pid)).toThrow("disk full");
+    expect(readHold(pid)).toEqual(old);
+    expect(fs.readdirSync(dir)).toEqual(["daemon.hold"]);
+  });
+  it.each(["expired", "invalid"])("a %s snapshot reader cannot remove a newly published hold", (kind) => {
+    if (kind === "expired") writeHold(pid, { now: new Date(0) });
+    else fs.writeFileSync(holdPath(pid), "invalid");
+    intercept.reading = () => { writeHold(pid, { reason: "new" }); };
+    expect(readHold(pid)).toBeNull();
+    expect(readHold(pid)?.reason).toBe("new");
+  });
+});

--- a/test/daemon/hold-startup-race.test.ts
+++ b/test/daemon/hold-startup-race.test.ts
@@ -5,7 +5,7 @@ import { createServer } from "node:net";
 import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
-import { registerDaemonStartup } from "../../src/daemon/lifecycle.js";
+import { registerDaemonActivity } from "../../src/daemon/lifecycle.js";
 
 const execute = promisify(execFile);
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -82,7 +82,7 @@ it.each([1, 2])("held stop waits for %i concurrent startup(s) before claiming an
 
 it("held stop fails instead of claiming maintenance readiness when startup never settles", async () => {
   const root = mkdtempSync(join(tmpdir(), "lcm-startup-timeout-"));
-  const unregister = registerDaemonStartup(join(root, "daemon.pid"));
+  const unregister = registerDaemonActivity(join(root, "daemon.pid"));
   // A registration with a live owner must not be signalled: it could be stale
   // and the OS may have reused that PID for an unrelated process.
   writeFileSync(join(root, "config.json"), JSON.stringify({ daemon: { port: 1 } }));

--- a/test/daemon/hold-startup-race.test.ts
+++ b/test/daemon/hold-startup-race.test.ts
@@ -1,0 +1,101 @@
+import { expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createServer } from "node:net";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { registerDaemonStartup } from "../../src/daemon/lifecycle.js";
+
+const execute = promisify(execFile);
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+async function waitFor(predicate: () => boolean) {
+  const deadline = Date.now() + 10000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("startup barrier timed out");
+    await delay(10);
+  }
+}
+
+it.each([1, 2])("held stop waits for %i concurrent startup(s) before claiming an offline window", async (count) => {
+  const root = mkdtempSync(join(tmpdir(), "lcm-startup-race-"));
+  const listener = createServer();
+  await new Promise<void>((resolve) => listener.listen(0, "127.0.0.1", resolve));
+  const port = (listener.address() as { port: number }).port;
+  await new Promise<void>((resolve) => listener.close(() => resolve()));
+  writeFileSync(join(root, "config.json"), JSON.stringify({ daemon: { port } }));
+  const preload = join(root, "pause-start.mjs");
+  // Freeze the real CLI after observing no hold, but before createDaemon.
+  // The stale false result is intentional: another read alone cannot fix this race.
+  writeFileSync(preload, `
+    import fs from 'node:fs';
+    import { syncBuiltinESMExports } from 'node:module';
+    const root = process.env.LCM_HOME;
+    const original = fs.existsSync;
+    let paused = false;
+    fs.existsSync = function(path) {
+      const result = original(path);
+      if (!paused && String(path) === root + '/daemon.hold'
+          && fs.readdirSync(root).some(name => name.startsWith('daemon.starting.' + process.pid + '.'))) {
+        paused = true;
+        fs.writeFileSync(root + '/ready.' + process.pid, '');
+        while (!original(root + '/resume')) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+      }
+      return result;
+    };
+    syncBuiltinESMExports();
+  `);
+  const env = { ...process.env, HOME: root, LCM_HOME: root };
+  const cli = resolve("dist/bin/lcm.js");
+  const starts = Array.from({ length: count }, () => execute(process.execPath,
+    ["--import", preload, cli, "daemon", "start", "--automatic"], { env, timeout: 15000 }));
+  // Attach rejection handlers immediately: cancellation may precede the assertion.
+  const outcomes = starts.map((start) => start.then(() => ({ code: 0, stderr: "", signal: null }),
+    (error: { code: number | null; stderr: string; signal: string | null }) => error));
+  let stop: ReturnType<typeof execute> | undefined;
+  try {
+    await waitFor(() => readdirSync(root).filter((name) => name.startsWith("ready.")).length === count);
+    stop = execute(process.execPath, [cli, "daemon", "stop", "--hold"], { env, timeout: 10000 });
+    let settled = false;
+    void stop.then(() => { settled = true; }, () => { settled = true; });
+    await waitFor(() => existsSync(join(root, "daemon.hold")));
+    await delay(100);
+    expect(settled).toBe(false);
+    writeFileSync(join(root, "resume"), "");
+    for (const outcome of await Promise.all(outcomes)) {
+      // Concurrent starters can lose the listen race, or stop can signal one
+      // after it listens. Every path must terminate before stop succeeds.
+      if (outcome.code === 1) expect(outcome.stderr).toContain("already in use");
+      else if (outcome.signal) expect(outcome.signal).toBe("SIGTERM");
+      else expect(outcome.code).toBe(75);
+    }
+    await expect(stop).resolves.toMatchObject({ stderr: "" });
+    await expect(fetch(`http://127.0.0.1:${port}/health`)).rejects.toThrow();
+    expect(readdirSync(root).filter((name) => name.startsWith("daemon.starting."))).toEqual([]);
+  } finally {
+    writeFileSync(join(root, "resume"), "");
+    for (const start of starts) start.child.kill();
+    await Promise.allSettled([...outcomes, ...(stop ? [stop] : [])]);
+    rmSync(root, { recursive: true, force: true });
+  }
+}, 20000);
+
+it("held stop fails instead of claiming maintenance readiness when startup never settles", async () => {
+  const root = mkdtempSync(join(tmpdir(), "lcm-startup-timeout-"));
+  const unregister = registerDaemonStartup(join(root, "daemon.pid"));
+  // A registration with a live owner must not be signalled: it could be stale
+  // and the OS may have reused that PID for an unrelated process.
+  writeFileSync(join(root, "config.json"), JSON.stringify({ daemon: { port: 1 } }));
+  try {
+    const result = await execute(process.execPath, [resolve("dist/bin/lcm.js"), "daemon", "stop", "--hold"], {
+      env: { ...process.env, HOME: root, LCM_HOME: root }, timeout: 10000,
+    }).then(() => { throw new Error("stop must not succeed"); }, (error) => error);
+    expect(result.code).toBe(1);
+    expect(result.stderr).toContain("still up");
+    expect(result.stdout).not.toContain("held down until");
+    expect(existsSync(join(root, "daemon.hold"))).toBe(true);
+  } finally {
+    unregister();
+    rmSync(root, { recursive: true, force: true });
+  }
+}, 15000);

--- a/test/daemon/hold-startup.test.ts
+++ b/test/daemon/hold-startup.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { createServer, type Server } from "node:http";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { register } from "../../hooks/lcm-hooks.js";
+import { lcmHome } from "../../src/lcm-home.js";
+import { createLcmPaths } from "../../src/lcm-paths.js";
+import { clearHold, readHold, writeHold } from "../../src/daemon/hold.js";
+import { ensureDaemon } from "../../src/daemon/lifecycle.js";
+
+const execute = promisify(execFile);
+let dir: string, home: string, root: string, pid: string, server: Server, requests: number;
+let env: NodeJS.ProcessEnv;
+beforeEach(async () => {
+  dir = mkdtempSync(join(tmpdir(), "hold-start-"));
+  home = join(dir, "home"); root = join(dir, "storage");
+  mkdirSync(home); mkdirSync(root);
+  env = { ...process.env, HOME: home, LCM_HOME: root };
+  pid = createLcmPaths(lcmHome(env)).pidPath;
+  requests = 0;
+  server = createServer((_req, res) => { requests++; res.setHeader("content-type", "application/json"); res.end(JSON.stringify({ status: "ok", version: "test" })); });
+  await new Promise<void>(r => server.listen(0, "127.0.0.1", r));
+  writeFileSync(join(root, "config.json"), JSON.stringify({ daemon: { port: (server.address() as any).port } }));
+});
+afterEach(async () => { await new Promise<void>(r => server.close(() => r())); rmSync(dir, { recursive: true, force: true }); });
+const cli = (...args: string[]) => execute(process.execPath, [resolve("dist/bin/lcm.js"), "daemon", "start", ...args], { env, timeout: 10000 });
+
+it("automatic built CLI preserves the LCM_HOME hold; explicit start releases it", async () => {
+  const hold = writeHold(pid);
+  await cli("--automatic", "--detach");
+  expect(readHold(pid)).toEqual(hold);
+  expect(requests).toBe(0);
+  const result = await ensureDaemon({ port: (server.address() as any).port, pidFilePath: pid, spawnTimeoutMs: 100 });
+  expect(result).toMatchObject({ connected: false, spawned: false });
+  expect(requests).toBe(0);
+  expect(clearHold(pid)).toBe(true);
+  writeHold(pid);
+  await cli();
+  expect(readHold(pid)).toBeNull();
+  expect(requests).toBe(1);
+  expect(existsSync(join(home, ".lossless-claude"))).toBe(false);
+});
+
+it("a function-hook tool event cannot release a hold through its actual startup command", async () => {
+  const held = writeHold(pid);
+  const handlers = new Map<string, any>();
+  register(((event: string, callback: any) => handlers.set(event, callback)) as any, {} as any);
+  const commands: string[] = [];
+  const engine = {
+    session: { id: async () => "hold-test", cwd: async () => dir },
+    ui: { log: () => {} },
+    http: { fetch: async () => { throw new Error("offline"); } },
+    process: { run: async (args: string[]) => {
+      const command = args[2];
+      if (command.includes("__CONFIG__")) return { stdout: `\n__CONFIG__\n{}\n__TMPDIR__\n${dir}`, stderr: "", exitCode: 0 };
+      commands.push(command);
+      const suffix = command.split("exec lcm daemon start ")[1].split(" ");
+      const result = await cli(...suffix);
+      return { ...result, exitCode: 0 };
+    } },
+  };
+  await handlers.get("tool.call")(engine, { tool: "Read", tool_use_id: "one" }, async () => ({ result: "ok" }));
+  expect(commands).toHaveLength(1);
+  expect(readHold(pid)).toEqual(held);
+  expect(requests).toBe(0);
+  expect(existsSync(join(home, ".lossless-claude"))).toBe(false);
+});

--- a/test/daemon/hold-startup.test.ts
+++ b/test/daemon/hold-startup.test.ts
@@ -30,7 +30,7 @@ const cli = (...args: string[]) => execute(process.execPath, [resolve("dist/bin/
 
 it("automatic built CLI preserves the LCM_HOME hold; explicit start releases it", async () => {
   const hold = writeHold(pid);
-  await cli("--automatic", "--detach");
+  await expect(cli("--automatic", "--detach")).rejects.toMatchObject({ code: 75 });
   expect(readHold(pid)).toEqual(hold);
   expect(requests).toBe(0);
   const result = await ensureDaemon({ port: (server.address() as any).port, pidFilePath: pid, spawnTimeoutMs: 100 });
@@ -44,7 +44,7 @@ it("automatic built CLI preserves the LCM_HOME hold; explicit start releases it"
   expect(existsSync(join(home, ".lossless-claude"))).toBe(false);
 });
 
-it("a function-hook tool event cannot release a hold through its actual startup command", async () => {
+it("function hooks preserve a hold and resume immediately after expiry without a restart cooldown", async () => {
   const held = writeHold(pid);
   const handlers = new Map<string, any>();
   register(((event: string, callback: any) => handlers.set(event, callback)) as any, {} as any);
@@ -58,13 +58,22 @@ it("a function-hook tool event cannot release a hold through its actual startup 
       if (command.includes("__CONFIG__")) return { stdout: `\n__CONFIG__\n{}\n__TMPDIR__\n${dir}`, stderr: "", exitCode: 0 };
       commands.push(command);
       const suffix = command.split("exec lcm daemon start ")[1].split(" ");
-      const result = await cli(...suffix);
-      return { ...result, exitCode: 0 };
+      try {
+        const result = await cli(...suffix);
+        return { ...result, exitCode: 0 };
+      } catch (error) {
+        const result = error as { code: number; stdout: string; stderr: string };
+        return { ...result, exitCode: result.code };
+      }
     } },
   };
   await handlers.get("tool.call")(engine, { tool: "Read", tool_use_id: "one" }, async () => ({ result: "ok" }));
   expect(commands).toHaveLength(1);
   expect(readHold(pid)).toEqual(held);
   expect(requests).toBe(0);
+  writeFileSync(join(root, "daemon.hold"), JSON.stringify({ ...held, until: new Date(Date.now() - 1).toISOString() }));
+  await handlers.get("tool.call")(engine, { tool: "Read", tool_use_id: "two" }, async () => ({ result: "ok" }));
+  expect(commands).toHaveLength(2);
+  expect(requests).toBe(1);
   expect(existsSync(join(home, ".lossless-claude"))).toBe(false);
 });

--- a/test/daemon/hold.test.ts
+++ b/test/daemon/hold.test.ts
@@ -50,6 +50,30 @@ describe("hold marker", () => {
     expect(existsSync(holdPath(pidFilePath))).toBe(false);
   });
 
+  it.each([
+    null, [], "hold", 42,
+    { until: "2099-01-01T00:00:00.000Z" },
+    { pid: "42", until: "2099-01-01T00:00:00.000Z" },
+    { pid: 0, until: "2099-01-01T00:00:00.000Z" },
+    { pid: 1.5, until: "2099-01-01T00:00:00.000Z" },
+    { pid: 42, until: 4102444800000 },
+    { pid: 42, until: "invalid" },
+    { pid: 42, until: "2099-01-01T00:00:00.000Z", reason: {} },
+  ])("removes a malformed marker: %j", (value) => {
+    writeFileSync(holdPath(pidFilePath), JSON.stringify(value));
+    expect(readHold(pidFilePath)).toBeNull();
+    expect(existsSync(holdPath(pidFilePath))).toBe(false);
+  });
+
+  it.each([NaN, Infinity, -Infinity, 0, -1, Number.MAX_VALUE])(
+    "rejects invalid duration %s without replacing an existing hold",
+    (minutes) => {
+      const existing = writeHold(pidFilePath, { reason: "maintenance" });
+      expect(() => writeHold(pidFilePath, { minutes })).toThrow(/Hold minutes/);
+      expect(readHold(pidFilePath)).toEqual(existing);
+    },
+  );
+
   it("clearHold reports whether a marker was there", () => {
     expect(clearHold(pidFilePath)).toBe(false);
     writeHold(pidFilePath, {});

--- a/test/daemon/hold.test.ts
+++ b/test/daemon/hold.test.ts
@@ -36,18 +36,18 @@ describe("hold marker", () => {
     expect(hold.until).toBe(new Date(now.getTime() + DEFAULT_HOLD_MINUTES * 60_000).toISOString());
   });
 
-  it("treats an expired hold as no hold, and removes it", () => {
+  it("treats an expired hold as no hold, without removing it", () => {
     const now = new Date("2026-01-01T00:00:00.000Z");
     writeHold(pidFilePath, { minutes: 10, now });
     const later = new Date(now.getTime() + 11 * 60_000);
     expect(readHold(pidFilePath, later)).toBeNull();
-    expect(existsSync(holdPath(pidFilePath))).toBe(false);
+    expect(existsSync(holdPath(pidFilePath))).toBe(true);
   });
 
-  it("treats a corrupt marker as no hold, and removes it", () => {
+  it("treats a corrupt marker as no hold, without removing it", () => {
     writeFileSync(holdPath(pidFilePath), "not json");
     expect(readHold(pidFilePath)).toBeNull();
-    expect(existsSync(holdPath(pidFilePath))).toBe(false);
+    expect(existsSync(holdPath(pidFilePath))).toBe(true);
   });
 
   it.each([
@@ -59,10 +59,10 @@ describe("hold marker", () => {
     { pid: 42, until: 4102444800000 },
     { pid: 42, until: "invalid" },
     { pid: 42, until: "2099-01-01T00:00:00.000Z", reason: {} },
-  ])("removes a malformed marker: %j", (value) => {
+  ])("ignores a malformed marker: %j", (value) => {
     writeFileSync(holdPath(pidFilePath), JSON.stringify(value));
     expect(readHold(pidFilePath)).toBeNull();
-    expect(existsSync(holdPath(pidFilePath))).toBe(false);
+    expect(existsSync(holdPath(pidFilePath))).toBe(true);
   });
 
   it.each([NaN, Infinity, -Infinity, 0, -1, Number.MAX_VALUE])(
@@ -91,6 +91,14 @@ describe("hold marker", () => {
 });
 
 describe("ensureDaemon under a hold", () => {
+  it("honors a hold established while the health request is in flight", async () => {
+    const result = await ensureDaemon({
+      port: 39999, pidFilePath, spawnTimeoutMs: 100,
+      _fetchOverride: (async () => { writeHold(pidFilePath); throw new Error("down"); }) as typeof fetch,
+      _spawnOverride: (() => { throw new Error("must not spawn after hold"); }) as never,
+    });
+    expect(result).toEqual({ connected: false, port: 39999, spawned: false });
+  });
   it("refuses to spawn, and never asks the daemon anything", async () => {
     writeHold(pidFilePath, { reason: "maintenance" });
     let fetched = 0;

--- a/test/daemon/hold.test.ts
+++ b/test/daemon/hold.test.ts
@@ -1,9 +1,24 @@
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DEFAULT_HOLD_MINUTES, clearHold, holdPath, readHold, writeHold } from "../../src/daemon/hold.js";
 import { ensureDaemon } from "../../src/daemon/lifecycle.js";
+
+const interleave = vi.hoisted(() => ({ afterUnlink: undefined as (() => void) | undefined }));
+vi.mock("node:fs", async (original) => {
+  const actual = await original<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn(actual.existsSync),
+    unlinkSync: (path: string) => {
+      actual.unlinkSync(path);
+      const callback = interleave.afterUnlink;
+      interleave.afterUnlink = undefined;
+      callback?.();
+    },
+  };
+});
 
 let dir: string;
 let pidFilePath: string;
@@ -14,6 +29,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  interleave.afterUnlink = undefined;
   rmSync(dir, { recursive: true, force: true });
 });
 
@@ -79,6 +95,24 @@ describe("hold marker", () => {
     writeHold(pidFilePath, {});
     expect(clearHold(pidFilePath)).toBe(true);
     expect(readHold(pidFilePath)).toBeNull();
+  });
+
+  it("preserves a hold published immediately after atomic release", () => {
+    writeHold(pidFilePath, { reason: "old" });
+    interleave.afterUnlink = () => {
+      writeHold(pidFilePath, { reason: "new" });
+    };
+    vi.mocked(existsSync).mockClear();
+    expect(clearHold(pidFilePath)).toBe(true);
+    expect(existsSync).not.toHaveBeenCalled();
+    expect(readHold(pidFilePath)?.reason).toBe("new");
+  });
+
+  it("surfaces filesystem failures instead of claiming the hold was absent", () => {
+    // A directory at the marker path cannot be unlinked as a file.
+    mkdirSync(holdPath(pidFilePath));
+    expect(() => clearHold(pidFilePath)).toThrow();
+    expect(existsSync(holdPath(pidFilePath))).toBe(true);
   });
 
   it("a later hold replaces an earlier one", () => {

--- a/test/daemon/hold.test.ts
+++ b/test/daemon/hold.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { DEFAULT_HOLD_MINUTES, clearHold, holdPath, readHold, writeHold } from "../../src/daemon/hold.js";
+import { ensureDaemon } from "../../src/daemon/lifecycle.js";
+
+let dir: string;
+let pidFilePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "lcm-hold-"));
+  pidFilePath = join(dir, "daemon.pid");
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("hold marker", () => {
+  it("reports no hold when none was placed", () => {
+    expect(readHold(pidFilePath)).toBeNull();
+  });
+
+  it("reads back a hold it wrote", () => {
+    const written = writeHold(pidFilePath, { reason: "retag" });
+    const read = readHold(pidFilePath);
+    expect(read?.reason).toBe("retag");
+    expect(read?.until).toBe(written.until);
+    expect(read?.pid).toBe(process.pid);
+  });
+
+  it("defaults the expiry to DEFAULT_HOLD_MINUTES", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    const hold = writeHold(pidFilePath, { now });
+    expect(hold.until).toBe(new Date(now.getTime() + DEFAULT_HOLD_MINUTES * 60_000).toISOString());
+  });
+
+  it("treats an expired hold as no hold, and removes it", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    writeHold(pidFilePath, { minutes: 10, now });
+    const later = new Date(now.getTime() + 11 * 60_000);
+    expect(readHold(pidFilePath, later)).toBeNull();
+    expect(existsSync(holdPath(pidFilePath))).toBe(false);
+  });
+
+  it("treats a corrupt marker as no hold, and removes it", () => {
+    writeFileSync(holdPath(pidFilePath), "not json");
+    expect(readHold(pidFilePath)).toBeNull();
+    expect(existsSync(holdPath(pidFilePath))).toBe(false);
+  });
+
+  it("clearHold reports whether a marker was there", () => {
+    expect(clearHold(pidFilePath)).toBe(false);
+    writeHold(pidFilePath, {});
+    expect(clearHold(pidFilePath)).toBe(true);
+    expect(readHold(pidFilePath)).toBeNull();
+  });
+
+  it("a later hold replaces an earlier one", () => {
+    const now = new Date("2026-01-01T00:00:00.000Z");
+    writeHold(pidFilePath, { minutes: 5, reason: "first", now });
+    writeHold(pidFilePath, { minutes: 60, reason: "second", now });
+    const hold = readHold(pidFilePath, new Date(now.getTime() + 10 * 60_000));
+    expect(hold?.reason).toBe("second");
+  });
+});
+
+describe("ensureDaemon under a hold", () => {
+  it("refuses to spawn, and never asks the daemon anything", async () => {
+    writeHold(pidFilePath, { reason: "maintenance" });
+    let fetched = 0;
+    const result = await ensureDaemon({
+      port: 39999,
+      pidFilePath,
+      spawnTimeoutMs: 100,
+      _fetchOverride: (async () => { fetched++; throw new Error("unreachable"); }) as unknown as typeof globalThis.fetch,
+      _spawnOverride: (() => { throw new Error("must not spawn under a hold"); }) as never,
+    });
+    expect(result).toEqual({ connected: false, port: 39999, spawned: false });
+    expect(fetched).toBe(0);
+  });
+
+  it("resumes normally once the hold expires", async () => {
+    const now = new Date();
+    writeHold(pidFilePath, { minutes: 1, now: new Date(now.getTime() - 120_000) });
+    let fetched = 0;
+    const result = await ensureDaemon({
+      port: 39999,
+      pidFilePath,
+      spawnTimeoutMs: 100,
+      _skipSpawn: true,
+      _fetchOverride: (async () => { fetched++; throw new Error("down"); }) as unknown as typeof globalThis.fetch,
+    });
+    expect(result.spawned).toBe(false);
+    expect(fetched).toBeGreaterThan(0);
+  });
+});

--- a/test/daemon/lifecycle.test.ts
+++ b/test/daemon/lifecycle.test.ts
@@ -13,6 +13,30 @@ afterEach(() => {
 });
 
 describe("ensureDaemon", () => {
+  it.each(["/checkout/bin/lcm.ts", "/checkout/dist/bin/lcm.js"])("preserves only source loader flags for %s", async (entrypoint) => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-source-spawn-"));
+    tempDirs.push(tempDir);
+    const spawnMock = vi.fn().mockReturnValue({ pid: 12345, unref: vi.fn() });
+    const originalArgv = process.argv;
+    const originalExecArgv = process.execArgv;
+    process.argv = [process.execPath, entrypoint];
+    process.execArgv = ["--inspect=9229", "--require", "/tsx/preflight.cjs", "--import=file:///tsx/loader.mjs", "--eval", "not child code"];
+    try {
+      await ensureDaemon({
+        port: 1, pidFilePath: join(tempDir, "daemon.pid"), spawnTimeoutMs: 100,
+        _fetchOverride: (async () => { throw new Error("offline"); }) as typeof fetch,
+        _skipHealthWait: true, _spawnOverride: spawnMock as any,
+      });
+      expect(spawnMock.mock.calls[0][1]).toEqual([
+        ...(entrypoint.endsWith(".ts") ? ["--require", "/tsx/preflight.cjs", "--import=file:///tsx/loader.mjs"] : []),
+        entrypoint, "daemon", "start", "--automatic",
+      ]);
+    } finally {
+      process.argv = originalArgv;
+      process.execArgv = originalExecArgv;
+    }
+  });
+
   it("connects to existing healthy daemon", async () => {
     const { createDaemon } = await import("../../src/daemon/server.js");
     const { loadDaemonConfig } = await import("../../src/daemon/config.js");

--- a/test/daemon/lifecycle.test.ts
+++ b/test/daemon/lifecycle.test.ts
@@ -202,6 +202,9 @@ describe("ensureDaemon", () => {
 
     expect(result.connected).toBe(false);
     expect(result.spawned).toBe(true);
+    // Only a listening child owns daemon.pid; the spawner must not race its
+    // startup registration or overwrite a concurrently successful child.
+    expect(existsSync(pidFile)).toBe(false);
     expect(spawnMock).toHaveBeenCalledWith(
       "lcm",
       ["daemon", "start"],

--- a/test/daemon/version.test.ts
+++ b/test/daemon/version.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
 import { copyFileSync, mkdirSync, mkdtempSync, rmSync, statSync, utimesSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 import { BUILD_ID, fingerprintFile, readBuildIdFile } from "../../src/daemon/version.js";
 
@@ -33,6 +33,23 @@ describe("BUILD_ID", () => {
   it("is a 16-char lowercase hex fingerprint", () => {
     expect(BUILD_ID).toBeDefined();
     expect(BUILD_ID).toMatch(HEX16);
+  });
+});
+
+describe("PKG_VERSION", () => {
+  it.each(["src/daemon", "dist/src/daemon"])("reads LCM's own package in a nested %s layout", (layout) => {
+    const parent = newTempDir();
+    const checkout = join(parent, "lcm");
+    const moduleDir = join(checkout, layout);
+    mkdirSync(moduleDir, { recursive: true });
+    writeFileSync(join(parent, "package.json"), JSON.stringify({ name: "enclosing-project", version: "99.0.0" }));
+    writeFileSync(join(checkout, "package.json"), JSON.stringify({ name: "@lossless-claude/lcm", version: "1.2.3" }));
+    const modulePath = join(moduleDir, "version.mjs");
+    copyFileSync(resolve("dist/src/daemon/version.js"), modulePath);
+    const result = execFileSync(process.execPath, ["--input-type=module", "-e",
+      `import { PKG_VERSION } from ${JSON.stringify(pathToFileURL(modulePath).href)}; console.log(PKG_VERSION);`,
+    ], { encoding: "utf8" });
+    expect(result.trim()).toBe("1.2.3");
   });
 });
 

--- a/test/db/events-stats.test.ts
+++ b/test/db/events-stats.test.ts
@@ -1,6 +1,7 @@
 // test/db/events-stats.test.ts
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -9,7 +10,7 @@ vi.mock("../../src/db/events-path.js", () => ({
   eventsDir: () => mockEventsDir,
 }));
 
-import { collectEventStats } from "../../src/db/events-stats.js";
+import { collectEventStats, collectDetailedEventStats } from "../../src/db/events-stats.js";
 import { EventsDb } from "../../src/hooks/events-db.js";
 
 describe("collectEventStats", () => {
@@ -49,6 +50,33 @@ describe("collectEventStats", () => {
     expect(stats.errors).toBe(1);
     expect(stats.scanned).toBe(2);
     expect(stats.total).toBe(2);
+    const detailed = collectDetailedEventStats();
+    expect(detailed).toMatchObject(stats);
+    expect(detailed.projects).toHaveLength(2);
+    expect(detailed.recentErrors).toEqual([expect.objectContaining({ hook: "PostToolUse", error: "err1" })]);
+  });
+
+  it.each([collectEventStats, collectDetailedEventStats])("reads legacy sidecars without changing their schema or bytes (%s)", (collect) => {
+    const path = join(tempDir, "legacy.db");
+    const db = new DatabaseSync(path);
+    db.exec(`
+      PRAGMA user_version = 1;
+      CREATE TABLE events (event_id INTEGER PRIMARY KEY, created_at TEXT, processed_at TEXT);
+      CREATE TABLE error_log (id INTEGER PRIMARY KEY, created_at TEXT, hook TEXT, error TEXT);
+      INSERT INTO events VALUES (1, datetime('now'), NULL);
+      INSERT INTO error_log VALUES (1, datetime('now'), 'PostToolUse', 'legacy error');
+    `);
+    const schema = db.prepare("SELECT sql FROM sqlite_master ORDER BY name").all();
+    db.close();
+    const before = readFileSync(path);
+    expect(collect()).toMatchObject({ captured: 1, unprocessed: 1, errors: 1, scanned: 1, total: 1 });
+    expect(readFileSync(path)).toEqual(before);
+    expect(readdirSync(tempDir)).toEqual(["legacy.db"]);
+    const inspect = new DatabaseSync(path, { readOnly: true });
+    try {
+      expect(inspect.prepare("PRAGMA user_version").get()).toMatchObject({ user_version: 1 });
+      expect(inspect.prepare("SELECT sql FROM sqlite_master ORDER BY name").all()).toEqual(schema);
+    } finally { inspect.close(); }
   });
 
   it("skips non-.db files in events directory", () => {

--- a/test/db/events-stats.test.ts
+++ b/test/db/events-stats.test.ts
@@ -79,6 +79,52 @@ describe("collectEventStats", () => {
     } finally { inspect.close(); }
   });
 
+  it.each([collectEventStats, collectDetailedEventStats])("reads v1 sidecars without error_log or mutations (%s)", (collect) => {
+    const path = join(tempDir, "v1.db");
+    const db = new DatabaseSync(path);
+    db.exec(`
+      CREATE TABLE schema_version (version INTEGER NOT NULL);
+      INSERT INTO schema_version VALUES (1);
+      CREATE TABLE events (
+        event_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        seq INTEGER NOT NULL DEFAULT 0,
+        type TEXT NOT NULL,
+        category TEXT NOT NULL,
+        data TEXT NOT NULL,
+        priority INTEGER DEFAULT 3,
+        source_hook TEXT NOT NULL,
+        prev_event_id INTEGER,
+        processed_at TEXT,
+        created_at TEXT DEFAULT (datetime('now'))
+      );
+      INSERT INTO events (session_id, type, category, data, source_hook, created_at)
+        VALUES ('s1', 'file', 'pattern', 'file.ts', 'PostToolUse', '2026-01-02 03:04:05');
+      INSERT INTO events (session_id, type, category, data, source_hook, created_at, processed_at)
+        VALUES ('s1', 'file', 'pattern', 'other.ts', 'PostToolUse', '2026-01-01 03:04:05', '2026-01-02');
+    `);
+    const schema = db.prepare("SELECT sql FROM sqlite_master ORDER BY name").all();
+    db.close();
+    const before = readFileSync(path);
+    const stats = collect();
+    expect(stats).toMatchObject({
+      captured: 2, unprocessed: 1, errors: 0, lastCapture: "2026-01-02 03:04:05", scanned: 1, total: 1,
+    });
+    if ("projects" in stats) {
+      expect(stats.projects).toEqual([{
+        file: "v1.db", captured: 2, unprocessed: 1, lastCapture: "2026-01-02 03:04:05",
+      }]);
+      expect(stats.recentErrors).toEqual([]);
+    }
+    expect(readFileSync(path)).toEqual(before);
+    expect(readdirSync(tempDir)).toEqual(["v1.db"]);
+    const inspect = new DatabaseSync(path, { readOnly: true });
+    try {
+      expect(inspect.prepare("SELECT version FROM schema_version").get()).toMatchObject({ version: 1 });
+      expect(inspect.prepare("SELECT sql FROM sqlite_master ORDER BY name").all()).toEqual(schema);
+    } finally { inspect.close(); }
+  });
+
   it("skips non-.db files in events directory", () => {
     const { writeFileSync } = require("node:fs");
     writeFileSync(join(tempDir, "not-a-db.txt"), "hello");

--- a/test/hooks/user-prompt.test.ts
+++ b/test/hooks/user-prompt.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { createHash } from "node:crypto";
 import { handleUserPromptSubmit } from "../../src/hooks/user-prompt.js";
 
-vi.mock("../../src/daemon/lifecycle.js", () => ({
+vi.mock("../../src/daemon/lifecycle.js", async (original) => ({
+  ...await original<typeof import("../../src/daemon/lifecycle.js")>(),
   ensureDaemon: vi.fn(),
 }));
 

--- a/test/hooks/write-admission.test.ts
+++ b/test/hooks/write-admission.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { existsSync, mkdtempSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { clearHold, writeHold } from "../../src/daemon/hold.js";
+import { recordPostToolEvents } from "../../src/hooks/post-tool.js";
+import { recordUserPromptEvents } from "../../src/hooks/user-prompt.js";
+import { safeLogError, _resetCircuitBreaker } from "../../src/hooks/hook-errors.js";
+
+vi.mock("../../src/db/events-path.js", () => ({
+  eventsDbPath: () => join(process.env.LCM_HOME!, "events", "test.db"),
+}));
+
+let root: string;
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "lcm-hook-admission-"));
+  vi.stubEnv("LCM_HOME", root);
+  vi.stubEnv("LCM_LOG_PATH", join(root, "events.log"));
+  _resetCircuitBreaker();
+});
+afterEach(() => { vi.unstubAllEnvs(); rmSync(root, { recursive: true, force: true }); });
+
+const payload = { session_id: "test", cwd: "/project", tool_name: "AskUserQuestion",
+  tool_input: { question: "Use SQLite?" }, tool_response: "yes" };
+
+it("blocks every direct hook sidecar writer and error-log fallback while held", async () => {
+  writeHold(join(root, "daemon.pid"));
+  expect(recordPostToolEvents(payload).recorded).toBe(0);
+  expect(await recordUserPromptEvents("Always use TypeScript", "test", "/project")).toBe(0);
+  safeLogError("PostToolUse", new Error("held"), { cwd: "/project" });
+  safeLogError("PostToolUse", new Error("held fallback"), {});
+  expect(readdirSync(root)).toEqual(["daemon.hold"]);
+  clearHold(join(root, "daemon.pid"));
+  expect(recordPostToolEvents(payload).recorded).toBeGreaterThan(0);
+  expect(await recordUserPromptEvents("Always use TypeScript", "test", "/project")).toBeGreaterThan(0);
+  safeLogError("PostToolUse", new Error("resumed fallback"), {});
+  expect(existsSync(join(root, "events.log"))).toBe(true);
+  expect(readdirSync(root).some((name) => name.startsWith("daemon.starting."))).toBe(false);
+});
+
+it("held stop drains a command-hook write already inside SQLite before succeeding", async () => {
+  const execute = promisify(execFile);
+  const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+  async function waitFor(predicate: () => boolean) {
+    const deadline = Date.now() + 10000;
+    while (!predicate()) {
+      if (Date.now() >= deadline) throw new Error("hook barrier timed out");
+      await delay(10);
+    }
+  }
+  writeFileSync(join(root, "config.json"), JSON.stringify({ daemon: { port: 1 } }));
+  const script = join(root, "writer.mjs");
+  const moduleUrl = (file: string) => JSON.stringify(pathToFileURL(resolve("dist/src/hooks", file)).href);
+  writeFileSync(script, `
+    import fs from 'node:fs';
+    import { EventsDb } from ${moduleUrl("events-db.js")};
+    import { recordPostToolEvents } from ${moduleUrl("post-tool.js")};
+    const root = process.env.LCM_HOME;
+    const insert = EventsDb.prototype.insertToolCallEvents;
+    EventsDb.prototype.insertToolCallEvents = function(...args) {
+      fs.writeFileSync(root + '/ready', '');
+      while (!fs.existsSync(root + '/resume')) Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+      return insert.apply(this, args);
+    };
+    console.log(recordPostToolEvents(${JSON.stringify(payload)}).recorded);
+  `);
+  const env = { ...process.env, HOME: root, LCM_HOME: root };
+  const writer = execute(process.execPath, [script], { env, timeout: 15000 });
+  const writerDone = writer.then((result) => result, (error) => { throw error; });
+  void writerDone.catch(() => {});
+  let stop: ReturnType<typeof execute> | undefined;
+  try {
+    await waitFor(() => existsSync(join(root, "ready")));
+    stop = execute(process.execPath, [resolve("dist/bin/lcm.js"), "daemon", "stop", "--hold"], { env, timeout: 10000 });
+    let stopped = false;
+    void stop.then(() => { stopped = true; }, () => { stopped = true; });
+    await waitFor(() => existsSync(join(root, "daemon.hold")));
+    await delay(100);
+    expect(stopped).toBe(false);
+    writeFileSync(join(root, "resume"), "");
+    expect(Number((await writerDone).stdout.trim())).toBeGreaterThan(0);
+    await expect(stop).resolves.toMatchObject({ stderr: "" });
+    expect(readdirSync(root).some((name) => name.startsWith("daemon.starting."))).toBe(false);
+  } finally {
+    writeFileSync(join(root, "resume"), "");
+    writer.child.kill();
+    await Promise.allSettled([writerDone, ...(stop ? [stop] : [])]);
+  }
+}, 20000);

--- a/test/mcp/hold-drain.test.ts
+++ b/test/mcp/hold-drain.test.ts
@@ -1,0 +1,61 @@
+import { expect, it, vi } from "vitest";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { writeHold } from "../../src/daemon/hold.js";
+import { stopDaemon } from "../../src/daemon/lifecycle.js";
+import { startMcpServer } from "../../src/mcp/server.js";
+
+const state = vi.hoisted(() => {
+  let release!: () => void;
+  return { root: "", accessed: false, handlers: new Map<string, any>(),
+    gate: new Promise<void>((resolve) => { release = resolve; }), release: () => release() };
+});
+vi.mock("../../src/lcm-home.js", () => ({ lcmPath: (name: string) => `${state.root}/${name}` }));
+vi.mock("../../src/daemon/config.js", () => ({ loadDaemonConfig: () => ({ daemon: { port: 1 } }) }));
+vi.mock("../../src/daemon/lifecycle.js", async (original) => ({
+  ...await original<typeof import("../../src/daemon/lifecycle.js")>(),
+  ensureDaemon: vi.fn().mockResolvedValue({ connected: false }),
+}));
+vi.mock("@modelcontextprotocol/server", () => ({
+  Server: class { setRequestHandler(name: string, handler: any) { state.handlers.set(name, handler); } },
+}));
+vi.mock("@modelcontextprotocol/server/stdio", () => ({ serveStdio: vi.fn() }));
+vi.mock("../../src/stats.js", async () => {
+  await state.gate;
+  return { formatNumber: String, collectStats: () => {
+    state.accessed = true;
+    throw new Error("simulated database failure");
+  } };
+});
+
+it("held stop waits for an admitted local MCP operation, including its error cleanup", async () => {
+  state.root = mkdtempSync(join(tmpdir(), "lcm-mcp-drain-"));
+  const pidFilePath = join(state.root, "daemon.pid");
+  let request: Promise<any> | undefined;
+  let stopping: Promise<any> | undefined;
+  try {
+    await startMcpServer();
+    request = state.handlers.get("tools/call")({ params: { name: "lcm_stats", arguments: {} } });
+    expect(readdirSync(state.root).some((name) => name.startsWith("daemon.starting."))).toBe(true);
+    writeHold(pidFilePath);
+    let stopped = false;
+    stopping = stopDaemon({ port: 1, pidFilePath, timeoutMs: 1000,
+      _fetchOverride: vi.fn().mockRejectedValue(new TypeError("offline")) }).then((result) => {
+      stopped = true;
+      return result;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 30));
+    expect(stopped).toBe(false);
+    expect(state.accessed).toBe(false);
+    state.release();
+    expect((await request).isError).toBe(true);
+    expect(state.accessed).toBe(true);
+    await expect(stopping).resolves.toMatchObject({ stopped: true });
+    expect(readdirSync(state.root).some((name) => name.startsWith("daemon.starting."))).toBe(false);
+  } finally {
+    state.release();
+    await Promise.allSettled([request, stopping]);
+    rmSync(state.root, { recursive: true, force: true });
+  }
+});

--- a/test/mcp/protocol.test.ts
+++ b/test/mcp/protocol.test.ts
@@ -12,6 +12,7 @@ const state = vi.hoisted(() => ({
 
 vi.mock("../../src/daemon/lifecycle.js", () => ({
   ensureDaemon: vi.fn().mockResolvedValue({ connected: true }),
+  registerDaemonActivity: vi.fn(() => vi.fn()),
 }));
 vi.mock("../../src/daemon/config.js", () => ({
   loadDaemonConfig: () => ({ daemon: { port: 9999 } }),

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -11,6 +11,7 @@ afterEach(() => { holdMock.mockReturnValue(null); });
 
 vi.mock("../../src/daemon/lifecycle.js", () => ({
   ensureDaemon: ensureDaemonMcpMock,
+  registerDaemonActivity: vi.fn(() => vi.fn()),
 }));
 vi.mock("../../src/daemon/config.js", () => ({
   loadDaemonConfig: vi.fn().mockReturnValue({ daemon: { port: 9999 } }),

--- a/test/mcp/server.test.ts
+++ b/test/mcp/server.test.ts
@@ -1,7 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { getMcpToolDefinitions, handleDaemonRequest } from "../../src/mcp/server.js";
 
 const ensureDaemonMcpMock = vi.hoisted(() => vi.fn().mockResolvedValue({ connected: true, port: 9999, spawned: false }));
+
+const holdMock = vi.hoisted(() => vi.fn().mockReturnValue(null));
+const collectStatsMock = vi.hoisted(() => vi.fn(() => { throw new Error("database access during hold"); }));
+vi.mock("../../src/daemon/hold.js", () => ({ readHold: holdMock }));
+vi.mock("../../src/stats.js", () => ({ collectStats: collectStatsMock, formatNumber: String }));
+afterEach(() => { holdMock.mockReturnValue(null); });
 
 vi.mock("../../src/daemon/lifecycle.js", () => ({
   ensureDaemon: ensureDaemonMcpMock,
@@ -196,4 +202,18 @@ describe("handleDaemonRequest spawn opts propagation", () => {
     expect(callArgs.spawnCommand).toBeUndefined();
     expect(callArgs.spawnArgs).toBeUndefined();
   });
+});
+
+it("blocks local database tools when a hold begins after MCP startup", async () => {
+  const { Server } = await import("@modelcontextprotocol/server");
+  const { startMcpServer } = await import("../../src/mcp/server.js");
+  await startMcpServer();
+  const server = vi.mocked(Server).mock.results.at(-1)!.value;
+  const handler = server.setRequestHandler.mock.calls.find(([method]: [string]) => method === "tools/call")[1];
+  holdMock.mockReturnValue({ until: "2099-01-01T00:00:00.000Z", pid: 1 });
+  collectStatsMock.mockClear();
+  const result = await handler({ params: { name: "lcm_stats", arguments: {} } });
+  expect(result.isError).toBe(true);
+  expect(result.content[0].text).toContain("held down until");
+  expect(collectStatsMock).not.toHaveBeenCalled();
 });

--- a/test/stats-readonly.test.ts
+++ b/test/stats-readonly.test.ts
@@ -33,3 +33,27 @@ it.each([false, true])("stats during a hold never migrates or writes project dat
   expect(readFileSync(path)).toEqual(before);
   expect(stats.messages).toBe(current ? 1 : 0);
 });
+
+it.each([false, true])("keeps legacy project counts when optional metrics are absent (partial usage: %s)", (usage) => {
+  root = mkdtempSync(join(tmpdir(), "lcm-legacy-stats-"));
+  vi.stubEnv("LCM_HOME", root);
+  const project = join(root, "projects", "legacy");
+  mkdirSync(project, { recursive: true });
+  const path = join(project, "db.sqlite");
+  const db = new DatabaseSync(path);
+  db.exec(`
+    CREATE TABLE conversations (conversation_id INTEGER);
+    CREATE TABLE messages (conversation_id INTEGER, token_count INTEGER);
+    CREATE TABLE summaries (conversation_id INTEGER, token_count INTEGER);
+    INSERT INTO conversations VALUES (1);
+    INSERT INTO messages VALUES (1, 40);
+    INSERT INTO summaries VALUES (1, 10);
+  `);
+  if (usage) db.exec("CREATE TABLE llm_usage_stats (calls_total INTEGER); INSERT INTO llm_usage_stats VALUES (3)");
+  db.close();
+  const before = readFileSync(path);
+  const stats = collectStats();
+  expect(stats).toMatchObject({ projects: 1, conversations: 1, messages: 1, summaries: 1, rawTokens: 40, summaryTokens: 10, maxDepth: 0 });
+  expect(stats.llmUsage).toMatchObject({ calls: usage ? 3 : 0, costUsd: null });
+  expect(readFileSync(path)).toEqual(before);
+});

--- a/test/stats-readonly.test.ts
+++ b/test/stats-readonly.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { DatabaseSync } from "node:sqlite";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { collectStats } from "../src/stats.js";
+import { runLcmMigrations } from "../src/db/migration.js";
+import { ConversationStore } from "../src/store/conversation-store.js";
+import { writeHold } from "../src/daemon/hold.js";
+
+let root: string | undefined;
+afterEach(() => { vi.unstubAllEnvs(); if (root) rmSync(root, { recursive: true, force: true }); });
+
+it.each([false, true])("stats during a hold never migrates or writes project databases (current schema: %s)", async (current) => {
+  root = mkdtempSync(join(tmpdir(), "lcm-readonly-stats-"));
+  vi.stubEnv("LCM_HOME", root);
+  const project = join(root, "projects", "fixture");
+  mkdirSync(project, { recursive: true });
+  const path = join(project, "db.sqlite");
+  const db = new DatabaseSync(path);
+  if (current) {
+    runLcmMigrations(db);
+    const store = new ConversationStore(db);
+    const conversation = await store.getOrCreateConversation("readonly-session");
+    await store.createMessagesBulk([{ conversationId: conversation.conversationId, seq: 0, role: "user", content: "stored", tokenCount: 1 }]);
+  } else {
+    db.exec("CREATE TABLE maintenance_marker (value TEXT); INSERT INTO maintenance_marker VALUES ('in-progress')");
+  }
+  db.close();
+  writeHold(join(root, "daemon.pid"));
+  const before = readFileSync(path);
+  const stats = collectStats();
+  expect(readFileSync(path)).toEqual(before);
+  expect(stats.messages).toBe(current ? 1 : 0);
+});


### PR DESCRIPTION
Adds a time-bounded daemon hold for maintenance and fixes CLI execution from source checkouts.

`lcm daemon stop --hold --minutes 20 --reason "maintenance"` publishes the hold before stopping. Automatic startup and background hooks respect it; explicit `daemon start` or `restart` releases it. Stop reports success only after registered startup, MCP, hook, and daemon-dependent CLI activity has drained, and fails explicitly if the drain times out.

Concurrent startup registers before checking the hold and hands off to the listening PID before unregistering. Local MCP tools and direct command-hook sidecar writers use the same admission/drain boundary. Compact, import, and promote retain activity registration through CLI exit. Expired or invalid holds are inactive; passive readers do not delete replacement markers.

Stats opens project and event databases read-only, without migrations. Legacy schemas retain their core counts when newer optional metrics or error history are absent. Source CLI startup preserves loader arguments and package-version lookup verifies the LCM package identity, including nested checkouts.

Validation includes full typecheck/build and 1,675 passing tests (6 skipped), plus hook typechecking. Regressions exercise real CLI startup/stop races, concurrent starters, drain timeouts, admitted MCP/hook/compact work, source loader and nested package resolution, and byte-preserving legacy statistics scans. GitHub CI and final Codex review are tracked on the current head.

Part of #399. The subcommand-help fix is the dependent PR #416. Review policy for this repository is CI plus Copilot and/or Codex via comments and resolution of actionable findings; plugin-installed deep-review tiers are not required.
