### PR TITLE
fix(guidance): one storing rule across every surface

### DIFF
--- a/.agents/skills/lcm-context/SKILL.md
+++ b/.agents/skills/lcm-context/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lcm-context
-description: "You MUST use this before any work to recall project memory, and after implementing to store decisions. Lossless-claude (lcm) provides persistent cross-session memory via CLI commands."
+description: "You MUST use this before any work to recall project memory, and to store durable insights. Lossless-claude (lcm) provides persistent cross-session memory via CLI commands."
 ---
 
 # lcm Memory — Universal Agent Guide
@@ -13,7 +13,7 @@ Memory is stored in SQLite (FTS5) and accessed via CLI commands or MCP tools.
 ## Workflow
 
 1. **Before Thinking:** Run `lcm search` or `lcm grep` to recall past decisions and context.
-2. **After Implementing:** Run `lcm store` to persist new decisions, patterns, or findings.
+2. **After Implementing:** If a durable insight emerged, run `lcm store` with a `type:` tag. One concise insight and its why per store.
 
 ## Commands
 
@@ -84,8 +84,8 @@ Persist knowledge for retrieval in future sessions.
 - It's general knowledge, not project-specific
 
 ```bash
-lcm store "Auth uses JWT with 24h expiry. Tokens stored in httpOnly cookies." --tags decision,auth
-lcm store "SessionEnd hook only fires on graceful /exit, not on crash or terminal close" --tags finding,hooks
+lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances." --tag type:decision --tag scope:security
+lcm store "SessionEnd hook only fires on graceful /exit, not on crash or terminal close, so a crashed session loses its tail." --tag type:gotcha --tag scope:lcm
 ```
 
 ### 5. Check System Health

--- a/.changeset/olive-clocks-repeat.md
+++ b/.changeset/olive-clocks-repeat.md
@@ -1,0 +1,7 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+fix: one storing rule across every guidance surface
+
+`~/.claude/lcm.md` banned manual storing while the connector skill made `lcm store` mandatory on every code task. Every generated surface now states the same rule: store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly, tagged with `type:`, one concise insight and its why per store.

--- a/.codex/skills/lcm-memory/SKILL.md
+++ b/.codex/skills/lcm-memory/SKILL.md
@@ -44,7 +44,7 @@ lcm expand sum_abc123def456 --depth 2
 ### 5. Store Knowledge
 Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm store`, tagged with `type:`. One concise insight and its why per store.
 ```bash
-lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances. See src/middleware/auth.ts" --tag type:decision --tag scope:auth
+lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances. See src/middleware/auth.ts" --tag type:decision --tag scope:security
 ```
 
 ### 6. Stats

--- a/.codex/skills/lcm-memory/SKILL.md
+++ b/.codex/skills/lcm-memory/SKILL.md
@@ -6,13 +6,13 @@ description: Lossless context management — search and store persistent memory 
 # Lossless Context Management
 
 > **Before responding to code tasks, check memory first.**
-> Code task? → `lcm search` FIRST. Completed work? → `lcm store` BEFORE done.
+> Code task? → `lcm search` FIRST. Durable insight? → `lcm store` before done.
 
 You have access to a persistent memory system that survives across conversations.
 
 ## Workflow
 
-Code task received → `lcm search` FIRST → Work → `lcm store` → Done
+Code task received → `lcm search` FIRST → Work → `lcm store` (durable insights only) → Done
 Non-code task → Just respond normally
 
 ## Commands
@@ -42,9 +42,9 @@ lcm expand sum_abc123def456 --depth 2
 ```
 
 ### 5. Store Knowledge
-Persist important knowledge after completing work.
+Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm store`, tagged with `type:`. One concise insight and its why per store.
 ```bash
