### PR TITLE
chore(hooks): a command that type-checks the function-hooks module

### DIFF
--- a/hooks/lcm-hooks.ts
+++ b/hooks/lcm-hooks.ts
@@ -14,6 +14,9 @@
 // The module has no Node and no SQLite, so the daemon does every write.
 //
 // Types: run /plugin-types in a session, then `import type { Register } from "claude-code"`.
+// They are written from the running build and not committed, so the check is on demand:
+// `npm run typecheck:hooks`. Run it after a Claude Code update too — the API is early
+// access, and a green run is the answer to whether the release moved anything under this.
 // `claude plugin validate` reads this file statically: `$` may only be passed to a function
 // declared at the top level, and calls on it must be spelled `$.noun.method(...)`.
 import type { Register, EngineInterface } from "claude-code";

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "release:verify": "npm test && npm pack --dry-run",
     "test": "vitest run --dir test",
     "typecheck": "tsc --noEmit",
+    "typecheck:hooks": "sh scripts/typecheck-hooks.sh",
     "version-packages": "changeset version"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "release:verify": "npm test && npm pack --dry-run",
     "test": "vitest run --dir test",
     "typecheck": "tsc --noEmit",
-    "typecheck:hooks": "sh scripts/typecheck-hooks.sh",
+    "typecheck:hooks": "bash scripts/typecheck-hooks.sh",
     "version-packages": "changeset version"
   },
   "dependencies": {

--- a/scripts/typecheck-hooks.sh
+++ b/scripts/typecheck-hooks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Type-check the function-hooks module against the declarations of the Claude
+# Code build installed right now.
+#
+# Run it before touching hooks/lcm-hooks.ts, and again after a Claude Code
+# update: the plugin API is early access, so a green run is also the answer to
+# "did this release move anything the module stands on".
+set -euo pipefail
+
+TYPES=".claude/types/claude-code.d.ts"
+
+if [ ! -f "$TYPES" ]; then
+  echo "Missing $TYPES."
+  echo "The declarations are written from the running build and are not committed."
+  echo "Generate them by running /plugin-types in a Claude Code session, then run this again."
+  exit 1
+fi
+
+echo "Types written by: $(head -1 "$TYPES" | sed 's|^// ||')"
+npx tsc -p tsconfig.hooks.json
+echo "hooks/ type-checks clean against this build."

--- a/tsconfig.hooks.json
+++ b/tsconfig.hooks.json
@@ -1,0 +1,17 @@
+{
+  "//": "Type-checks hooks/lcm-hooks.ts, the function-hooks module, which the main tsconfig does not cover: it compiles against `claude-code`, a module that exists only as declarations /plugin-types writes from the running build. Those declarations are early access and deliberately not committed — a stale copy would compile against an API that no longer exists. So this runs on demand (npm run typecheck:hooks), never in CI. Settings come verbatim from the header of the generated claude-code.d.ts: no DOM in `lib` (the environment has none, and the DOM's own Text would shadow the element), and `types: []` because the module has no Node.",
+  "compilerOptions": {
+    "target": "es2023",
+    "lib": ["es2023"],
+    "types": [],
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "jsx": "react",
+    "jsxFactory": "h",
+    "jsxFragmentFactory": "Fragment"
+  },
+  "include": [".claude/types", "hooks"]
+}


### PR DESCRIPTION
`hooks/lcm-hooks.ts` runs on every tool call and every prompt, and nothing checked it. The main `tsconfig.json` covers `src/`, `bin/` and `installer/` only — the module compiles against `claude-code`, which exists solely as the declarations `/plugin-types` writes from the running build.

## Why not CI, and why not commit the types

The plugin API is early access. A pinned copy of `claude-code.d.ts` would keep compiling against a surface that no longer exists — green, and meaningless. That is worse than not checking, so the declarations stay uncommitted (`.gitignore` already excludes `.claude/`, and the module's own header has always said to generate them), and the check is on demand rather than in CI.

## What this adds

```
$ npm run typecheck:hooks
Types written by: Written by Claude Code 2.1.263.
hooks/ type-checks clean against this build.
```

and, when they have not been generated:

```
Missing .claude/types/claude-code.d.ts.
The declarations are written from the running build and are not committed.
Generate them by running /plugin-types in a Claude Code session, then run this again.
```

`tsconfig.hooks.json` takes its settings verbatim from the header of the generated file, so the check is as strict as the real environment: no DOM in `lib` (the environment has none, and the DOM's own `Text` would shadow the element) and `types: []` (the module has no Node).

Worth running after a Claude Code update as much as before an edit — a green run answers whether the release moved anything the module stands on.

## Verification

```
npm run typecheck:hooks   clean, against Claude Code 2.1.263
npm run typecheck         unchanged
claude plugin validate .  passes
```

Both paths of the script were exercised: with the declarations present, and with `.claude/types` moved away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1wwybhXYEnbZVqA4SvJ83