### PR TITLE
fix(mcp): resolve node without depending on PATH

### DIFF
--- a/.changeset/manifest-declares-what-dist-imports.md
+++ b/.changeset/manifest-declares-what-dist-imports.md
@@ -1,0 +1,7 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+fix: check-manifest verifies dist/ imports match declared dependencies and versions stay in step
+
+The published MCP server could import a package the manifest never declared, which failed silently past the bootstrap's `npm install` and only surfaced as `CONNECTION_CLOSED` in a user's session. `npm run check-manifest` now runs in CI and before publish: it fails the build if `dist/` imports anything outside `dependencies` ∪ `peerDependencies` ∪ `optionalDependencies`, or if `package.json`, `.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` disagree on version. `version-packages` now also runs `scripts/sync-versions.mjs` to keep the two plugin manifests in step with `package.json` automatically. `mcp.mjs`'s bootstrap no longer swallows a failed `npm install` or `npm run build` silently — the error now reaches stderr, next to the `CONNECTION_CLOSED` symptom in the debug log.

--- a/.changeset/mcp-server-resolves-node-without-path.md
+++ b/.changeset/mcp-server-resolves-node-without-path.md
@@ -1,0 +1,20 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+fix: the MCP server no longer depends on PATH to resolve node
+
+The plugin's MCP entry ran bare `node`, and the untracked entry lcm writes into an
+agent's own config (`~/.claude/settings.json`, `.mcp.json`, …) ran bare `lcm` —
+which itself depends on PATH resolving `node` via its shebang. Either could fail with
+`CONNECTION_CLOSED` and no clue why on a session whose PATH doesn't match the shell
+`lcm` was installed from (nvm, volta, a Homebrew shim, a sandboxed plugin runtime).
+
+`plugin.json` now points at `.claude-plugin/lcm-mcp.sh`, a static, tracked launcher
+that reads the node interpreter lcm's own hooks already recorded in
+`~/.lossless-claude/config.json` (`mcpNodePath`, written by `ensureCore` from
+`process.execPath`), falling back to `command -v node` when nothing is recorded yet.
+The entry lcm writes into an agent's own config now carries `process.execPath` and
+the absolute path to the installed `dist/bin/lcm.js`, both measured at install time —
+naming neither `lcm` nor `node` by name. See
+`docs/design/mcp-interpreter-resolution.md`.