-lcm store "Auth middleware uses JWT with 24h expiry. See src/middleware/auth.ts"
+lcm store "Auth middleware uses JWT with 24h expiry. See src/middleware/auth.ts" --tag type:gotcha --tag scope:auth
 ```
 
 ### 6. Stats
@@ -57,11 +57,11 @@ lcm stats
 
 | Task Type | Search? | Store? |
 |-----------|---------|--------|
-| Add/create/implement feature | MUST | MUST |
-| Fix/debug/resolve bug | MUST | MUST |
-| Refactor/optimize/move code | MUST | MUST |
-| Write/add tests | MUST | MUST |
-| "How does X work?" (codebase) | MUST | Only if insights |
+| Add/create/implement feature | MUST | If durable insight |
+| Fix/debug/resolve bug | MUST | If durable insight |
+| Refactor/optimize/move code | MUST | If durable insight |
+| Write/add tests | MUST | If durable insight |
+| "How does X work?" (codebase) | MUST | If durable insight |
 | General concept question | NO | NO |
 | Meta task (run tests, build) | NO | NO |
 | Git task (commit, PR, push) | NO | NO |

--- a/.codex/skills/lcm-memory/SKILL.md
+++ b/.codex/skills/lcm-memory/SKILL.md
@@ -12,7 +12,7 @@ You have access to a persistent memory system that survives across conversations
 
 ## Workflow
 
-Code task received → `lcm search` FIRST → Work → `lcm store` (durable insights only) → Done
+Code task received → `lcm search` FIRST → Work → durable insight? → `lcm store` → Done
 Non-code task → Just respond normally
 
 ## Commands
@@ -44,7 +44,7 @@ lcm expand sum_abc123def456 --depth 2
 ### 5. Store Knowledge
 Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm store`, tagged with `type:`. One concise insight and its why per store.
 ```bash
-lcm store "Auth middleware uses JWT with 24h expiry. See src/middleware/auth.ts" --tag type:gotcha --tag scope:auth
+lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances. See src/middleware/auth.ts" --tag type:decision --tag scope:auth
 ```
 
 ### 6. Stats

--- a/.github/skills/lcm-memory/SKILL.md
+++ b/.github/skills/lcm-memory/SKILL.md
@@ -44,7 +44,7 @@ lcm expand sum_abc123def456 --depth 2
 ### 5. Store Knowledge
 Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm store`, tagged with `type:`. One concise insight and its why per store.
 ```bash
-lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances. See src/middleware/auth.ts" --tag type:decision --tag scope:auth
+lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances. See src/middleware/auth.ts" --tag type:decision --tag scope:security
 ```
 
 ### 6. Stats

--- a/.github/skills/lcm-memory/SKILL.md
+++ b/.github/skills/lcm-memory/SKILL.md
@@ -6,13 +6,13 @@ description: Lossless context management — search and store persistent memory 
 # Lossless Context Management
 
 > **Before responding to code tasks, check memory first.**
-> Code task? → `lcm search` FIRST. Completed work? → `lcm store` BEFORE done.
+> Code task? → `lcm search` FIRST. Durable insight? → `lcm store` before done.
 
 You have access to a persistent memory system that survives across conversations.
 
 ## Workflow
 
-Code task received → `lcm search` FIRST → Work → `lcm store` → Done
+Code task received → `lcm search` FIRST → Work → `lcm store` (durable insights only) → Done
 Non-code task → Just respond normally
 
 ## Commands
@@ -42,9 +42,9 @@ lcm expand sum_abc123def456 --depth 2
 ```
 
 ### 5. Store Knowledge
-Persist important knowledge after completing work.
+Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm store`, tagged with `type:`. One concise insight and its why per store.
 ```bash
