### PR TITLE
Tell the reader to restart before regenerating declarations

### DIFF
--- a/scripts/typecheck-hooks.sh
+++ b/scripts/typecheck-hooks.sh
@@ -38,7 +38,10 @@ elif [ "$declared" != "$running" ]; then
   echo "Declarations are from Claude Code $declared, but $running is installed."
   echo "The plugin API is early access and moves between releases, so this check would"
   echo "hold hooks/ to an API that may no longer exist."
-  echo "Run /plugin-types in a Claude Code session, then run this again."
+  # /plugin-types writes what the session it runs in knows, so a session started before
+  # the update regenerates the same old version however many times it is asked. Saying
+  # "run /plugin-types" alone sends the reader in a circle.
+  echo "Restart Claude Code so a session runs $running, then run /plugin-types in it."
   exit 1
 fi
 

--- a/test/hooks/typecheck-hooks.test.ts
+++ b/test/hooks/typecheck-hooks.test.ts
@@ -51,6 +51,15 @@ describe("typecheck-hooks staleness guard", () => {
     expect(result.output).not.toContain("stub-tsc");
   });
 
+  // /plugin-types writes what the session it runs in knows. After an update the running
+  // session is still the old build, so regenerating there returns the old version and a
+  // message naming only that command sends the reader round in a circle.
+  it("says to restart before regenerating, since a running session writes its own build", async () => {
+    const result = await run({ header: "// Written by Claude Code 2.1.267.", claudeVersion: "2.1.268" });
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toContain("Restart Claude Code so a session runs 2.1.268");
+  });
+
   it("compiles when the declarations match the installed build", async () => {
     const result = await run({ header: "// Written by Claude Code 2.1.267.", claudeVersion: "2.1.267" });
     expect(result.exitCode).toBe(0);


### PR DESCRIPTION
The staleness guard merged in #426 named `/plugin-types` as the fix and nothing else.
That command writes what the session it runs in knows, so after a Claude Code update the
running session is still the previous build and regenerating there produces the same old
version.

Observed immediately after #426 merged: Claude Code had moved 2.1.267 → 2.1.268, the
guard fired, `/plugin-types` was run, the header still read 2.1.267, and the guard fired
again with the same instruction.

A refusal that names an action which cannot work is the defect this repository has an
open issue about (#425), reached here by the guard written to prevent a different one.

The message now says to restart Claude Code first, naming the version a new session will
run. One test pins it: declarations one build behind must not be answered with the
command alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D4TuAYZ6Qfk2u5dRA9SL3