--- a/.claude-plugin/lcm-mcp.sh
+++ b/.claude-plugin/lcm-mcp.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Static launcher for the lcm MCP server, referenced by plugin.json.
+#
+# This file is tracked, so it must carry no machine-specific data. It resolves the
+# node interpreter at runtime from lcm's per-machine config (~/.lossless-claude by
+# default, or $LCM_HOME — mirrors src/lcm-home.ts), falling back to PATH when that
+# config has no recorded path yet (e.g. before lcm has ever run). See
+# docs/design/mcp-interpreter-resolution.md.
+set -eu
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+plugin_root="$(cd "$script_dir/.." && pwd)"
+lcm_home="${LCM_HOME:-${HOME:-$(cd ~ && pwd)}/.lossless-claude}"
+config_file="$lcm_home/config.json"
+
+node_path=""
+if [ -f "$config_file" ]; then
+  node_path=$(grep -o '"mcpNodePath"[[:space:]]*:[[:space:]]*"[^"]*"' "$config_file" 2>/dev/null \
+    | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/')
+fi
+
+if [ -z "$node_path" ] || [ ! -x "$node_path" ]; then
+  node_path=$(command -v node 2>/dev/null || true)
+fi
+
+if [ -z "$node_path" ]; then
+  echo "lcm-mcp.sh: no node interpreter found (checked $config_file and PATH)" >&2
+  exit 1
+fi
+
+exec "$node_path" "$plugin_root/mcp.mjs"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
         "repo": "lossless-claude/lcm"
       },
       "description": "Lossless context management — DAG-based summarization that preserves every message",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "strict": true
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -21,8 +21,7 @@
   },
   "mcpServers": {
     "lcm": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/mcp.mjs"]
+      "command": "${CLAUDE_PLUGIN_ROOT}/.claude-plugin/lcm-mcp.sh"
     }
   },
   "hooks": {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lcm",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Lossless context management — DAG-based summarization that preserves every message",
   "author": {
     "name": "Pedro Almeida",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Check manifest
+        run: npm run check-manifest
+
       - name: Run tests
         run: npm test
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,6 +71,10 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         run: npm run build
 
+      - name: Check manifest
+        if: steps.check.outputs.skip == 'false'
+        run: npm run check-manifest
+
       - name: Run tests
         if: steps.check.outputs.skip == 'false'
         run: npm test

--- a/docs/design/mcp-interpreter-resolution.md
+++ b/docs/design/mcp-interpreter-resolution.md
@@ -1,0 +1,61 @@
+# The MCP launcher measures its node interpreter instead of naming one
+
+**Status:** accepted, 2026-09-12. Scopes #424.
+
+lcm registers its MCP server in two places, and each had its own way of depending on
+`PATH` to find an interpreter. `.claude-plugin/plugin.json` (tracked) ran
+`node ${CLAUDE_PLUGIN_ROOT}/mcp.mjs` — depends on `PATH` resolving `node`. The
+installer's writes into an agent's own (untracked) config —
+`~/.claude/settings.json`, `.mcp.json`, `.qwen/mcp.json` — registered bare `lcm`,
+which depends on `PATH` resolving the `lcm` shim *and* that shim's
+`#!/usr/bin/env node` shebang resolving `node`. Two dependencies, not one, on a
+machine where a session's `PATH` (nvm, volta, a Homebrew shim, a plugin runtime's own
+sandboxed spawn) may not match the shell where `lcm` was installed.
+
+## Three alternatives considered
+
+| # | Approach | Why not |
+|---|---|---|
+| 1 | Write the absolute node/CLI path directly into `plugin.json` | `plugin.json` is tracked. An absolute path is per-machine, per-user data; committing it would work for exactly the machine that last ran `npm run build` and break for everyone else who clones the repo. |
+| 2 | A launcher that guesses via `$NVM_DIR`, volta, or common Homebrew paths | Every guess is a maintenance surface that drifts from whatever version managers actually do next, and it still fails silently (falls through every guess) with no measured fact to fall back to — it's guessing with extra steps, not resolving. |
+| 3 (chosen) | Record the node path lcm's own hooks already ran under, in **per-machine, untracked** config; a tracked static launcher reads it, falling back to `PATH` | The value is measured, not guessed — it's `process.execPath` from a process that just ran successfully — and it lives where per-machine state already lives (`~/.lossless-claude/config.json`, or `$LCM_HOME`), never in a tracked file. |
+
+## The two fixes, one per entry
+
+| entry | tracked | fix |
+|---|---|---|
+| `.claude-plugin/plugin.json` → `plugin:lcm:lcm` | yes | `command` points at [`.claude-plugin/lcm-mcp.sh`](../../.claude-plugin/lcm-mcp.sh): a static script carrying no machine data, which reads `mcpNodePath` out of `config.json` and `exec`s it, falling back to `command -v node` |
+| an agent's own MCP config (`~/.claude/settings.json`, `.mcp.json`, …) | no | [`src/installer/mcp-server-entry.ts`](../../src/installer/mcp-server-entry.ts) returns `process.execPath` (absolute) plus the absolute path to the installed `dist/bin/lcm.js`, both measured from the node process running the installer at write time |
+
+Precedent already in the repo: `src/connectors/codex-hooks.ts`'s `buildCodexHookCommand`
+does `options.nodePath ?? process.execPath` and writes the resolved path into Codex's
+own (untracked) `hooks.json`. Same technique, same reason, applied here to the second
+entry; `mcp-server-entry.ts` is the equivalent for the three call sites that write an
+MCP registration (`src/connectors/installer.ts`, `installer/install.ts`,
+`src/doctor/doctor.ts` — all three previously built the entry independently, one of
+them, `resolveBinaryPath`, still via `command -v lcm`).
+
+## Why the launcher script, not a second absolute-path write
+
+`plugin.json` is committed. Writing `process.execPath` into it would encode *this
+machine's* node path into a file every clone and every CI run shares — exactly the
+defect this issue is about, moved one file over. The static `.sh` is the part that's
+safe to commit; the absolute path it needs is the part that isn't, so it stays in
+config the tracked file only reads at runtime.
+
+## The chicken-and-egg boundary
+
+The node path is recorded by `ensureCore` (`src/bootstrap.ts`), which runs on every
+hook dispatch — already executing under a node that just worked, since it's the node
+that ran this hook. Those hooks are themselves invoked by `plugin.json` as bare
+`node ${CLAUDE_PLUGIN_ROOT}/lcm.mjs ...` (out of scope for this issue — a separate,
+lower-severity instance of the same class of bug, since Claude Code itself resolves
+that `node`, not a shim `lcm` installed). On a machine that has never run any lcm hook,
+`config.json` has no `mcpNodePath` yet, and the launcher falls back to `command -v
+node` — identical to today's behavior, so this is not a regression on first run.
+
+## Windows
+
+Zero `win32` branches exist anywhere in `src/`, and `package.json` has no `os` field,
+so a `.sh` launcher drops no platform lcm supports today. A future Windows port needs
+a `.cmd` (or PowerShell) twin of `lcm-mcp.sh` alongside it — not addressed here.

--- a/installer/install.ts
+++ b/installer/install.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { spawnSync, type SpawnSyncReturns } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { ensureCore } from "../src/bootstrap.js";
+import { mcpServerEntry } from "../src/installer/mcp-server-entry.js";
 export { REQUIRED_HOOKS, mergeClaudeSettings } from "../src/installer/settings.js";
 
 export interface ServiceDeps {
@@ -241,8 +242,7 @@ export async function install(deps: ServiceDeps = defaultDeps): Promise<void> {
     merged = {};
   }
   const mcpServers = (typeof merged.mcpServers === "object" && merged.mcpServers !== null) ? merged.mcpServers : {};
-  const lcmBin = resolveBinaryPath(deps);
-  mcpServers["lcm"] = { command: lcmBin, args: ["mcp"] };
+  mcpServers["lcm"] = mcpServerEntry();
   (merged as any).mcpServers = mcpServers;
 
   deps.mkdirSync(dirname(settingsPath), { recursive: true });

--- a/mcp.mjs
+++ b/mcp.mjs
@@ -17,14 +17,23 @@ if (__dirname.endsWith(".claude-plugin")) {
 if (!existsSync(join(__dirname, "node_modules"))) {
   try {
     execSync("npm install --silent", { cwd: __dirname, stdio: "pipe", timeout: 60000 });
-  } catch {}
+  } catch (err) {
+    // Don't throw: the import below will fail anyway if a package is truly
+    // missing, and that failure reaches Claude Code as CONNECTION_CLOSED with
+    // no detail. Logging here puts the real cause in the same debug log as
+    // that symptom, next to each other, instead of only one of them existing.
+    console.error("mcp.mjs: npm install failed:", err?.message ?? err);
+  }
 }
 
 // Auto-build: compile TypeScript if dist/ is missing (fresh GitHub install)
 if (!existsSync(join(__dirname, "dist"))) {
   try {
     execSync("npm run build --silent", { cwd: __dirname, stdio: "pipe", timeout: 120000 });
-  } catch {}
+  } catch (err) {
+    // Same reasoning as the install catch above: log instead of swallowing.
+    console.error("mcp.mjs: npm run build failed:", err?.message ?? err);
+  }
 }
 
 const serverModule = join(__dirname, "dist", "src", "mcp", "server.js");

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "test": "vitest run --dir test",
     "typecheck": "tsc --noEmit",
     "typecheck:hooks": "bash scripts/typecheck-hooks.sh",
-    "version-packages": "changeset version"
+    "check-manifest": "node scripts/check-manifest.mjs",
+    "version-packages": "changeset version && node scripts/sync-versions.mjs"
   },
   "dependencies": {
     "@modelcontextprotocol/server": "^2.0.0",

--- a/scripts/check-manifest.mjs
+++ b/scripts/check-manifest.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+// Verifies the published artifact matches the manifest that describes it.
+//
+// Two independent checks, both born from the same defect: a manifest that
+// claims something the artifact does not do.
+//
+//   (a) every external import in dist/ is declared somewhere the installer
+//       will actually install it from — dependencies, peerDependencies, or
+//       optionalDependencies. devDependencies do not ship, so they do not
+//       count. peerDependencies must be included: dist/src/llm/anthropic.js
+//       and dist/src/llm/openai.js import "@anthropic-ai/sdk" and "openai",
+//       both declared only as peers.
+//   (b) package.json, .claude-plugin/plugin.json and
+//       .claude-plugin/marketplace.json (plugins[0].version) all name the
+//       same version. Nothing else keeps them in step.
+//
+// An empty dist/ or a scan that finds zero files or zero imports is treated
+// as a failure, not a pass — that is the exact shape of the bug this script
+// exists to catch (a build that silently produced nothing to check).
+//
+// Usage: node scripts/check-manifest.mjs [root]
+//   exported: checkManifest(root) -> Finding[]
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+import { builtinModules } from "node:module";
+
+const CODE_EXT = new Set([".js", ".mjs", ".cjs"]);
+
+// import ... from "x" | export ... from "x" | import("x") | require("x")
+const IMPORT_RE = /\b(?:import|export)\s[^;]*?\bfrom\s*["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\brequire\s*\(\s*["']([^"']+)["']\s*\)/g;
+
+function extname(name) {
+  const i = name.lastIndexOf(".");
+  return i === -1 ? "" : name.slice(i);
+}
+
+function collectCodeFiles(dir, out = []) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) collectCodeFiles(full, out);
+    else if (CODE_EXT.has(extname(entry.name))) out.push(full);
+  }
+  return out;
+}
+
+function isExternalSpecifier(spec) {
+  if (spec.startsWith(".") || spec.startsWith("/")) return false;
+  if (spec.includes(":")) return false; // node:*, file:, http(s):, etc.
+  return true;
+}
+
+function packageNameFor(spec) {
+  const parts = spec.split("/");
+  return spec.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0];
+}
+
+function extractImports(source) {
+  const specs = new Set();
+  let match;
+  IMPORT_RE.lastIndex = 0;
+  while ((match = IMPORT_RE.exec(source))) {
+    const spec = match[1] ?? match[2] ?? match[3];
+    if (spec) specs.add(spec);
+  }
+  return specs;
+}
+
+function recordImport(imports, pkgName, filePath) {
+  if (!imports.has(pkgName)) imports.set(pkgName, new Set());
+  imports.get(pkgName).add(filePath);
+}
+
+/** Map of external package name -> Set of dist-relative file paths importing it. */
+function collectExternalImports(files, root) {
+  const imports = new Map();
+  for (const file of files) {
+    const source = readFileSync(file, "utf8");
+    for (const spec of extractImports(source)) {
+      if (!isExternalSpecifier(spec) || builtinModules.includes(spec)) continue;
+      recordImport(imports, packageNameFor(spec), relative(root, file));
+    }
+  }
+  return imports;
+}
+
+function declaredPackages(pkg) {
+  return new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.peerDependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ]);
+}
+
+function checkDeclaredImports(root, pkg) {
+  const distDir = join(root, "dist");
+
+  if (!existsSync(distDir) || !statSync(distDir).isDirectory()) {
+    return [`dist/ does not exist at ${distDir}. Run "npm run build" before check-manifest — an empty dist means every import check trivially passes, which is the failure mode this script exists to catch.`];
+  }
+
+  const files = collectCodeFiles(distDir);
+  if (files.length === 0) {
+    return [`dist/ contains no .js/.mjs/.cjs files. A build that produces zero code files must not be treated as a passing check. Run "npm run build" and verify it emits JavaScript.`];
+  }
+
+  const imports = collectExternalImports(files, root);
+  if (imports.size === 0) {
+    return [`Scanned ${files.length} file(s) under dist/ and found zero external imports. That is almost certainly a bug in the scan (or a dist/ that was never actually exercised), not evidence the build has no dependencies — fix the scan before trusting a pass here.`];
+  }
+
+  const declared = declaredPackages(pkg);
+  const findings = [];
+  for (const [pkgName, importingFiles] of imports) {
+    if (declared.has(pkgName)) continue;
+    const example = [...importingFiles][0];
+    findings.push(`"${pkgName}" is imported by dist/ (e.g. ${example}) but is not declared in dependencies, peerDependencies, or optionalDependencies of package.json. Add it to one of those — devDependencies does not ship with the package.`);
+  }
+  return findings;
+}
+
+function loadJsonIfExists(path) {
+  return existsSync(path) ? JSON.parse(readFileSync(path, "utf8")) : null;
+}
+
+function checkVersionParity(root, pkg) {
+  const pluginPath = join(root, ".claude-plugin", "plugin.json");
+  const marketplacePath = join(root, ".claude-plugin", "marketplace.json");
+  const plugin = loadJsonIfExists(pluginPath);
+  const marketplace = loadJsonIfExists(marketplacePath);
+
+  const missing = [];
+  if (!plugin) missing.push(`Missing ${pluginPath} — cannot verify version parity.`);
+  if (!marketplace) missing.push(`Missing ${marketplacePath} — cannot verify version parity.`);
+  if (missing.length > 0) return missing;
+
+  const marketplaceVersion = marketplace.plugins?.[0]?.version;
+  if (marketplaceVersion === undefined) {
+    return [`${marketplacePath} has no plugins[0].version — cannot verify version parity.`];
+  }
+
+  const pkgVersion = pkg.version;
+  const pluginVersion = plugin.version;
+  const inStep = pkgVersion === pluginVersion && pkgVersion === marketplaceVersion;
+  if (inStep) return [];
+
+  return [
+    `Version mismatch: package.json=${pkgVersion}, .claude-plugin/plugin.json=${pluginVersion}, ` +
+    `.claude-plugin/marketplace.json plugins[0].version=${marketplaceVersion}. ` +
+    `Run "node scripts/sync-versions.mjs" to bring plugin.json and marketplace.json in line with package.json.`,
+  ];
+}
+
+function checkManifest(root) {
+  const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+  return [...checkDeclaredImports(root, pkg), ...checkVersionParity(root, pkg)];
+}
+
+function isMain() {
+  return process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+}
+
+if (isMain()) {
+  const root = process.argv[2] ?? process.cwd();
+  const findings = checkManifest(root);
+  if (findings.length > 0) {
+    console.error(`check-manifest: ${findings.length} finding(s):\n`);
+    for (const f of findings) console.error(`  - ${f}\n`);
+    process.exit(1);
+  }
+  console.log("check-manifest: OK");
+}
+
+export { checkManifest };

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Writes package.json's version into the two other manifests that
+// check-manifest.mjs's version-parity rule reads: .claude-plugin/plugin.json
+// and .claude-plugin/marketplace.json (plugins[0].version). Reads and writes
+// the same paths that rule reads, so syncing and checking never drift apart.
+//
+// Called from "version-packages" (changeset version && node
+// scripts/sync-versions.mjs), so it runs right after changesets bumps
+// package.json.
+//
+// Preserves each file's existing indentation and trailing newline instead of
+// imposing a fixed style, so a version-only change stays a version-only diff.
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+function detectIndent(raw) {
+  const match = raw.match(/^[ \t]+/m);
+  return match ? match[0] : "  ";
+}
+
+function writeJsonPreservingStyle(path, mutate) {
+  const raw = readFileSync(path, "utf8");
+  const indent = detectIndent(raw);
+  const trailingNewline = raw.endsWith("\n") ? "\n" : "";
+  const manifest = JSON.parse(raw);
+  mutate(manifest);
+  writeFileSync(path, JSON.stringify(manifest, null, indent) + trailingNewline);
+}
+
+function syncVersions(root, version) {
+  const pluginPath = join(root, ".claude-plugin", "plugin.json");
+  const marketplacePath = join(root, ".claude-plugin", "marketplace.json");
+
+  writeJsonPreservingStyle(pluginPath, (manifest) => {
+    manifest.version = version;
+  });
+
+  writeJsonPreservingStyle(marketplacePath, (manifest) => {
+    if (!manifest.plugins?.[0]) {
+      throw new Error(`${marketplacePath} has no plugins[0] to write a version onto.`);
+    }
+    manifest.plugins[0].version = version;
+  });
+
+  return { pluginPath, marketplacePath };
+}
+
+function isMain() {
+  return process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+}
+
+if (isMain()) {
+  const root = process.argv[2] ?? process.cwd();
+  const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+  const { pluginPath, marketplacePath } = syncVersions(root, pkg.version);
+  console.log(`sync-versions: set ${pluginPath} and ${marketplacePath} to ${pkg.version}`);
+}
+
+export { syncVersions };

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -32,6 +32,34 @@ function defaultDeps(): EnsureCoreDeps {
   };
 }
 