-lcm store "Auth middleware uses JWT with 24h expiry. See src/middleware/auth.ts"
+lcm store "Auth middleware uses JWT with 24h expiry. See src/middleware/auth.ts" --tag type:gotcha --tag scope:auth
 ```
 
 ### 6. Stats
@@ -57,11 +57,11 @@ lcm stats
 
 | Task Type | Search? | Store? |
 |-----------|---------|--------|
-| Add/create/implement feature | MUST | MUST |
-| Fix/debug/resolve bug | MUST | MUST |
-| Refactor/optimize/move code | MUST | MUST |
-| Write/add tests | MUST | MUST |
-| "How does X work?" (codebase) | MUST | Only if insights |
+| Add/create/implement feature | MUST | If durable insight |
+| Fix/debug/resolve bug | MUST | If durable insight |
+| Refactor/optimize/move code | MUST | If durable insight |
+| Write/add tests | MUST | If durable insight |
+| "How does X work?" (codebase) | MUST | If durable insight |
 | General concept question | NO | NO |
 | Meta task (run tests, build) | NO | NO |
 | Git task (commit, PR, push) | NO | NO |

--- a/.github/skills/lcm-memory/SKILL.md
+++ b/.github/skills/lcm-memory/SKILL.md
@@ -12,7 +12,7 @@ You have access to a persistent memory system that survives across conversations
 
 ## Workflow
 
-Code task received → `lcm search` FIRST → Work → `lcm store` (durable insights only) → Done
+Code task received → `lcm search` FIRST → Work → durable insight? → `lcm store` → Done
 Non-code task → Just respond normally
 
 ## Commands
@@ -44,7 +44,7 @@ lcm expand sum_abc123def456 --depth 2
 ### 5. Store Knowledge
 Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm store`, tagged with `type:`. One concise insight and its why per store.
 ```bash
-lcm store "Auth middleware uses JWT with 24h expiry. See src/middleware/auth.ts" --tag type:gotcha --tag scope:auth
+lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances. See src/middleware/auth.ts" --tag type:decision --tag scope:auth
 ```
 
 ### 6. Stats

--- a/docs/passive-learning.md
+++ b/docs/passive-learning.md
@@ -1,6 +1,6 @@
 # Passive Learning
 
-Passive learning captures insights from your Claude Code sessions automatically — no manual `lcm_store()` calls needed. It observes tool usage patterns, user decisions, and session events, then promotes high-signal observations into cross-session memory.
+Passive learning captures your Claude Code sessions automatically; durable insights are still stored explicitly with `lcm_store`. It observes tool usage patterns, user decisions, and session events, then promotes high-signal observations into cross-session memory.
 
 ## How It Works
 

--- a/src/connectors/templates/sections/command-reference.md
+++ b/src/connectors/templates/sections/command-reference.md
@@ -4,7 +4,7 @@
 - `lcm grep "pattern" --mode regex` — Regex search across messages and summaries
 - `lcm describe <nodeId>` — Inspect metadata for a specific memory node
 - `lcm expand <nodeId> --depth N` — Expand a summary node into lower-level detail
-- `lcm store "content"` — Persist knowledge to promoted memory
+- `lcm store "content" --tag type:<kind>` — Persist a durable insight to promoted memory
 - `lcm stats` — Show compression ratios and token savings
 - `lcm doctor` — Run diagnostics
 - `lcm diagnose` — Scan recent Claude Code transcripts for hook and MCP issues

--- a/src/connectors/templates/sections/command-reference.md
+++ b/src/connectors/templates/sections/command-reference.md
@@ -4,7 +4,7 @@
 - `lcm grep "pattern" --mode regex` — Regex search across messages and summaries
 - `lcm describe <nodeId>` — Inspect metadata for a specific memory node
 - `lcm expand <nodeId> --depth N` — Expand a summary node into lower-level detail
-- `lcm store "content" --tag type:<kind>` — Persist a durable insight to promoted memory
+- `lcm store "content" --tag type:<kind> --tag scope:<domain>` — Persist a durable insight to promoted memory
 - `lcm stats` — Show compression ratios and token savings
 - `lcm doctor` — Run diagnostics
 - `lcm diagnose` — Scan recent Claude Code transcripts for hook and MCP issues

