### PR TITLE
Follow the $.fs rename, and stop the type-check from agreeing with stale declarations

### DIFF
--- a/hooks/lcm-hooks.ts
+++ b/hooks/lcm-hooks.ts
@@ -104,7 +104,7 @@ async function claimSession($: EngineInterface, sessionId: string): Promise<void
   if (!sessionId) return;
   const { tmpDir } = await readHostEnv($);
   const file = `${tmpDir}/lcm-claim-${sessionId.replace(/[^a-zA-Z0-9_-]/g, "_")}.json`;
-  await $.fs.writeFile(file, JSON.stringify({ sessionId, ts: Date.now() }));
+  await $.fs.write(file, JSON.stringify({ sessionId, ts: Date.now() }));
 }
 
 /** Last time this module asked the host to start the daemon; one attempt per cooldown window. */

--- a/scripts/typecheck-hooks.sh
+++ b/scripts/typecheck-hooks.sh
@@ -7,7 +7,7 @@
 # "did this release move anything the module stands on".
 set -euo pipefail
 
-TYPES=".claude/types/claude-code.d.ts"
+TYPES="${HOOKS_TYPES:-.claude/types/claude-code.d.ts}"
 
 if [ ! -f "$TYPES" ]; then
   echo "Missing $TYPES."
@@ -16,6 +16,31 @@ if [ ! -f "$TYPES" ]; then
   exit 1
 fi
 
-echo "Types written by: $(head -1 "$TYPES" | sed 's|^// ||')"
+header=$(head -1 "$TYPES" | sed 's|^// ||')
+echo "Types written by: $header"
+
+# The check is only worth what the declarations are worth. They state the API of
+# the build that wrote them, so against a newer build they describe methods that
+# may no longer exist and this script agrees with them — which is how a rename
+# reached a session green. Compare, and refuse rather than reassure.
+# Ends on a digit: the header is a sentence, so the version is followed by a full
+# stop that would otherwise be read as part of it and never match a bare version.
+declared=$(printf '%s' "$header" | sed -n 's|.*Claude Code \([0-9][0-9.]*[0-9]\).*|\1|p')
+running=$(claude --version 2>/dev/null | sed -n 's|^\([0-9][0-9.]*\).*|\1|p' || true)
+
+if [ -z "$running" ]; then
+  # No Claude Code here — CI, or a machine without it. The type-check still says
+  # something about the module; it just cannot say the declarations are current.
+  echo "No Claude Code on PATH: cannot confirm the declarations match a running build."
+elif [ -z "$declared" ]; then
+  echo "$TYPES has no version in its header; cannot confirm it matches Claude Code $running."
+elif [ "$declared" != "$running" ]; then
+  echo "Declarations are from Claude Code $declared, but $running is installed."
+  echo "The plugin API is early access and moves between releases, so this check would"
+  echo "hold hooks/ to an API that may no longer exist."
+  echo "Run /plugin-types in a Claude Code session, then run this again."
+  exit 1
+fi
+
 npx tsc -p tsconfig.hooks.json
 echo "hooks/ type-checks clean against this build."

