### PR TITLE
Document both MCP revisions, and how to pick the newer one

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -2,10 +2,12 @@
 
 LCM provides seven MCP tools for agents to search, inspect, store, and recall information from conversation history.
 
-The MCP server uses the [2026-07-28 protocol](https://modelcontextprotocol.io/specification/2026-07-28)
-over stdio, powered by the TypeScript SDK v2. Clients must support this revision;
-legacy `initialize` connections are rejected. The entrypoints remain `lcm mcp`
-and `node mcp.mjs`. Tool names, arguments, and text results are unchanged.
+The MCP server speaks the [2026-07-28 protocol](https://modelcontextprotocol.io/specification/2026-07-28)
+over stdio, powered by the TypeScript SDK v2, and also serves the earlier 2025-11-25
+revision. Which one a connection uses is the client's choice; both reach the same seven
+tools with the same arguments and text results. Only the newer revision carries the
+result envelope (`resultType`, `ttlMs`, `cacheScope`, `_meta`). The entrypoints remain
+`lcm mcp` and `node mcp.mjs`.
 
 ## Usage patterns
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,23 @@ lcm install
 
 `lcm install` is the Claude Code setup path. It writes config, registers hooks, installs slash commands, registers MCP, and verifies the daemon.
 
+#### MCP protocol revision
+
+Claude Code opens a stdio server on the 2025-11-25 revision unless you ask it to
+negotiate, and lcm serves both, so the tools work either way with nothing set. To use
+the 2026-07-28 revision instead, set it in `~/.claude/settings.json`:
+
+```json
+{ "env": { "MCP_PROTOCOL_NEGOTIATION": "auto" } }
+```
+
+The variable is Claude Code's, not lcm's, and it applies to every stdio MCP server you
+run. On the newer revision Claude Code asks the server what it supports before
+connecting, and results carry the envelope described in
+[agent-tools.md](./agent-tools.md); on the earlier one it connects directly. A server on
+the newer revision cannot deliver Claude Code channel messages, so leave the variable
+unset if you use lcm as a channel.
+
 ### VS Code (GitHub Copilot)
 
 Install the repo-local connector:


### PR DESCRIPTION
Two things, both surfaced by #428.

## A document that outran its code

`docs/agent-tools.md` stated that clients must support 2026-07-28 and that legacy
`initialize` connections are rejected. #428 made the server serve both revisions, so
that paragraph now describes behaviour the code no longer has — the same drift this
project reports about other repositories, in its own docs.

It now says both revisions are served, that the choice is the client's, and that only
the newer one carries the result envelope.

## The setting that decides which one

Claude Code opens stdio MCP servers on 2025-11-25 unless `MCP_PROTOCOL_NEGOTIATION` is
set to `auto`; HTTP and connector servers are asked about the newer revision without it.
That is documented on Claude Code's side, but nothing on ours said it, and locating it
took reading the client's own binary after the connection failures in #423 through #425.

`docs/configuration.md` now carries it under Claude Code setup, including the caveat
that a server on the newer revision cannot deliver channel messages — so a user running
lcm as a channel should leave the variable alone.

Measured both ways against a real client before writing this, with a pass-through tap on
the wire: unset, Claude Code sends `initialize` with 2025-11-25 and gets all seven tools;
`auto`, it sends `tools/list` carrying `protocolVersion: 2026-07-28` and gets the same
seven plus the envelope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011D4TuAYZ6Qfk2u5dRA9SL3