--- a/src/connectors/templates/sections/mcp-workflow.md
+++ b/src/connectors/templates/sections/mcp-workflow.md
@@ -5,7 +5,7 @@ You are a coding agent integrated with lossless-claude via MCP (Model Context Pr
 ## Core Rules
 
 - Use the `lcm_search` tool to query memory before starting code tasks.
-- Use the `lcm_store` tool to persist important decisions after completing work.
+- Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with the `lcm_store` tool, tagged with `type:`. One concise insight and its why per store.
 
 ## Tool Usage
 
@@ -13,6 +13,6 @@ You are a coding agent integrated with lossless-claude via MCP (Model Context Pr
 - `lcm_grep` — Regex search across conversations
 - `lcm_expand` — Expand on a specific memory topic
 - `lcm_describe` — Show memory metadata
-- `lcm_store` — Persist knowledge to promoted memory
+- `lcm_store` — Persist a durable insight to promoted memory
 - `lcm_stats` — Show compression ratios and token savings
 - `lcm_doctor` — Run diagnostics

--- a/src/connectors/templates/sections/workflow.md
+++ b/src/connectors/templates/sections/workflow.md
@@ -5,7 +5,7 @@ You are a coding agent. Use the lcm CLI to manage persistent memory across sessi
 ## Core Rules
 
 - **Search first.** Before starting any code task, retrieve relevant context with `lcm search`.
-- **Store what matters.** After completing work, use `lcm store` to persist key decisions and learnings.
+- **Store durable insights.** Explicitly, with `lcm store`, tagged with `type:` — one concise insight and its why per store.
 
 ## When to Search
 
@@ -16,9 +16,15 @@ You are a coding agent. Use the lcm CLI to manage persistent memory across sessi
 
 ## When to Store
 
-- Completed a feature, fix, or refactor
-- An architectural decision was made
-- Discovered something non-obvious about the codebase
+| Tag | Store when |
+|-----|------------|
+| `type:decision` | An architectural or design choice was made, with trade-offs |
+| `type:preference` | The user stated a working style or tool preference |
+| `type:root-cause` | A bug cause took effort to uncover |
+| `type:pattern` | A codebase convention is documented nowhere else |
+| `type:gotcha` | A non-obvious pitfall or footgun surfaced |
+| `type:solution` | A non-trivial fix is worth remembering |
+| `type:workflow` | A multi-step process worked |
 
 ## When to Skip
 

--- a/src/connectors/templates/skill/SKILL.md
+++ b/src/connectors/templates/skill/SKILL.md
@@ -44,7 +44,7 @@ lcm expand sum_abc123def456 --depth 2
 ### 5. Store Knowledge
 Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm store`, tagged with `type:`. One concise insight and its why per store.
 ```bash
-lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances. See src/middleware/auth.ts" --tag type:decision --tag scope:auth
+lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances. See src/middleware/auth.ts" --tag type:decision --tag scope:security
 ```
 
 ### 6. Stats

--- a/src/connectors/templates/skill/SKILL.md
+++ b/src/connectors/templates/skill/SKILL.md
@@ -6,13 +6,13 @@ description: Lossless context management — search and store persistent memory 
 # Lossless Context Management
 
 > **Before responding to code tasks, check memory first.**
-> Code task? → `lcm search` FIRST. Completed work? → `lcm store` BEFORE done.
+> Code task? → `lcm search` FIRST. Durable insight? → `lcm store` before done.
 
 You have access to a persistent memory system that survives across conversations.
 
 ## Workflow
 
-Code task received → `lcm search` FIRST → Work → `lcm store` → Done
+Code task received → `lcm search` FIRST → Work → `lcm store` (durable insights only) → Done
 Non-code task → Just respond normally
 
 ## Commands
@@ -42,9 +42,9 @@ lcm expand sum_abc123def456 --depth 2
 ```
 
 ### 5. Store Knowledge
-Persist important knowledge after completing work.
+Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm store`, tagged with `type:`. One concise insight and its why per store.
 ```bash
-lcm store "Auth middleware uses JWT with 24h expiry. See src/middleware/auth.ts"
+lcm store "Auth middleware uses JWT with 24h expiry. See src/middleware/auth.ts" --tag type:gotcha --tag scope:auth
 ```
 
 ### 6. Stats
@@ -57,11 +57,11 @@ lcm stats
 
 | Task Type | Search? | Store? |
 |-----------|---------|--------|
-| Add/create/implement feature | MUST | MUST |
-| Fix/debug/resolve bug | MUST | MUST |
-| Refactor/optimize/move code | MUST | MUST |
-| Write/add tests | MUST | MUST |
-| "How does X work?" (codebase) | MUST | Only if insights |
+| Add/create/implement feature | MUST | If durable insight |
+| Fix/debug/resolve bug | MUST | If durable insight |
+| Refactor/optimize/move code | MUST | If durable insight |
+| Write/add tests | MUST | If durable insight |
+| "How does X work?" (codebase) | MUST | If durable insight |
 | General concept question | NO | NO |
 | Meta task (run tests, build) | NO | NO |
 | Git task (commit, PR, push) | NO | NO |

--- a/src/connectors/templates/skill/SKILL.md
+++ b/src/connectors/templates/skill/SKILL.md
@@ -12,7 +12,7 @@ You have access to a persistent memory system that survives across conversations
 
 ## Workflow
 
-Code task received → `lcm search` FIRST → Work → `lcm store` (durable insights only) → Done
+Code task received → `lcm search` FIRST → Work → durable insight? → `lcm store` → Done
 Non-code task → Just respond normally
 
 ## Commands
@@ -44,7 +44,7 @@ lcm expand sum_abc123def456 --depth 2
 ### 5. Store Knowledge
 Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm store`, tagged with `type:`. One concise insight and its why per store.
 ```bash
-lcm store "Auth middleware uses JWT with 24h expiry. See src/middleware/auth.ts" --tag type:gotcha --tag scope:auth
+lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances. See src/middleware/auth.ts" --tag type:decision --tag scope:auth
 ```
 
 ### 6. Stats

--- a/src/daemon/orientation.ts
+++ b/src/daemon/orientation.ts
@@ -1,8 +1,12 @@
+// The storing rule's leading phrase. Every guidance surface states it, then names its own tool;
+// tests import it instead of duplicating the wording.
+export const STORE_RULE_PHRASE = "Store durable insights";
+
 // Content written to ~/.claude/lcm.md during install/doctor — loaded via CLAUDE.md @include.
 // Kept here as the single source of truth for the guidance text.
 export const LCM_MD_CONTENT = `# lossless-claude memory — MANDATORY routing rules
 
-Memory is captured automatically by hooks. Do NOT store manually.
+Hooks capture sessions automatically.
 
 ## When to search
 
@@ -28,7 +32,7 @@ lcm_expand <nodeId>       → full decompressed content
 
 ## Storage
 
-Memory is captured automatically by hooks. Do NOT store manually via \`lcm store\` CLI — use the MCP tools (\`lcm_store\`) only when explicitly needed.
+${STORE_RULE_PHRASE} (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with \`lcm_store\` (MCP) or \`lcm store\` (CLI), tagged with \`type:\`. One concise insight and its why per store.
 `;
 
 // Guidance is now delivered via ~/.claude/lcm.md (installed by `lcm install` / `lcm doctor`),

--- a/test/connectors/template-service.test.ts
+++ b/test/connectors/template-service.test.ts
@@ -138,7 +138,10 @@ describe('storing guidance is consistent across surfaces', () => {
 
   for (const [name, render] of surfaces) {
     it(`${name} states the shared storing rule`, () => {
-      expect(render()).toContain(STORE_RULE_PHRASE);
+      const content = render();
+      expect(content).toContain(STORE_RULE_PHRASE);
+      expect(content).toContain(name === 'mcp' ? 'lcm_store' : 'lcm store');
+      expect(content).toContain('type:');
     });
 
     it(`${name} does not make storing mandatory`, () => {

--- a/test/connectors/template-service.test.ts
+++ b/test/connectors/template-service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest';
 import { generateRulesContent, generateMcpContent, generateSkillContent, generateContent } from '../../src/connectors/template-service.js';
 import { LCM_MARKERS } from '../../src/connectors/constants.js';
 import type { Agent } from '../../src/connectors/types.js';
+import { STORE_RULE_PHRASE } from '../../src/daemon/orientation.js';
 
 const mockAgent: Agent = {
   id: 'test-agent',
@@ -126,6 +127,27 @@ describe('generateSkillContent', () => {
     const content = generateSkillContent(mockAgent);
     expect(content).toContain('name: lcm-memory');
   });
+});
+
+describe('storing guidance is consistent across surfaces', () => {
+  const surfaces = [
+    ['rules', () => generateRulesContent(mockAgent)],
+    ['mcp', () => generateMcpContent(mockAgent)],
+    ['skill', () => generateSkillContent(mockAgent)],
+  ] as const;
+
+  for (const [name, render] of surfaces) {
+    it(`${name} states the shared storing rule`, () => {
+      expect(render()).toContain(STORE_RULE_PHRASE);
+    });
+
+    it(`${name} does not make storing mandatory`, () => {
+      const content = render();
+      expect(content).not.toContain('BEFORE done');
+      expect(content).not.toContain('Do NOT store manually');
+      expect(content).not.toMatch(/\|\s*MUST\s*\|\s*MUST\s*\|/);
+    });
+  }
 });
 
 describe('generateContent dispatch', () => {

--- a/test/connectors/template-service.test.ts
+++ b/test/connectors/template-service.test.ts
@@ -146,6 +146,7 @@ describe('storing guidance is consistent across surfaces', () => {
       expect(content).not.toContain('BEFORE done');
       expect(content).not.toContain('Do NOT store manually');
       expect(content).not.toMatch(/\|\s*MUST\s*\|\s*MUST\s*\|/);
+      if (name === 'skill') expect(content).toContain('durable insight?');
     });
   }
 });

--- a/test/daemon/orientation.test.ts
+++ b/test/daemon/orientation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { buildOrientationPrompt, LCM_MD_CONTENT } from "../../src/daemon/orientation.js";
+import { buildOrientationPrompt, LCM_MD_CONTENT, STORE_RULE_PHRASE } from "../../src/daemon/orientation.js";
 
 describe("buildOrientationPrompt", () => {
   it("returns empty string — guidance now lives in ~/.claude/lcm.md", () => {
@@ -14,8 +14,11 @@ describe("LCM_MD_CONTENT", () => {
     expect(LCM_MD_CONTENT).toContain("lcm_describe");
     expect(LCM_MD_CONTENT).toContain("lcm_search");
   });
-  it("instructs not to store manually", () => {
-    expect(LCM_MD_CONTENT).toContain("Do NOT store manually");
+  it("states the shared storing rule", () => {
+    expect(LCM_MD_CONTENT).toContain(STORE_RULE_PHRASE);
+  });
+  it("does not ban manual storing", () => {
+    expect(LCM_MD_CONTENT).not.toContain("Do NOT store manually");
   });
   it("includes retrieval chain example", () => {
     expect(LCM_MD_CONTENT).toContain("lcm_search");


### PR DESCRIPTION
## Changes

`~/.claude/lcm.md` banned manual storing ("Do NOT store manually") while the connector skill made `lcm store` mandatory on every code task ("Completed work? → `lcm store` BEFORE done"). A user running both Claude Code and Codex got opposite rules for the same memory store.

Every generated guidance surface now states one rule, with the surface's own tool name:

> Store durable insights (decision, preference, root-cause, pattern, gotcha, solution, workflow) explicitly with `lcm_store` (MCP) or `lcm store` (CLI), tagged with `type:`. One concise insight and its why per store.

The clause "Hooks capture sessions automatically" stays only in the orientation content, since connector templates are shared with agents that have no lifecycle hooks.

`STORE_RULE_PHRASE` is exported from `src/daemon/orientation.ts` as the shared leading phrase, so tests assert against one constant instead of duplicating the wording.

**Two deviations from the spec's literal wording**, both from a mid-implementation instruction to apply the `writing-great-skills` principles:

1. The spec's sentence ended "Do not store raw transcript content or routine task summaries." Replaced with the positive form "One concise insight and its why per store." — steering by prohibition names the banned behaviour and makes it more available, not less.
2. `STORE_RULE_PHRASE` is `"Store durable insights"`, not the full sentence including the type list. The type enumeration then appears once per file, at the place it belongs, instead of twice.

The decision table's fifth row ("How does X work?") also changed to `If durable insight`, beyond the four rows the spec listed, so the column is consistent.

## Files Touched

- `src/daemon/orientation.ts` — exports `STORE_RULE_PHRASE`; the ban is gone from both the header and the Storage section, which now carries the rule once
- `src/connectors/templates/skill/SKILL.md` — header and workflow lines drop the mandatory store; store example gains `--tag type:` / `--tag scope:`; decision table Store column `MUST` → `If durable insight`
- `.codex/skills/lcm-memory/SKILL.md`, `.github/skills/lcm-memory/SKILL.md` — this repo's own installed copies of that template, regenerated (they are tracked and were shipping the contradiction)
- `src/connectors/templates/sections/workflow.md` — "Store what matters" → the shared rule; the 3-item "When to Store" list → a table of the seven insight types
- `src/connectors/templates/sections/mcp-workflow.md` — `lcm_store` bullet → the shared rule
- `src/connectors/templates/sections/command-reference.md` — store line shows the tagged form
- `docs/passive-learning.md` — opening sentence no longer says manual stores are unneeded
- `test/daemon/orientation.test.ts` — asserts the shared phrase; rejects "Do NOT store manually"
- `test/connectors/template-service.test.ts` — for the rules, mcp and skill renderers: shared phrase present; "BEFORE done", "Do NOT store manually" and a `| MUST | MUST |` row absent
- `.changeset/olive-clocks-repeat.md` — patch, fix

## Issue Reference

Closes #432

## Test Evidence

```
npx vitest run test/daemon/orientation.test.ts test/connectors/template-service.test.ts test/hooks/learning-instruction.test.ts
 Test Files  3 passed (3)
      Tests  37 passed (37)
```

`npx tsc --noEmit` clean.

Full `npm test`: 25 failures across 10 files (`test/bin/compact-hold`, `offline-hold`, `subcommand-help-routing`, `test/daemon/hold-startup`, `hold-startup-race`, `version`, `test/e2e/flows/codex-lifecycle`, `codex-replay-cli`, `hook-process`, `test/hooks/write-admission`). The identical 25 failures reproduce on base `50a831a` — pre-existing, unrelated to this change (daemon/hook process timing).

`--tag <tag>` verified repeatable against the CLI definition at `bin/lcm.ts:155` before writing it into the examples.

## Risks & Follow-ups

- Manual stores insert straight into promoted memory with no dedup, while passive promotion dedups (`src/daemon/routes/store.ts` vs `src/promotion/dedup.ts`). Guidance now tells more surfaces to store explicitly, so this gap matters more. Out of scope here; no follow-up issue opened yet.
- `src/hooks/learning-instruction.ts` is deliberately untouched — it is the reference wording, and its byte-equal copy in `hooks/lcm-hooks.ts` would need a matching edit.
- Users only pick up the new `~/.claude/lcm.md` on the next `lcm install` or `lcm doctor`.

## AR Status

[SKIP_AR: guidance prose only — no behavioural code paths changed]

## Introspection Findings

- `.codex/skills/lcm-memory/SKILL.md` and `.github/skills/lcm-memory/SKILL.md` are tracked copies of the skill template, differing only by a trailing newline. The issue's Files list omitted them, so they would have kept shipping "BEFORE done" while the template said otherwise.
- The obvious negative assertion for the decision table, `not.toContain('| MUST |')`, false-fails: the Search column is still `MUST`. The test matches two adjacent cells instead — `/\|\s*MUST\s*\|\s*MUST\s*\|/`.

## Token Cost

~120k tokens (Opus 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3J9skcoo9SHyJRTxyQQoy
