### PR TITLE
test: give every test file its own lcm home

### DIFF
--- a/test/daemon/routes/stats.test.ts
+++ b/test/daemon/routes/stats.test.ts
@@ -9,8 +9,8 @@ import { runLcmMigrations } from "../../../src/db/migration.js";
 import { ConversationStore } from "../../../src/store/conversation-store.js";
 import { SummaryStore } from "../../../src/store/summary-store.js";
 
-// collectStats() scans every project database under homedir()/.lossless-claude,
-// opening each one writable and running migrations. Point homedir() at a
+// collectStats() scans every project database under the lcm home, opening each one
+// writable and running migrations. Point LCM_HOME at a
 // temporary tree so the test never touches (or waits on) the user's real data.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
@@ -24,7 +24,7 @@ describe("GET /stats", () => {
 
   beforeAll(async () => {
     home = mkdtempSync(join(tmpdir(), "lcm-stats-home-"));
-    vi.mocked(homedir).mockReturnValue(home);
+    process.env.LCM_HOME = join(home, ".lossless-claude");
 
     // One project with two messages and one summary, so the aggregation path
     // runs instead of the empty-tree early return.
@@ -54,7 +54,7 @@ describe("GET /stats", () => {
 
   afterAll(async () => {
     await daemon.stop();
-    vi.mocked(homedir).mockReset();
+    delete process.env.LCM_HOME;
     rmSync(home, { recursive: true, force: true });
   });
 

--- a/test/daemon/routes/stats.test.ts
+++ b/test/daemon/routes/stats.test.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { describe, expect, it, beforeAll, afterAll, vi } from "vitest";
+import { describe, expect, it, beforeAll, afterAll } from "vitest";
 import { createDaemon, type DaemonInstance } from "../../../src/daemon/server.js";
 import { loadDaemonConfig } from "../../../src/daemon/config.js";
 import { runLcmMigrations } from "../../../src/db/migration.js";
@@ -12,11 +12,6 @@ import { SummaryStore } from "../../../src/store/summary-store.js";
 // collectStats() scans every project database under the lcm home, opening each one
 // writable and running migrations. Point LCM_HOME at a
 // temporary tree so the test never touches (or waits on) the user's real data.
-vi.mock("node:os", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:os")>();
-  return { ...actual, homedir: vi.fn(actual.homedir) };
-});
-
 describe("GET /stats", () => {
   let daemon: DaemonInstance;
   let port: number;

--- a/test/db/events-path.test.ts
+++ b/test/db/events-path.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect } from "vitest";
 import { eventsDbPath, eventsDir } from "../../src/db/events-path.js";
 import { join } from "node:path";
-import { homedir } from "node:os";
+import { lcmHome } from "../../src/lcm-home.js";
 
 describe("eventsDbPath", () => {
-  it("returns a path under ~/.lossless-claude/events/", () => {
+  it("returns a path under the lcm home's events directory", () => {
     const result = eventsDbPath("/some/project");
-    expect(result).toMatch(/\.lossless-claude\/events\/.+\.db$/);
+    expect(result.startsWith(join(eventsDir(), ""))).toBe(true);
+    expect(result.endsWith(".db")).toBe(true);
   });
 
   it("produces consistent paths for the same cwd", () => {
@@ -23,7 +24,7 @@ describe("eventsDbPath", () => {
 });
 
 describe("eventsDir", () => {
-  it("returns ~/.lossless-claude/events", () => {
-    expect(eventsDir()).toBe(join(homedir(), ".lossless-claude", "events"));
+  it("sits directly under the lcm home", () => {
+    expect(eventsDir()).toBe(join(lcmHome(), "events"));
   });
 });

--- a/test/e2e/flows/codex-lifecycle.test.ts
+++ b/test/e2e/flows/codex-lifecycle.test.ts
@@ -24,7 +24,13 @@ function runHook(event: string, extra: Record<string, unknown> = {}) {
   return new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
     const child = spawn(process.execPath, [cli, "codex-hook"], {
       cwd: harness.tmpDir,
-      env: { ...process.env, HOME: fakeHome, CLAUDE_PROJECT_DIR: undefined },
+      // LCM_HOME as well as HOME: the suite sets one per test file, and it would win here.
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        LCM_HOME: join(fakeHome, ".lossless-claude"),
+        CLAUDE_PROJECT_DIR: undefined,
+      },
     });
     let stdout = "", stderr = "";
     child.stdout.on("data", chunk => { stdout += chunk; });

--- a/test/e2e/flows/codex-replay-cli.test.ts
+++ b/test/e2e/flows/codex-replay-cli.test.ts
@@ -61,6 +61,8 @@ function runImport(args: string[]): Promise<{ code: number | null; stdout: strin
       env: {
         ...process.env,
         HOME: fakeHome,
+        // The suite sets one LCM_HOME per test file; without this it wins over fakeHome.
+        LCM_HOME: join(fakeHome, ".lossless-claude"),
         NO_COLOR: "1",
       },
     });

--- a/test/e2e/flows/hook-process.test.ts
+++ b/test/e2e/flows/hook-process.test.ts
@@ -43,7 +43,14 @@ interface HookRun { status: number | null; stdout: string; stderr: string }
 function runHook(args: readonly string[], stdin: string): Promise<HookRun> {
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, [WRAPPER, ...args], {
-      env: { ...process.env, HOME: fakeHome, CLAUDE_PROJECT_DIR: undefined },
+      // LCM_HOME, not just HOME: the suite sets one per test file, and it would otherwise
+      // be inherited here and win over the fake home this flow set up.
+      env: {
+        ...process.env,
+        HOME: fakeHome,
+        LCM_HOME: join(fakeHome, ".lossless-claude"),
+        CLAUDE_PROJECT_DIR: undefined,
+      },
     });
     let stdout = "";
     let stderr = "";

--- a/test/lcm-paths-guard.test.ts
+++ b/test/lcm-paths-guard.test.ts
@@ -10,6 +10,9 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync } from "node:fs";
 import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { lcmHome } from "../src/lcm-home.js";
 
 const ROOT_LITERAL = ".lossless-claude";
 
@@ -37,6 +40,15 @@ function sourceFiles(): string[] {
   const out = execFileSync("git", ["ls-files", "src", "bin", "hooks"], { encoding: "utf-8" });
   return out.split("\n").filter((f) => f.endsWith(".ts") || f.endsWith(".mjs"));
 }
+
+describe("the suite never runs against the developer's own memory", () => {
+  it("resolves a root of its own", () => {
+    // test/setup-env.ts gives every test file its own. If that ever stops working, a test
+    // that writes through lcm would reach into ~/.lossless-claude for real — and two files
+    // would share one project database, which is how SQLITE_BUSY reached CI.
+    expect(lcmHome()).not.toBe(join(homedir(), ".lossless-claude"));
+  });
+});
 
 describe("the storage root is resolved in one place", () => {
   it("names ~/.lossless-claude only in the factory", () => {

--- a/test/setup-env.ts
+++ b/test/setup-env.ts
@@ -9,6 +9,17 @@ import { afterAll } from "vitest";
 // suite must not see it.
 delete process.env.CLAUDE_CODE_ENABLE_FUNCTION_HOOKS;
 
+// Everything lcm stores goes to a directory this file owns, so no test can reach the
+// developer's real memory — and, because each test file gets its own, two files cannot
+// contend for one project database. That contention is not hypothetical: it answered
+// SQLITE_BUSY on the CI runner, where the suite runs in parallel, and never here.
+// Set before the test file's imports, since the root is resolved when a module loads.
+const lcmHomeDir = mkdtempSync(join(tmpdir(), "lcm-home-"));
+process.env.LCM_HOME = lcmHomeDir;
+afterAll(() => {
+  rmSync(lcmHomeDir, { recursive: true, force: true });
+});
+
 // Language packs live under ~/.lossless-claude/languages on a developer's machine. A test
 // that goes through query preparation must see the same packs on every machine — none —
 // unless it writes its own. The variable is inherited by the daemons the e2e tests spawn,

--- a/test/stats-cost-aggregation.test.ts
+++ b/test/stats-cost-aggregation.test.ts
@@ -1,8 +1,8 @@
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
-import { describe, expect, it, afterEach, vi } from "vitest";
+import { describe, expect, it, afterEach } from "vitest";
 import { runLcmMigrations } from "../src/db/migration.js";
 import { recordCompactLlmUsage, type CompactLlmUsage } from "../src/daemon/routes/compact.js";
 import { collectStats } from "../src/stats.js";
@@ -10,11 +10,6 @@ import { ConversationStore } from "../src/store/conversation-store.js";
 
 // collectStats() scans every project database under the lcm home, so each fixture
 // points LCM_HOME at its own.
-vi.mock("node:os", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("node:os")>();
-  return { ...actual, homedir: vi.fn(actual.homedir) };
-});
-
 function usage(overrides: Partial<CompactLlmUsage> = {}): CompactLlmUsage {
   return {
     provider: "openai",

--- a/test/stats-cost-aggregation.test.ts
+++ b/test/stats-cost-aggregation.test.ts
@@ -8,7 +8,8 @@ import { recordCompactLlmUsage, type CompactLlmUsage } from "../src/daemon/route
 import { collectStats } from "../src/stats.js";
 import { ConversationStore } from "../src/store/conversation-store.js";
 
-// collectStats() scans every project database under homedir()/.lossless-claude.
+// collectStats() scans every project database under the lcm home, so each fixture
+// points LCM_HOME at its own.
 vi.mock("node:os", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:os")>();
   return { ...actual, homedir: vi.fn(actual.homedir) };
@@ -34,7 +35,7 @@ describe("collectStats cost aggregation", () => {
   let home: string | undefined;
 
   afterEach(() => {
-    vi.mocked(homedir).mockReset();
+    delete process.env.LCM_HOME;
     if (home) rmSync(home, { recursive: true, force: true });
     home = undefined;
   });
@@ -43,7 +44,7 @@ describe("collectStats cost aggregation", () => {
   // needs one before its usage row is counted at all.
   async function withProjects(...usages: CompactLlmUsage[][]): Promise<void> {
     home = mkdtempSync(join(tmpdir(), "lcm-cost-home-"));
-    vi.mocked(homedir).mockReturnValue(home);
+    process.env.LCM_HOME = join(home, ".lossless-claude");
     for (const [i, rows] of usages.entries()) {
       const dir = join(home!, ".lossless-claude", "projects", `p${i}`);
       mkdirSync(dir, { recursive: true });


### PR DESCRIPTION
Part of #409. Not the step 3 the issue describes — read on.

## What I found when I measured step 3

Threading an `LcmPaths` through the library means touching **71 test call sites** for the six hook handlers alone, plus signature changes across 25 files. Before spending that, I checked what the threading was actually buying, and the answer was: it stops a test or a sandboxed run from reaching the real `~/.lossless-claude`.

That is obtainable for the whole suite in five lines, and the repo already does exactly this for language packs in `test/setup-env.ts`, with the same reasoning in the comment. So this PR takes that route first.

## What it does

Every test file gets its own lcm home. Two consequences, both load-bearing:

1. **The suite stopped running against the developer's real memory.** It was, except where a test remembered to mock `homedir()`. Two did. The rest did not.
2. **It ends the CI failure that has been red since yesterday.** `test/daemon/routes/ingest.test.ts` returned 500 where 400 was expected, four times, only on the runner. The diagnostic added earlier in the stack named it: `{"error":"database is locked"}`. Tests that share a root share a project database, and the runner runs files in parallel. One root per file removes the contention that made it possible.

## Fixtures that were isolating themselves, and now conflict

Three places had built their own isolation because no override existed. The variable now wins over both mechanisms, so they state their root instead:

| Fixture | Was | Now |
|---|---|---|
| `stats-cost-aggregation`, `routes/stats` | `vi.mock("node:os")` on `homedir` | sets `LCM_HOME` |
| `hook-process`, `codex-lifecycle`, `codex-replay-cli` e2e | `HOME: fakeHome` on the subprocess | also passes `LCM_HOME` |

`test/db/events-path.test.ts` asserted the literal `~/.lossless-claude/events` path. It now asserts the relationship it meant — the events directory sits under the home — which survives the root moving.

## The guard

A new assertion fails if the suite ever resolves the real home again, so this cannot quietly regress.

## What is left of #409

Steps 3 and 4 as written — threading the object and deleting the default — are still the end state, and I would still do them. What changed is the urgency: the risk they were mainly protecting against is now closed at the suite level, so the remaining value is design clarity rather than safety. Worth doing deliberately rather than in one 71-site sweep.

Full suite green: 1602 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ga2dD8xzcqyoXuq6NkZB6L