--- a/test/hooks/session-summarizer.test.ts
+++ b/test/hooks/session-summarizer.test.ts
@@ -14,7 +14,7 @@ async function start(options: Record<string, number> = {}, jobs: unknown[] = [le
   const engine = {
     session: { id: vi.fn(async () => sessionId), cwd: vi.fn(async () => "/proj") },
     process: { run: vi.fn(async () => ({ stdout: "secret\n__CONFIG__\n{}\n__TMPDIR__/tmp", exitCode: 0 })) },
-    fs: { writeFile: vi.fn(async () => undefined) },
+    fs: { write: vi.fn(async () => undefined) },
     model: {
       complete: vi.fn(async () => "  summary  "),
       fork: vi.fn(async (): Promise<any> => null),
@@ -55,7 +55,7 @@ describe("function-hook session summarizer", () => {
   it("claims the session but starts no poller when the summarizer is disabled", async () => {
     const harness = await start({ sessionSummarizerMaxOutputTokens: 0 });
     expect(await harness.trigger()).toEqual({});
-    expect(harness.engine.fs.writeFile).toHaveBeenCalledWith(
+    expect(harness.engine.fs.write).toHaveBeenCalledWith(
       `/tmp/lcm-claim-${sessionId.replace("/", "_")}.json`,
       expect.stringContaining(`"sessionId":"${sessionId}"`),
     );
@@ -64,7 +64,7 @@ describe("function-hook session summarizer", () => {
 
   it("lets session.start finish when the claim cannot be written", async () => {
     const harness = await start({ sessionSummarizerMaxOutputTokens: 0 });
-    harness.engine.fs.writeFile.mockRejectedValueOnce(new Error("read-only fs"));
+    harness.engine.fs.write.mockRejectedValueOnce(new Error("read-only fs"));
     expect(await harness.trigger()).toEqual({});
     expect(harness.engine.ui.log).toHaveBeenCalledWith(expect.stringContaining("could not claim the session"));
   });

--- a/test/hooks/typecheck-hooks.test.ts
+++ b/test/hooks/typecheck-hooks.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { chmodSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const execute = promisify(execFile);
+const SCRIPT = resolve(__dirname, "../../scripts/typecheck-hooks.sh");
+
+/**
+ * The script's job is to refuse rather than reassure, so the cases worth pinning are
+ * the ones where it must not reach the compiler. `npx` is stubbed too: a run that gets
+ * that far has already passed the guard, and the real compiler would only make the
+ * test slow and dependent on the module compiling.
+ */
+async function run(options: { header?: string; claudeVersion?: string }) {
+  const dir = mkdtempSync(join(tmpdir(), "lcm-typecheck-"));
+  const bin = join(dir, "bin");
+  await execute("mkdir", ["-p", bin]);
+  const types = join(dir, "claude-code.d.ts");
+  if (options.header !== undefined) {
+    writeFileSync(types, `${options.header}\ndeclare module "claude-code" {}\n`);
+  }
+  // A stub compiler: reaching it means the guard let the run through.
+  const npx = join(bin, "npx");
+  writeFileSync(npx, "#!/bin/sh\necho stub-tsc\n");
+  chmodSync(npx, 0o755);
+  if (options.claudeVersion !== undefined) {
+    const claude = join(bin, "claude");
+    writeFileSync(claude, `#!/bin/sh\necho "${options.claudeVersion} (Claude Code)"\n`);
+    chmodSync(claude, 0o755);
+  }
+  try {
+    const { stdout } = await execute("bash", [SCRIPT], {
+      env: { ...process.env, PATH: `${bin}:/usr/bin:/bin`, HOOKS_TYPES: types },
+    });
+    return { exitCode: 0, output: stdout };
+  } catch (error) {
+    const failure = error as { code?: number; stdout?: string; stderr?: string };
+    return { exitCode: failure.code ?? 1, output: `${failure.stdout ?? ""}${failure.stderr ?? ""}` };
+  }
+}
+
+describe("typecheck-hooks staleness guard", () => {
+  it("refuses when the declarations are older than the installed build", async () => {
+    const result = await run({ header: "// Written by Claude Code 2.1.263.", claudeVersion: "2.1.267" });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Declarations are from Claude Code 2.1.263, but 2.1.267 is installed");
+    expect(result.output).toContain("/plugin-types");
+    expect(result.output).not.toContain("stub-tsc");
+  });
+
+  it("compiles when the declarations match the installed build", async () => {
+    const result = await run({ header: "// Written by Claude Code 2.1.267.", claudeVersion: "2.1.267" });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("stub-tsc");
+  });
+
+  // CI has no Claude Code, so the guard cannot confirm freshness there. It says so
+  // rather than failing: the type-check still holds the module to the declarations
+  // it has, it just cannot claim they are current.
+  it("says it cannot confirm freshness when no Claude Code is installed", async () => {
+    const result = await run({ header: "// Written by Claude Code 2.1.263." });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("cannot confirm the declarations match a running build");
+    expect(result.output).toContain("stub-tsc");
+  });
+
+  it("does not claim a match when the header carries no version", async () => {
+    const result = await run({ header: "// Written by some other tool.", claudeVersion: "2.1.267" });
+    expect(result.exitCode).toBe(0);
+    expect(result.output).toContain("no version in its header");
+  });
+
+  it("names /plugin-types when the declarations are missing entirely", async () => {
+    const result = await run({ claudeVersion: "2.1.267" });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("/plugin-types");
+    expect(result.output).not.toContain("stub-tsc");
+  });
+});


### PR DESCRIPTION
## What broke

`session.start` failed with `$.fs.writeFile is not a function`, so the session claim was
never written. The claim is how the function-hooks module tells the command hooks it owns
the session, and without it both paths stay active on every session.

Claude Code 2.1.267 renamed the filesystem methods: `readFile`, `writeFile` and `listDir`
became `read`, `write` and `list`. The last claim written on this machine is timestamped
before the update and there are none after it.

## Why the type-check agreed

`typecheck:hooks` holds the module to `.claude/types/claude-code.d.ts`, which
`/plugin-types` writes from whatever build is running. The copy here was three builds
old, so it declared a method the engine no longer had and the check passed all day
against an API that did not exist.

The script already printed the declarations' version and never compared it to anything.
It now reads the version out of the header, reads the installed one from
`claude --version`, and refuses when they differ. Without Claude Code on PATH it says it
cannot confirm freshness rather than claiming a match — CI has no engine, and the
narrower answer is still worth having.

## Verification

Five tests cover the guard's branches with a stub compiler and a stub `claude`, so no
case reaches `tsc` that the guard should have stopped. Writing them caught the version
parse taking the header sentence's full stop, which would have read every matching build
as stale — the opposite failure, and silent.

Full suite: 1701 passed, 6 skipped. `typecheck` and `typecheck:hooks` clean.

Confirmed live rather than only in tests: claims are being written again, timestamped
after the fix, where the newest before it was from the previous afternoon.

## Left open

CI does not run `typecheck:hooks` and cannot — the declarations are generated per machine
and not committed, and the runner has no Claude Code. So this gate still only runs when
someone remembers to run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D4TuAYZ6Qfk2u5dRA9SL3