### PR TITLE
docs: a glossary, a roadmap of themes, and a hooks type-check

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,42 @@
+# lcm
+
+Durable cross-session memory for coding agents. lcm reads the transcripts an agent
+harness writes to disk and turns them into a searchable, compacted record.
+
+## Language
+
+### What lcm does to a transcript
+
+**Capture**:
+A transcript's content reaching lcm's database at all.
+_Avoid_: ingestion, collection
+
+**Attribution**:
+Knowing which session a captured message belongs to, and which session dispatched it.
+Independent of capture — content can be captured and still be unattributed.
+_Avoid_: linking, correlation
+
+**Structure**:
+The same captured content held as a queryable field rather than as text inside a
+message. Structure is what a filter can select on; message text is what only full-text
+search can reach.
+_Avoid_: typing, parsing, normalisation
+
+### What a transcript holds
+
+**Session**:
+One conversation between a person and the agent, written as one transcript file.
+
+**Subagent session**:
+A session a parent session dispatched. The harness writes it as its own transcript
+file, so it is a session in every respect except that nobody started it directly.
+_Avoid_: sidechain, agent session
+
+**Parent session**:
+The session that dispatched a subagent session.
+_Avoid_: caller, origin session
+
+**Skill expansion**:
+The text a skill injects into the model's context when it is invoked. It arrives in
+the transcript as ordinary message text, not as a tool call.
+_Avoid_: skill prompt, skill body

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,53 +1,51 @@
-# Version Roadmap — @lossless-claude/lcm
+# Roadmap — @lossless-claude/lcm
 
-## Unreleased
+The strategic source of truth for this project: the durable themes work is judged
+against. Released versions are recorded in [CHANGELOG.md](./CHANGELOG.md); execution
+state lives in GitHub issues. This file is neither — **it is not a queue**, and an entry
+is not done when an issue closes.
 
-_(no features queued — v0.8.0 shipped 2026-03-28)_
+A theme states what must become true and how we would know. Work derives from it: an
+issue that fits no theme is either out of scope or evidence a theme is missing. Large
+features are admitted here first, as a theme or an amendment to one, before any issue
+is opened.
 
----
+## Themes
 
-## v0.9.0 — Candidates
+### Retrieval quality is measured on real corpora, not synthetic gates
 
