### PR TITLE
fix(cli): --help on a subcommand no longer runs the subcommand

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -994,13 +994,13 @@ async function main() {
     });
 
   connectorsCmd
-    .command("install <agent>")
+    .command("install [agent]")
     .description("Install a connector for an agent")
     .option("--type <type>", "Connector type: rules, mcp, skill, or hooks")
     .option("--global", "Install into the global agent config in your home directory")
     .helpOption(false)
     .option("-h, --help", "Show help")
-    .action(async (agentName: string, opts) => {
+    .action(async (agentName: string | undefined, opts) => {
       if (helpRequested(connectorsCmd, opts)) {
         const { printHelp } = await import("../src/cli-help.js");
         printHelp("connectors"); exit(0);
@@ -1026,13 +1026,13 @@ async function main() {
     });
 
   connectorsCmd
-    .command("remove <agent>")
+    .command("remove [agent]")
     .description("Remove a connector for an agent")
     .option("--type <type>", "Connector type: rules, mcp, skill, or hooks")
     .option("--global", "Remove from the global agent config in your home directory")
     .helpOption(false)
     .option("-h, --help", "Show help")
-    .action(async (agentName: string, opts) => {
+    .action(async (agentName: string | undefined, opts) => {
       if (helpRequested(connectorsCmd, opts)) {
         const { printHelp } = await import("../src/cli-help.js");
         printHelp("connectors"); exit(0);

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -940,7 +940,7 @@ async function main() {
   const connectorsCmd = new Command("connectors").description("Manage connectors for coding agents");
   connectorsCmd.helpOption(false).option("-h, --help", "Show help");
   connectorsCmd.action(async (opts) => {
-    if (opts.help) {
+    if (helpRequested(connectorsCmd, opts)) {
       const { printHelp } = await import("../src/cli-help.js");
       printHelp("connectors"); exit(0);
     }

--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -23,6 +23,19 @@ function readStdin(): Promise<string> {
   });
 }
 
+/**
+ * True when `--help` was asked for on this command or on the parent it hangs from.
+ *
+ * Commander routes a flag declared on both a parent and its subcommand to the
+ * parent's options, so a subcommand that only reads its own would never see it:
+ * `lcm daemon stop --help` ran the action and stopped the daemon. Both command
+ * trees that carry a hand-rolled help option — `daemon` and `connectors` —
+ * declare it on the parent as well, so both need the parent consulted.
+ */
+export function helpRequested(parent: Command, opts: { help?: boolean }): boolean {
+  return Boolean(opts.help || (parent.opts() as { help?: boolean }).help);
+}
+
 async function withCustomHelp(cmd: Command, commandName: string): Promise<void> {
   const { printHelp } = await import("../src/cli-help.js");
   printHelp(commandName);
@@ -326,7 +339,7 @@ async function main() {
     .addOption(new Option("--automatic").hideHelp())
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) { await withCustomHelp(daemonCmd, "daemon"); return; }
+      if (helpRequested(daemonCmd, opts)) { await withCustomHelp(daemonCmd, "daemon"); return; }
       const { ensureDaemon, checkDaemonHealth, isStaleDaemon } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { PKG_VERSION, BUILD_ID } = await import("../src/daemon/version.js");
@@ -399,7 +412,7 @@ async function main() {
     .option("--reason <text>", "Why the daemon is held down")
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) { await withCustomHelp(daemonCmd, "daemon"); return; }
+      if (helpRequested(daemonCmd, opts)) { await withCustomHelp(daemonCmd, "daemon"); return; }
       const { stopDaemon, checkDaemonHealth } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { writeHold, DEFAULT_HOLD_MINUTES } = await import("../src/daemon/hold.js");
@@ -431,7 +444,7 @@ async function main() {
     .description("Restart the background daemon")
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) { await withCustomHelp(daemonCmd, "daemon"); return; }
+      if (helpRequested(daemonCmd, opts)) { await withCustomHelp(daemonCmd, "daemon"); return; }
       const { stopDaemon, ensureDaemon, checkDaemonHealth } = await import("../src/daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../src/daemon/config.js");
       const { PKG_VERSION, BUILD_ID } = await import("../src/daemon/version.js");
@@ -457,7 +470,7 @@ async function main() {
     });
 
   daemonCmd.action(async (opts) => {
-    if (opts.help) { await withCustomHelp(daemonCmd, "daemon"); return; }
+    if (helpRequested(daemonCmd, opts)) { await withCustomHelp(daemonCmd, "daemon"); return; }
   });
   program.addCommand(daemonCmd);
 
@@ -943,7 +956,7 @@ async function main() {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
+      if (helpRequested(connectorsCmd, opts)) {
         const { printHelp } = await import("../src/cli-help.js");
         printHelp("connectors"); exit(0);
       }
@@ -986,7 +999,7 @@ async function main() {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (agentName: string, opts) => {
-      if (opts.help) {
+      if (helpRequested(connectorsCmd, opts)) {
         const { printHelp } = await import("../src/cli-help.js");
         printHelp("connectors"); exit(0);
       }
@@ -1018,7 +1031,7 @@ async function main() {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (agentName: string, opts) => {
-      if (opts.help) {
+      if (helpRequested(connectorsCmd, opts)) {
         const { printHelp } = await import("../src/cli-help.js");
         printHelp("connectors"); exit(0);
       }
@@ -1045,7 +1058,7 @@ async function main() {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (agentName: string | undefined, opts) => {
-      if (opts.help) {
+      if (helpRequested(connectorsCmd, opts)) {
         const { printHelp } = await import("../src/cli-help.js");
         printHelp("connectors"); exit(0);
       }

--- a/test/bin/subcommand-help-routing.test.ts
+++ b/test/bin/subcommand-help-routing.test.ts
@@ -1,0 +1,55 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { helpRequested } from "../../bin/lcm.js";
+
+/**
+ * Rebuilds the shape the `daemon` and `connectors` trees have in bin/lcm.ts:
+ * a parent that turns off commander's help option and declares its own, and
+ * subcommands that do the same. Those commands are registered inside main(),
+ * so the shape is reproduced here rather than imported.
+ */
+function tree(onHelp: (where: string) => void): Command {
+  const program = new Command("lcm");
+  const parent = new Command("daemon");
+  parent.helpOption(false).option("-h, --help", "Show help");
+  parent.action((opts) => { if (helpRequested(parent, opts)) onHelp("parent"); else onHelp("parent-action"); });
+
+  const child = parent.command("stop");
+  child.helpOption(false).option("-h, --help", "Show help");
+  child.action((opts) => { if (helpRequested(parent, opts)) onHelp("help"); else onHelp("ACTION RAN"); });
+
+  program.addCommand(parent);
+  return program;
+}
+
+describe("--help on a subcommand whose parent declares the same flag", () => {
+  it.each(["--help", "-h"])("%s reaches the subcommand instead of running it", (flag) => {
+    let where = "";
+    tree((w) => { where = w; }).parse(["daemon", "stop", flag], { from: "user" });
+    expect(where).toBe("help");
+  });
+
+  it("the parent's own --help still works", () => {
+    let where = "";
+    tree((w) => { where = w; }).parse(["daemon", "--help"], { from: "user" });
+    expect(where).toBe("parent");
+  });
+
+  it("without --help the subcommand action runs", () => {
+    let where = "";
+    tree((w) => { where = w; }).parse(["daemon", "stop"], { from: "user" });
+    expect(where).toBe("ACTION RAN");
+  });
+});
+
+describe("helpRequested", () => {
+  it("is true when the subcommand itself carries the flag", () => {
+    const parent = new Command("daemon");
+    expect(helpRequested(parent, { help: true })).toBe(true);
+  });
+
+  it("is false when neither carries it", () => {
+    const parent = new Command("daemon");
+    expect(helpRequested(parent, {})).toBe(false);
+  });
+});

--- a/test/bin/subcommand-help-routing.test.ts
+++ b/test/bin/subcommand-help-routing.test.ts
@@ -1,6 +1,10 @@
 import { Command } from "commander";
 import { describe, expect, it } from "vitest";
 import { helpRequested } from "../../bin/lcm.js";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
 
 /**
  * Rebuilds the shape the `daemon` and `connectors` trees have in bin/lcm.ts:
@@ -51,5 +55,42 @@ describe("helpRequested", () => {
   it("is false when neither carries it", () => {
     const parent = new Command("daemon");
     expect(helpRequested(parent, {})).toBe(false);
+  });
+});
+
+describe("built connector CLI without an agent argument", () => {
+  const cli = resolve("dist/bin/lcm.js");
+  function invoke(args: string[]) {
+    const directory = mkdtempSync(join(tmpdir(), "lcm-help-"));
+    try {
+      const result = spawnSync(process.execPath, [cli, "connectors", ...args], {
+        cwd: directory,
+        env: { ...process.env, HOME: directory, LCM_HOME: join(directory, "lcm") },
+        encoding: "utf8",
+        timeout: 10000,
+      });
+      expect(result.error).toBeUndefined();
+      expect(readdirSync(directory)).toEqual([]);
+      return result;
+    } finally {
+      rmSync(directory, { recursive: true, force: true });
+    }
+  }
+
+  it.each([
+    ["install", "--help"], ["install", "-h"],
+    ["remove", "--help"], ["remove", "-h"],
+  ])("connectors %s %s shows help without side effects", (command, flag) => {
+    const result = invoke([command, flag]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain("lcm connectors —");
+    expect(result.stderr).toBe("");
+  });
+
+  it.each(["install", "remove"])("connectors %s still requires an agent without help", (command) => {
+    const result = invoke([command]);
+    expect(result.status).toBe(1);
+    expect(result.stderr).toMatch(/agent/);
+    expect(result.stdout).toBe("");
   });
 });


### PR DESCRIPTION
> **Stacked on #414** (`fix/daemon-hold-and-cli-version`). Merge that first, or take both with `gh stack merge`.

## `--help` ran the command instead of describing it

```
$ lcm daemon stop --help
lcm daemon stopped (pid 65345)          # asked what it does; it did it

$ lcm connectors install claude-code --help
✓ Installed default connector for claude-code
```

Every subcommand under `daemon` and `connectors` was affected — `start`, `stop`, `restart`, `list`, `install`, `remove`, `doctor`. Found by asking `lcm daemon stop --help` while running the retag by hand, which stopped the daemon.

## Why

Commander routes a flag declared on **both** a parent and its subcommand to the **parent's** options. Both trees turn commander's built-in help off and declare `-h, --help` on the parent as well as on each child, so the child's `opts.help` was never set and the guard fell straight through into the action.

Probed against commander 14.0.3 directly:

| parent declares `-h, --help` | child action receives |
|---|---|
| yes | `{}` |
| no | `{"help":true}` |

Neither `helpOption(false)` on the child nor `enablePositionalOptions()` changes it: the program has already split the subcommand name out of the argument list before the parent parses, so the parent recognises `--help` as its own and consumes it first. `enablePositionalOptions()` would only help if the whole program went positional, which changes flag ordering for every `lcm` command — a grammar change, not a help fix.

## The fix

```ts
export function helpRequested(parent: Command, opts: { help?: boolean }): boolean {
  return Boolean(opts.help || (parent.opts() as { help?: boolean }).help);
}
```

Consulting the parent is what "help anywhere in this command's tree" meant all along. Eight call sites: four under `daemon`, four under `connectors`.

Not changed: `bench`, `search`, `grep` and the other flat commands. They have no parent declaring the same flag, so they were never affected — `test/bin/bench-command-routing.test.ts` already covers that shape and still passes.

## Verification

```
npm test        159 files, 1606 passed | 2 skipped
npm run typecheck   clean
```

Live:

```
$ npx tsx bin/lcm.ts daemon stop --help
  lcm daemon — Start, stop or restart the context daemon…
$ curl -s -o /dev/null -w "%{http_code}" localhost:3737/health
200                                      # still up

$ npx tsx bin/lcm.ts connectors install claude-code --help
  lcm connectors — Manage connectors for coding agents…
```

6 new tests in `test/bin/subcommand-help-routing.test.ts`. The `daemon` commands are built inside `main()` rather than an exported `register*`, so the test rebuilds the production shape — parent with `helpOption(false)` plus its own `-h, --help`, child the same — instead of extracting `main()` in a fix PR. Reverting `helpRequested` to the old one-line guard fails 2 of the 6, so the test pins the mechanism that broke.

## Issue Reference

Part of #399

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1wwybhXYEnbZVqA4SvJ83