+/**
+ * Record the node interpreter this process is running under in config.json, so the
+ * plugin's static `.claude-plugin/lcm-mcp.sh` launcher — which cannot depend on PATH
+ * resolving node either — can read a measured, working path instead of guessing.
+ * Read-modify-write: preserves every other key, and only rewrites when the recorded
+ * path is stale (e.g. after an nvm switch or node upgrade).
+ */
+function recordMcpNodePath(deps: EnsureCoreDeps): void {
+  let raw: unknown;
+  try {
+    raw = JSON.parse(deps.readFileSync(deps.configPath, "utf-8"));
+  } catch {
+    return; // config.json missing or unreadable — nothing to patch
+  }
+  if (typeof raw !== "object" || raw === null) return;
+  const config = raw as Record<string, unknown>;
+  if (config.mcpNodePath === process.execPath) return;
+  try {
+    deps.writeFileSync(deps.configPath, JSON.stringify({ ...config, mcpNodePath: process.execPath }, null, 2));
+  } catch (err) {
+    // Don't throw: a config that cannot be written must not stop the daemon from
+    // starting. But don't swallow either — the launcher then falls back to PATH
+    // for good, which is the failure this whole change exists to remove, and it
+    // would look identical to never having tried.
+    console.error("lcm: could not record mcpNodePath in config.json:", err instanceof Error ? err.message : err);
+  }
+}
+
 export async function ensureCore(deps: EnsureCoreDeps = defaultDeps()): Promise<void> {
   // 1. Create config.json with defaults if missing
   if (!deps.existsSync(deps.configPath)) {
@@ -42,6 +70,7 @@ export async function ensureCore(deps: EnsureCoreDeps = defaultDeps()): Promise<
       deps.chmodSync?.(deps.configPath, 0o600);
     } catch {}
   }
