### PR TITLE
Serve both MCP protocol revisions, not only the newer one

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -257,5 +257,5 @@ export async function startMcpServer(): Promise<void> {
     });
   });
 
-  serveStdio(() => server, { legacy: "reject" });
+  serveStdio(() => server, { legacy: "serve" });
 }

--- a/test/mcp/protocol.test.ts
+++ b/test/mcp/protocol.test.ts
@@ -133,16 +133,33 @@ describe("MCP 2026-07-28 over stdio", () => {
     });
   });
 
-  it("rejects legacy initialization while allowing a subsequent modern request", async () => {
-    const legacy = await request("initialize", {
+  // Both revisions are served, because which one a client offers is the client's choice
+  // and not ours. Claude Code opens stdio servers on the 2025 revision unless the user
+  // sets MCP_PROTOCOL_NEGOTIATION=auto, so serving only the modern one would answer
+  // nothing at all under the default the documentation describes.
+  it("serves a 2025-era client through initialization, listing and calling", async () => {
+    const initialized = await request("initialize", {
       protocolVersion: "2025-11-25", capabilities: {}, clientInfo: { name: "old", version: "1" },
     }, false);
-    expect(legacy.error).toMatchObject({ code: -32022 });
-    expect((await request("tools/list")).result.tools).toHaveLength(7);
+    expect(initialized.error).toBeUndefined();
+    expect(initialized.result).toMatchObject({ protocolVersion: "2025-11-25" });
+
+    const listed = await request("tools/list", {}, false);
+    expect(listed.error).toBeUndefined();
+    expect(listed.result.tools).toHaveLength(7);
+
+    const called = await request("tools/call", { name: "lcm_search", arguments: { query: "hello" } }, false);
+    expect(called.error).toBeUndefined();
+    expect(called.result.content).toEqual([{ type: "text", text: JSON.stringify({ matches: ["remembered"] }, null, 2) }]);
   });
 
-  it("rejects requests without per-request protocol metadata", async () => {
-    expect((await request("tools/list", {}, false)).error).toMatchObject({ code: -32022 });
-    expect(state.post).not.toHaveBeenCalled();
+  it("serves a 2026-era client, and only that one carries the modern envelope", async () => {
+    const listed = await request("tools/list");
+    expect(listed.error).toBeUndefined();
+    expect(listed.result.tools).toHaveLength(7);
+    expect(listed.result).toMatchObject({ resultType: "complete", ttlMs: 0, cacheScope: "private" });
+    expect(listed.result._meta).toMatchObject({
+      "io.modelcontextprotocol/serverInfo": { name: "lcm", version: "9.9.9-test" },
+    });
   });
 });


### PR DESCRIPTION
## What broke

The MCP server refused every connection Claude Code made, reported as
`plugin:lcm:lcm (-32022): "Unsupported protocol version: 2025-11-25"`, with all seven
`lcm_*` tools absent for the whole session.

Captured from the wire with a pass-through tap, the client's first message 8ms after the
server starts:

```
client -> server
{"method":"initialize","params":{"protocolVersion":"2025-11-25", ...,
 "clientInfo":{"name":"claude-code","version":"2.1.269"}},"jsonrpc":"2.0","id":0}

server -> client
{"error":{"code":-32022,"message":"Unsupported protocol version: 2025-11-25",
          "data":{"supported":["2026-07-28"],"requested":"2025-11-25"}}}

server exited
```

There is no `server/discover` probe before it. `serveStdio(..., { legacy: "reject" })`
answers that opening with an error and the connection ends.

## Why it is not a fault on either side

The documented behaviour: on the v2 runtime Claude Code asks HTTP and connector servers
whether they support revision 2026-07-28 and uses it with those that do, and *asks stdio
servers only if you set `MCP_PROTOCOL_NEGOTIATION` to `auto`*. Unset or `legacy` keeps
stdio servers on the earlier handshake.

So the choice to serve only the newer revision was coherent, and its consequence is that
a stdio server answers no one under the default — it works only for a user who knows to
set a variable.

## Measured cost of serving both

| | 2025-11-25 | 2026-07-28 |
|---|---|---|
| `initialize` | accepted | — |
| `tools/list` | 7 | 7 |
| `tools/call` | works | works |
| result envelope | absent | `_meta`, `resultType`, `ttlMs`, `cacheScope` |

The envelope is the entire difference. Its cache hints are already `ttlMs: 0` and
`cacheScope: "private"`, so a client that does not receive them loses no caching that was
being offered. Serving the earlier revision is additionally what a channel server needs:
the newer revision cannot carry channel messages.

Nothing here makes the client choose; it makes the server answer whichever the client
picked.

## Tests

The two that pinned the refusal now pin the pair, kept adjacent so the dual support is
visible: one drives a 2025-era client through initialize, list and call; the other holds
the modern envelope to the revision that carries it.

Full suite: 1702 passed, 6 skipped. `typecheck` clean.

## Related

#423 and #424 are separate faults with the same symptom, found while diagnosing this
one; #425 is the error message that named a version mismatch when the real complaint was
absent metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D4TuAYZ6Qfk2u5dRA9SL3