-- [ ] Copilot PR review negotiation workflow (round-count metric)
-- [ ] Permissions granularity improvements for agent teammates
+What search returns is what lcm is worth. The synthetic recall gate reports 93% where a
+reviewed real corpus scores 54% (#358), so the gate cannot be the evidence a change is
+good. Every retrieval claim carries a measurement against transcripts someone actually
+wrote.
 
----
+### The record matches what happened
 
-## v0.8.0 — 2026-03-28
+Capture, attribution and structure are separate properties, and a gap in one is not a
+gap in the others (see [CONTEXT.md](./CONTEXT.md)). Sessions must be attributable to
+whoever dispatched them (#419), what a session did must be filterable and not only
+greppable (#421), and no session may end without a durable record (#344).
 
-### Added
-- Connection pooling for sidecar EventsDb (#131)
-- Portable knowledge export/import — `lcm export`, `lcm import-knowledge` (#132)
-- Pool stats observable — `lcm stats --pool` + `GET /stats/pool` daemon endpoint
-- AR coverage gate CI workflow
-- Enriched GitHub Release notes — CHANGELOG extraction + npm badge (#173)
-- Copilot auto-review on all PRs
+### One project, one memory
 
-### Fixed
-- `post-tool` command not registered in CLI dispatcher (#162)
-- Security: upgraded hono, rollup, picomatch (3 high CVEs)
-- Security: CodeQL stack-trace exposure + sanitizeError backslash handling (#175)
-- Atomic meta.json write in `importKnowledge` — prevents crash mid-write corruption (#171)
-- `redaction_stats` migration for v0.7.0 → v0.8.0 upgrades (#171)
+A project's memory is a property of the project, not of the directory it was checked
+out into (#399), and every location lcm owns derives from one injected root rather than
+the ambient environment (#409).
 
----
+### Recall becomes enforcement
 
-## v0.7.0 — 2026-03-26
+Remembering a decision is weaker than making it structurally hard to violate. Critical
+memory should be promoted into contracts, checks and tests that bind future work
+(#198), rather than surfaced as prose an agent may ignore.
 
-_(see CHANGELOG.md)_
+### Parity across hosts and protocols
 
-## v0.6.0 — 2026-03-25
+lcm is a memory layer, not a Claude Code plugin. It holds the same guarantees under
+Codex and under Claude Code, across command hooks and function hooks, and tracks the
+MCP protocol it speaks (#401).
 
-_(see CHANGELOG.md)_
+## Privacy
 
-## v0.5.0 — 2026-03-23
-
-_(see CHANGELOG.md)_
-
-## v0.4.x — 2026-03-23
-
-_(see CHANGELOG.md)_
-
-## v0.1.0
-
-Initial release.
+Memory is captured passively, so redaction and sensitivity classification are part of
+capture, not a feature layered on top. Any theme above that widens what is captured
+must say what it does about sensitive content before it ships.

--- a/docs/design/message-parts-vs-events-db.md
+++ b/docs/design/message-parts-vs-events-db.md
@@ -1,0 +1,23 @@
+# Structure lives in `message_parts`, not the events database
+
+**Status:** accepted, 2026-09-09. Scopes #419 and #421; no schema change is made by this document.
+
+lcm has two places that already hold per-message facts: the permanent conversation
+store (`message_parts`) and the passive-learning events database, whose extractors
+already emit `skill_use` and `subagent_dispatch`. Reusing the events database would
+have cost nothing to build. We put structure in `message_parts` anyway, because the
+events database has a different lifetime and scope — it feeds promotion and is not the
+record a search is expected to filter — while `message_parts` already carries
+`part_type` and the unused `subtask_prompt` / `subtask_desc` / `subtask_agent` columns
+that this data was shaped for.
+
+## Consequences
+
+`message_parts.part_type` is constrained by `CHECK (part_type IN (...))`. Adding values
+to it requires rebuilding the table, on project databases reaching 122 MB. We accepted
+that cost, and it is the reason the parent-link work (#419, a plain column addition) is
+separate from the skill and slash-command work (#421, the rebuild).
+
+Backfills against this table are `UPDATE`, never `DELETE`: compacted conversations are
+protected by `ON DELETE RESTRICT` on `summary_messages.message_id`, so SQLite refuses
+to delete and re-ingest them.


### PR DESCRIPTION
## What

Three things, one of which was already on this branch before the docs work began.

**`CONTEXT.md`** — a glossary. Issue #419 asked for three new function-hook events; measuring showed two of the three data points already reached the database and the third was discarded in one line of `src/import.ts`. What was missing was not code but vocabulary: capture, attribution and structure were one word, so a gap in one read as a gap in all three. The file names them and nothing else.

**`ROADMAP.md`** — restated as durable themes. It had duplicated `CHANGELOG.md` verbatim for v0.8.0, deferred four more sections to it, and stood still since 2026-03-28 while the project shipped 0.10.0. It described versions; nothing described what the versions were for. History stays in `CHANGELOG.md`, execution state stays in issues.

**`docs/design/message-parts-vs-events-db.md`** — why structure goes in `message_parts` rather than the events database, and why rebuilding that table is a cost worth paying.

Also carried, from `chore/typecheck-hooks` which this branch was cut from: `npm run typecheck:hooks`, checking `hooks/` against the declarations the running Claude Code build writes.

## Verification

Local, all green: `build`, `typecheck`, `typecheck:hooks` (clean against the 2.1.263 declarations), and `npm test` at 1602 passed / 6 skipped across 159 files.

## Follow-ups

#419 and #421 are the work this vocabulary was written for; neither is implemented here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D4TuAYZ6Qfk2u5dRA9SL3