+  recordMcpNodePath(deps);
 
   // 2. Clean stale/duplicate hooks from settings.json (fixes #94)
   // Only rewrite settings.json if mergeClaudeSettings actually changed the data

--- a/src/connectors/installer.ts
+++ b/src/connectors/installer.ts
@@ -6,6 +6,7 @@ import { requiresRestart } from "./types.js";
 import { LCM_MARKERS } from "./constants.js";
 import { generateContent } from "./template-service.js";
 import { findAgent, AGENTS } from "./registry.js";
+import { mcpServerEntry } from "../installer/mcp-server-entry.js";
 import {
   diagnoseCodexHooks,
   installCodexHooks,
@@ -70,7 +71,7 @@ function installMcpJson(filePath: string): void {
   if (typeof existing.mcpServers !== 'object' || existing.mcpServers === null || Array.isArray(existing.mcpServers)) {
     existing.mcpServers = {};
   }
-  existing.mcpServers.lcm = { type: 'stdio', command: 'lcm', args: ['mcp'] };
+  existing.mcpServers.lcm = { type: 'stdio', ...mcpServerEntry() };
   writeFileSync(filePath, JSON.stringify(existing, null, 2) + '\n');
 }
 

--- a/src/doctor/doctor.ts
+++ b/src/doctor/doctor.ts
@@ -5,7 +5,8 @@ import { join, dirname } from "node:path";
 import { spawnSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import type { CheckResult, DoctorDeps } from "./types.js";
-import { mergeClaudeSettings, REQUIRED_HOOKS, resolveBinaryPath, ensureLcmMd } from "../../installer/install.js";
+import { mergeClaudeSettings, REQUIRED_HOOKS, ensureLcmMd } from "../../installer/install.js";
+import { mcpServerEntry } from "../installer/mcp-server-entry.js";
 import { NATIVE_PATTERNS, ScrubEngine, readGitleaksSyncDate } from "../scrub.js";
 import { GITLEAKS_PATTERNS } from "../generated-patterns.js";
 import { projectDir } from "../daemon/project.js";
@@ -423,9 +424,7 @@ export async function runDoctor(overrides?: Partial<DoctorDeps>, verbose = false
       // mergeClaudeSettings strips lcm hooks from settings.json; only safe when the plugin actually fires them.
       const merged = plugin.installed && plugin.enabled ? mergeClaudeSettings(currentSettings) : { ...currentSettings };
       if (typeof merged.mcpServers !== "object" || merged.mcpServers === null) merged.mcpServers = {};
-      // Use resolveBinaryPath for consistent binary resolution with installer
-      const lcmBinary = resolveBinaryPath(deps);
-      (merged.mcpServers as Record<string, unknown>)["lcm"] = { command: lcmBinary, args: ["mcp"] };
+      (merged.mcpServers as Record<string, unknown>)["lcm"] = mcpServerEntry();
       deps.writeFileSync(settingsPath, JSON.stringify(merged, null, 2));
       results.push({ name: "mcp-lcm", category: "Settings", status: "warn", message: "mcpServers.lcm missing from settings.json — re-added automatically", fixApplied: true });
     } catch {

--- a/src/installer/mcp-server-entry.ts
+++ b/src/installer/mcp-server-entry.ts
@@ -1,0 +1,31 @@
+import { fileURLToPath } from "node:url";
+
+/**
+ * Absolute path to the installed lcm CLI entrypoint (dist/bin/lcm.js), resolved
+ * from this compiled file's own location so it works regardless of cwd or PATH.
+ * Same technique as `codex-hooks.ts`'s `installedEntrypoint`.
+ */
+function installedCliEntrypoint(): string {
+  return fileURLToPath(new URL("../../bin/lcm.js", import.meta.url));
+}
+
+export interface McpServerEntryOptions {
+  /** Override for the node interpreter (tests only); defaults to the running process's own. */
+  nodePath?: string;
+  /** Override for the CLI entrypoint (tests only); defaults to the installed dist/bin/lcm.js. */
+  cliPath?: string;
+}
+
+/**
+ * The MCP server registration lcm writes into an agent's own (untracked) config —
+ * `~/.claude/settings.json`, `.mcp.json`, `.qwen/mcp.json`, etc. Both fields are
+ * absolute paths measured from the node process actually running the installer, so
+ * the entry depends on neither PATH resolving `lcm` nor a shim's
+ * `#!/usr/bin/env node` resolving a node interpreter. See
+ * docs/design/mcp-interpreter-resolution.md.
+ */
+export function mcpServerEntry(options: McpServerEntryOptions = {}): { command: string; args: string[] } {
+  const command = options.nodePath ?? process.execPath;
+  const cliPath = options.cliPath ?? installedCliEntrypoint();
+  return { command, args: [cliPath, "mcp"] };
+}

--- a/test/bootstrap.test.ts
+++ b/test/bootstrap.test.ts
@@ -25,10 +25,39 @@ describe("ensureCore", () => {
     );
   });
 
-  it("skips config.json creation when it already exists", async () => {
+  it("skips full config.json recreation when it already exists", async () => {
+    // readFileSync already reports the running process's node path, so recordMcpNodePath
+    // has nothing to patch either — the only way to get zero writes to configPath.
     const deps = makeDeps({
       existsSync: vi.fn().mockReturnValue(true),
-      readFileSync: vi.fn().mockReturnValue(JSON.stringify({ version: 1 })),
+      readFileSync: vi.fn().mockReturnValue(JSON.stringify({ version: 1, mcpNodePath: process.execPath })),
+    });
+    const { ensureCore } = await import("../src/bootstrap.js");
+    await ensureCore(deps);
+    const configWrites = (deps.writeFileSync as ReturnType<typeof vi.fn>).mock.calls
+      .filter((args) => args[0] === deps.configPath);
+    expect(configWrites.length).toBe(0);
+  });
+
+  it("records the running node interpreter's absolute path into config.json", async () => {
+    const deps = makeDeps({
+      existsSync: vi.fn().mockReturnValue(true),
+      readFileSync: vi.fn().mockReturnValue(JSON.stringify({ version: 1, other: "kept" })),
+    });
+    const { ensureCore } = await import("../src/bootstrap.js");
+    await ensureCore(deps);
+    const configWrites = (deps.writeFileSync as ReturnType<typeof vi.fn>).mock.calls
+      .filter((args) => args[0] === deps.configPath);
+    expect(configWrites.length).toBe(1);
+    const written = JSON.parse(configWrites[0][1]);
+    expect(written.mcpNodePath).toBe(process.execPath);
+    expect(written.other).toBe("kept"); // read-modify-write preserves unrelated keys
+  });
+
+  it("does not touch config.json when it cannot be read (corrupt or unreadable)", async () => {
+    const deps = makeDeps({
+      existsSync: vi.fn().mockReturnValue(true),
+      readFileSync: vi.fn().mockImplementation(() => { throw new Error("EACCES"); }),
     });
     const { ensureCore } = await import("../src/bootstrap.js");
     await ensureCore(deps);

--- a/test/check-manifest.test.ts
+++ b/test/check-manifest.test.ts
@@ -1,0 +1,215 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { checkManifest } from "../scripts/check-manifest.mjs";
+import { syncVersions } from "../scripts/sync-versions.mjs";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeFixture() {
+  const root = mkdtempSync(join(tmpdir(), "lcm-check-manifest-"));
+  tempDirs.push(root);
+  mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+  return root;
+}
+
+function writePackageJson(root: string, overrides: Record<string, unknown> = {}) {
+  const pkg = {
+    name: "@lossless-claude/lcm",
+    version: "1.0.0",
+    dependencies: {},
+    peerDependencies: {},
+    devDependencies: {},
+    ...overrides,
+  };
+  writeFileSync(join(root, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+}
+
+function writePluginManifests(root: string, pluginVersion: string, marketplaceVersion: string) {
+  writeFileSync(
+    join(root, ".claude-plugin", "plugin.json"),
+    JSON.stringify({ name: "lcm", version: pluginVersion }, null, 2) + "\n"
+  );
+  writeFileSync(
+    join(root, ".claude-plugin", "marketplace.json"),
+    JSON.stringify({ name: "lossless-claude", plugins: [{ name: "lcm", version: marketplaceVersion }] }, null, 2) + "\n"
+  );
+}
+
+function writeDistFile(root: string, relPath: string, content: string) {
+  const full = join(root, "dist", relPath);
+  mkdirSync(join(full, ".."), { recursive: true });
+  writeFileSync(full, content);
+}
+
+describe("checkManifest — rule (a): declared imports", () => {
+  it("fails on an import that is not declared anywhere", () => {
+    const root = makeFixture();
+    writePackageJson(root);
+    writePluginManifests(root, "1.0.0", "1.0.0");
+    writeDistFile(root, "index.js", `import { foo } from "left-pad";\n`);
+
+    const findings = checkManifest(root);
+    expect(findings.some((f) => f.includes("left-pad"))).toBe(true);
+  });
+
+  it("passes when the import is only a peerDependency", () => {
+    const root = makeFixture();
+    writePackageJson(root, { peerDependencies: { openai: "^6.0.0" } });
+    writePluginManifests(root, "1.0.0", "1.0.0");
+    writeDistFile(root, "index.js", `import OpenAI from "openai";\n`);
+
+    const findings = checkManifest(root);
+    expect(findings).toEqual([]);
+  });
+
+  it("fails when the import is declared only as a devDependency", () => {
+    const root = makeFixture();
+    writePackageJson(root, { devDependencies: { openai: "^6.0.0" } });
+    writePluginManifests(root, "1.0.0", "1.0.0");
+    writeDistFile(root, "index.js", `import OpenAI from "openai";\n`);
+
+    const findings = checkManifest(root);
+    expect(findings.some((f) => f.includes("openai"))).toBe(true);
+  });
+
+  it("ignores node: builtins and relative imports", () => {
+    const root = makeFixture();
+    writePackageJson(root, { dependencies: { commander: "^14.0.0" } });
+    writePluginManifests(root, "1.0.0", "1.0.0");
+    writeDistFile(
+      root,
+      "index.js",
+      `import { readFileSync } from "node:fs";\n` +
+        `import { helper } from "./helper.js";\n` +
+        `import { program } from "commander";\n`
+    );
+    writeDistFile(root, "helper.js", `export const helper = 1;\n`);
+
+    const findings = checkManifest(root);
+    expect(findings).toEqual([]);
+  });
+
+  it("resolves a scoped subpath import to its package name", () => {
+    const root = makeFixture();
+    writePackageJson(root, { dependencies: { "@scope/pkg": "^1.0.0" } });
+    writePluginManifests(root, "1.0.0", "1.0.0");
+    writeDistFile(root, "index.js", `import { thing } from "@scope/pkg/sub";\n`);
+
+    const findings = checkManifest(root);
+    expect(findings).toEqual([]);
+  });
+
+  it("fails noisily when dist/ is missing", () => {
+    const root = makeFixture();
+    writePackageJson(root);
+    writePluginManifests(root, "1.0.0", "1.0.0");
+
+    const findings = checkManifest(root);
+    expect(findings.some((f) => f.toLowerCase().includes("dist"))).toBe(true);
+  });
+
+  it("fails noisily when dist/ has no code files", () => {
+    const root = makeFixture();
+    writePackageJson(root);
+    writePluginManifests(root, "1.0.0", "1.0.0");
+    writeDistFile(root, "README.md", "not code");
+
+    const findings = checkManifest(root);
+    expect(findings.some((f) => f.toLowerCase().includes("dist"))).toBe(true);
+  });
+
+  it("fails noisily when the scan finds zero external imports", () => {
+    const root = makeFixture();
+    writePackageJson(root);
+    writePluginManifests(root, "1.0.0", "1.0.0");
+    writeDistFile(root, "index.js", `const x = 1;\nexport { x };\n`);
+
+    const findings = checkManifest(root);
+    expect(findings.some((f) => f.includes("zero external imports"))).toBe(true);
+  });
+});
+
+describe("checkManifest — rule (b): version parity", () => {
+  it("fails when the three versions are out of step", () => {
+    const root = makeFixture();
+    writePackageJson(root, { dependencies: { openai: "^6.0.0" } });
+    writePluginManifests(root, "1.0.0", "1.0.0");
+    writeDistFile(root, "index.js", `import OpenAI from "openai";\n`);
+    // Bump only package.json.
+    writePackageJson(root, { version: "1.1.0", dependencies: { openai: "^6.0.0" } });
+
+    const findings = checkManifest(root);
+    expect(findings.some((f) => f.includes("Version mismatch"))).toBe(true);
+  });
+
+  it("fails when only the marketplace version diverges", () => {
+    const root = makeFixture();
+    writePackageJson(root, { dependencies: { openai: "^6.0.0" } });
+    writePluginManifests(root, "1.0.0", "0.9.0");
+    writeDistFile(root, "index.js", `import OpenAI from "openai";\n`);
+
+    const findings = checkManifest(root);
+    expect(findings.some((f) => f.includes("Version mismatch"))).toBe(true);
+  });
+
+  it("passes when all three versions match and imports are declared", () => {
+    const root = makeFixture();
+    writePackageJson(root, { dependencies: { openai: "^6.0.0" } });
+    writePluginManifests(root, "1.0.0", "1.0.0");
+    writeDistFile(root, "index.js", `import OpenAI from "openai";\n`);
+
+    const findings = checkManifest(root);
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("syncVersions", () => {
+  it("brings plugin.json and marketplace.json in step and preserves formatting", () => {
+    const root = makeFixture();
+    writePackageJson(root, { version: "2.3.4" });
+    writePluginManifests(root, "1.0.0", "1.0.0");
+
+    const pluginPath = join(root, ".claude-plugin", "plugin.json");
+    const marketplacePath = join(root, ".claude-plugin", "marketplace.json");
+    const beforePlugin = readFileSync(pluginPath, "utf8");
+    const beforeMarketplace = readFileSync(marketplacePath, "utf8");
+
+    syncVersions(root, "2.3.4");
+
+    const afterPlugin = readFileSync(pluginPath, "utf8");
+    const afterMarketplace = readFileSync(marketplacePath, "utf8");
+
+    expect(JSON.parse(afterPlugin).version).toBe("2.3.4");
+    expect(JSON.parse(afterMarketplace).plugins[0].version).toBe("2.3.4");
+
+    // Formatting preserved: same indentation width and trailing newline.
+    expect(afterPlugin.endsWith("\n")).toBe(beforePlugin.endsWith("\n"));
+    expect(afterMarketplace.endsWith("\n")).toBe(beforeMarketplace.endsWith("\n"));
+    expect(afterPlugin.match(/^ +/m)?.[0]).toBe(beforePlugin.match(/^ +/m)?.[0]);
+    expect(afterMarketplace.match(/^ +/m)?.[0]).toBe(beforeMarketplace.match(/^ +/m)?.[0]);
+
+    // The synced files now satisfy the version-parity rule they feed.
+    writeDistFile(root, "index.js", `export const x = 1;\nimport "left-pad";\n`);
+    // (left-pad import intentionally undeclared to isolate the version check —
+    // rule (a) finding is not asserted here.)
+    const findings = checkManifest(root).filter((f) => f.includes("Version mismatch"));
+    expect(findings).toEqual([]);
+  });
+
+  it("throws a clear error when marketplace.json has no plugins[0]", () => {
+    const root = makeFixture();
+    writePackageJson(root, { version: "2.3.4" });
+    writeFileSync(join(root, ".claude-plugin", "plugin.json"), JSON.stringify({ version: "1.0.0" }, null, 2) + "\n");
+    writeFileSync(join(root, ".claude-plugin", "marketplace.json"), JSON.stringify({ plugins: [] }, null, 2) + "\n");
+
+    expect(() => syncVersions(root, "2.3.4")).toThrow(/plugins\[0\]/);
+  });
+});

--- a/test/connectors/installer.test.ts
+++ b/test/connectors/installer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, isAbsolute } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installConnector, removeConnector, listConnectors } from '../../src/connectors/installer.js';
 import { LCM_MARKERS } from '../../src/connectors/constants.js';
@@ -56,7 +56,14 @@ describe('installConnector — MCP JSON', () => {
     expect(result.success).toBe(true);
     const config = JSON.parse(readFileSync(result.path, 'utf-8'));
     expect(config.mcpServers?.lcm).toBeDefined();
-    expect(config.mcpServers.lcm.command).toBe('lcm');
+    // The entry must not depend on PATH resolving `lcm` or a shim's `node` shebang (#424):
+    // command/args are absolute paths measured from the running installer process.
+    expect(config.mcpServers.lcm.command).not.toBe('lcm');
+    expect(config.mcpServers.lcm.command).not.toBe('node');
+    expect(isAbsolute(config.mcpServers.lcm.command)).toBe(true);
+    expect(config.mcpServers.lcm.args).toHaveLength(2);
+    expect(isAbsolute(config.mcpServers.lcm.args[0])).toBe(true);
+    expect(config.mcpServers.lcm.args[1]).toBe('mcp');
   });
 
   it('merges into existing JSON without overwriting other keys', () => {

--- a/test/connectors/lcm-mcp-launcher.test.ts
+++ b/test/connectors/lcm-mcp-launcher.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { chmodSync, copyFileSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// `.claude-plugin/lcm-mcp.sh` is the static launcher plugin.json's mcpServers.lcm
+// points at (#424). It must start the server under `env -i PATH=/usr/bin:/bin` —
+// i.e. without relying on PATH resolving `node` — by reading the interpreter path
+// lcm itself measured and recorded in config.json, falling back to PATH only when
+// nothing was recorded yet.
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const launcherSrc = join(repoRoot, ".claude-plugin", "lcm-mcp.sh");
+
+let dir: string;
+let pluginDir: string;
+let launcher: string;
+let fakeHome: string;
+
+function writeStubNode(path: string, label: string): void {
+  writeFileSync(path, `#!/bin/sh\necho "${label}: $@"\n`, "utf8");
+  chmodSync(path, 0o755);
+}
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "lcm-mcp-launcher-"));
+  pluginDir = join(dir, "plugin", ".claude-plugin");
+  mkdirSync(pluginDir, { recursive: true });
+  launcher = join(pluginDir, "lcm-mcp.sh");
+  copyFileSync(launcherSrc, launcher);
+  chmodSync(launcher, 0o755);
+  writeFileSync(join(dir, "plugin", "mcp.mjs"), "// stub\n", "utf8");
+  fakeHome = join(dir, "home");
+  mkdirSync(fakeHome, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function run(env: Record<string, string>): string {
+  return execFileSync("env", ["-i", `PATH=${env.PATH ?? "/usr/bin:/bin"}`, ...Object.entries(env)
+    .filter(([k]) => k !== "PATH")
+    .map(([k, v]) => `${k}=${v}`), launcher], { encoding: "utf8" }).trim();
+}
+
+// This is exactly the "Done when" contract for #424: `env -i PATH=/usr/bin:/bin` —
+// which has no `node` on macOS/most Linux — plus the coreutils (dirname/sed/grep)
+// the launcher itself needs for its own logic.
+const MINIMAL_PATH = "/usr/bin:/bin";
+
+it("execs the node path recorded in config.json, ignoring PATH entirely", () => {
+  const recordedNode = join(dir, "recorded-node");
+  writeStubNode(recordedNode, "recorded");
+  const defaultLcmHome = join(fakeHome, ".lossless-claude");
+  mkdirSync(defaultLcmHome, { recursive: true });
+  writeFileSync(join(defaultLcmHome, "config.json"), JSON.stringify({ mcpNodePath: recordedNode }, null, 2));
+
+  // PATH has no node at all — proves the config path, not PATH, wins.
+  const out = run({ PATH: MINIMAL_PATH, HOME: fakeHome });
+
+  expect(out).toBe(`recorded: ${join(dir, "plugin", "mcp.mjs")}`);
+});
+
+it("honors LCM_HOME over HOME, mirroring src/lcm-home.ts", () => {
+  const recordedNode = join(dir, "recorded-node");
+  writeStubNode(recordedNode, "recorded");
+  const lcmHome = join(dir, "custom-lcm-home");
+  mkdirSync(lcmHome, { recursive: true });
+  writeFileSync(join(lcmHome, "config.json"), JSON.stringify({ mcpNodePath: recordedNode }, null, 2));
+
+  const out = run({ PATH: MINIMAL_PATH, HOME: fakeHome, LCM_HOME: lcmHome });
+
+  expect(out).toBe(`recorded: ${join(dir, "plugin", "mcp.mjs")}`);
+});
+
+it("falls back to PATH when config.json has no recorded node path yet", () => {
+  const pathBin = join(dir, "bin");
+  mkdirSync(pathBin, { recursive: true });
+  writeStubNode(join(pathBin, "node"), "from-path");
+  // No config.json at all — first-ever run.
+
+  const out = run({ PATH: `${pathBin}:${MINIMAL_PATH}`, HOME: fakeHome });
+
+  expect(out).toBe(`from-path: ${join(dir, "plugin", "mcp.mjs")}`);
+});
+
+it("falls back to PATH when the recorded node path is stale (no longer executable)", () => {
+  const pathBin = join(dir, "bin");
+  mkdirSync(pathBin, { recursive: true });
+  writeStubNode(join(pathBin, "node"), "from-path");
+  const defaultLcmHome = join(fakeHome, ".lossless-claude");
+  mkdirSync(defaultLcmHome, { recursive: true });
+  writeFileSync(join(defaultLcmHome, "config.json"), JSON.stringify({ mcpNodePath: join(dir, "gone") }, null, 2));
+
+  const out = run({ PATH: `${pathBin}:${MINIMAL_PATH}`, HOME: fakeHome });
+
+  expect(out).toBe(`from-path: ${join(dir, "plugin", "mcp.mjs")}`);
+});
+
+it("exits non-zero with a clear message when no interpreter is found anywhere", () => {
+  expect(() => run({ PATH: MINIMAL_PATH, HOME: fakeHome })).toThrowError(
+    /Command failed/,
+  );
+  try {
+    run({ PATH: MINIMAL_PATH, HOME: fakeHome });
+  } catch (err: any) {
+    expect(String(err.stderr)).toContain("no node interpreter found");
+  }
+});

--- a/test/installer/mcp-server-entry.test.ts
+++ b/test/installer/mcp-server-entry.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import { isAbsolute } from "node:path";
+import { mcpServerEntry } from "../../src/installer/mcp-server-entry.js";
+
+describe("mcpServerEntry", () => {
+  it("defaults to absolute, measured paths — never bare 'lcm' or 'node'", () => {
+    const entry = mcpServerEntry();
+    expect(entry.command).not.toBe("lcm");
+    expect(entry.command).not.toBe("node");
+    expect(isAbsolute(entry.command)).toBe(true);
+    expect(entry.args).toHaveLength(2);
+    expect(isAbsolute(entry.args[0])).toBe(true);
+    expect(entry.args[1]).toBe("mcp");
+  });
+
+  it("defaults the node interpreter to the running process's own executable", () => {
+    const entry = mcpServerEntry();
+    expect(entry.command).toBe(process.execPath);
+  });
+
+  it("accepts overrides for both paths (used by tests / cross-checks)", () => {
+    const entry = mcpServerEntry({ nodePath: "/opt/node", cliPath: "/opt/dist/bin/lcm.js" });
+    expect(entry).toEqual({ command: "/opt/node", args: ["/opt/dist/bin/lcm.js", "mcp"] });
+  });
+});


### PR DESCRIPTION
Closes #424

Stacked on #439 (#423). Review the top commit only; base retargets to `main` automatically when #439 merges.

## Two registrations, two fixes

The issue names one. There are two, and the unversioned one is worse than described.

| entry | tracked | before | after |
|---|---|---|---|
| `.claude-plugin/plugin.json` → `plugin:lcm:lcm` | **yes** | `command: "node"` | `.claude-plugin/lcm-mcp.sh` |
| `~/.claude/settings.json` → `mcpServers.lcm` | no | `command: "lcm"` | `process.execPath` + absolute `dist/bin/lcm.js` |

`command: 'lcm'` depended on PATH finding the shim **and** on that shim's `#!/usr/bin/env node` finding node — two PATH dependencies, not one.

**Correction to the plan's reading of the code.** The scoping note cited `src/connectors/installer.ts:73` as the writer of `~/.claude/settings.json`. That line is real, but it writes generic MCP JSON targets (`.mcp.json`, `.qwen/mcp.json`). The actual writers of `~/.claude/settings.json` are `installer/install.ts:~245` and `src/doctor/doctor.ts:~427`, both through `resolveBinaryPath` (`command -v lcm`). The bug is identical at all three, so all three now build the entry through one `mcpServerEntry()` helper — otherwise the decision would have landed on every file except the one the issue is about.

## Why a `.sh`

`docs/design/mcp-interpreter-resolution.md` has it in full. In short: `plugin.json` is tracked, so it cannot hold a machine's node path; a launcher that guesses via `$NVM_DIR`/volta/homebrew encodes every install layout and still misses; so the path is **measured** by a process already running under a working node and written to `~/.lossless-claude/config.json`, the per-machine config lcm already owns. The tracked launcher only reads it, and falls back to PATH.

Precedent: `src/connectors/codex-hooks.ts` already resolves an interpreter exactly this way.

Failing to record the path is logged, not swallowed — silence there sends the launcher back to PATH for good, which is the failure this PR removes, and would look identical to never having tried.

## Done when — measured

Run with an interpreter that is deliberately absent from the `PATH` handed to the launcher, so a fallback to `PATH` cannot be mistaken for success:

```
$ env -i PATH=/usr/bin:/bin HOME=<home> LCM_HOME=<scratch> .claude-plugin/lcm-mcp.sh < initialize.json
{"result":{"protocolVersion":"2025-11-25","capabilities":{"tools":{}},
 "serverInfo":{"name":"lcm","version":"0.11.0"}},"jsonrpc":"2.0","id":1}

$ env -i PATH=/usr/bin:/bin .claude-plugin/lcm-mcp.sh < initialize.json
lcm-mcp.sh: no node interpreter found (checked <config> and PATH)
```

The second case is the degenerate one — no `HOME`, nothing recorded yet. It fails loudly rather than silently, which is the behaviour asked for.

The entry the installer writes names neither `lcm` nor `node`: `command` is the absolute path of the interpreter the installing process is itself running under, and `args[0]` the absolute path of `dist/bin/lcm.js`.

Full suite: **1732 passed, 6 skipped, 0 failed**. `npm run check-manifest` (new in #439) stays green.

## Follow-ups, not fixed here

- `resolveBinaryPath` in `installer/install.ts` now has no production caller, only tests. Left in place rather than removed in a PR about something else.
- **Windows.** There is no `win32` anywhere in `src/` and no `os` field in `package.json`, so a `.sh` launcher loses no platform that works today. Worth its own issue if Windows is ever targeted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a

