### PR TITLE
feat(import): attribute subagent sessions from their sidecar

### DIFF
--- a/.changeset/subagent-attribution.md
+++ b/.changeset/subagent-attribution.md
@@ -1,0 +1,10 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+fix: subagent transcripts keep their parent session, type, and description
+
+Subagent conversations imported from `~/.claude/projects/<session>/subagents/` now carry
+`parent_session_id`, `subagent_type`, and `subagent_desc`, read from each transcript's
+`.meta.json` sidecar. A one-time migration backfills these for subagent conversations
+already ingested, matching against transcripts still present on disk.

--- a/docs/design/subagent-attribution-from-sidecar.md
+++ b/docs/design/subagent-attribution-from-sidecar.md
@@ -1,0 +1,68 @@
+# Subagent attribution comes from the `.meta.json` sidecar
+
+**Status:** accepted, 2026-09-12. Implements #419.
+
+## What it is
+
+Every subagent transcript Claude Code writes to
+`<projectDir>/<parent-session-id>/subagents/agent-<id>.jsonl` has a `.meta.json` sidecar
+next to it. `conversations` gains three columns — `parent_session_id`, `subagent_type`,
+`subagent_desc` — filled from that sidecar when `findSessionFiles` (`src/import.ts`)
+discovers the transcript, and backfilled once for conversations already ingested
+(`src/db/migration.ts`).
+
+## Why the sidecar, not the parent transcript
+
+The parent session's own transcript already carries the dispatch: a `tool_use` block
+naming the `Agent` tool with `subagent_type` and `description` in its input, matched to
+the child by `agentId` in the corresponding `tool_result`. That join works — it is how
+this issue's investigation first measured `agentType`/`description` coverage — but it
+requires parsing the parent's transcript, which can be many megabytes, to recover two
+strings that are already sitting in a few-hundred-byte JSON file beside the child.
+
+The sidecar is measured at 100% coverage over every subagent transcript on disk (1204/1204
+at investigation time). Reading it costs one `readFileSync` per subagent, already being
+walked by `findSessionFiles`; reading the parent transcript would mean opening and
+parsing a second, unrelated, and potentially much larger file for every subagent found.
+
+`parent_session_id` follows the same logic in reverse: the directory name that owns
+`subagents/` already gives the immediate dispatcher for every transcript (1204/1204,
+verified). The 37 sidecars that also carry `parentAgentId` (a dispatch nested inside
+another subagent) resolve to a sibling `agent-<id>.jsonl` in the same directory, never to
+the top-level owning session — verified 37/37. So `parentAgentId`, when present, is
+preferred over the directory name; the directory name is the fallback, not a second
+source that needs reconciling against it.
+
+A third source exists and is deliberately not read: newer-format transcripts carry
+`parentSessionId` on their header line. That value is always the owning session — the
+same thing the directory name already gives for every transcript, sidecar or not.
+Reading a transcript file to recover what its own path already encodes has no payoff.
+
+## Why not `message_parts`
+
+`message_parts` has unused `subtask_agent` / `subtask_desc` columns that look purpose-built
+for this. They are a dead end here: the `INSERT` in `src/store/conversation-store.ts`
+does not list the `subtask_*` columns, and the only writer of parts at all is
+`src/compaction.ts` — no import path writes parts, so reaching those columns means
+building the parts pipeline from scratch. That pipeline is real, scoped, and separate
+(#421, structured skill/slash-command extraction from `parseTranscript`); duplicating a
+slice of it here to reach three columns nothing else populates yet would create two
+writers into the same table with different rules for what counts as "this row exists,"
+which is exactly the kind of drift `message-parts-vs-events-db.md` already flags as a
+cost worth avoiding. Session-level attribution belongs on `conversations`, one row per
+session, not `message_parts`, one row per structured fragment inside a session.
+
+## Backfill: gated by a marker, not by "still has nulls"
+
+The natural backfill guard — "does this database have any `agent-%` conversation with
+`parent_session_id IS NULL`?" — is wrong on its own: a conversation whose transcript was
+deleted from disk after import stays permanently unresolvable, so that guard would keep
+being true forever and re-walk all of `~/.claude/projects` on every single
+`runLcmMigrations` call (every daemon route, on every project database) for the life of
+the installation. Instead, a singleton table
+(`subagent_attribution_backfill`, `id INTEGER PRIMARY KEY CHECK (id = 1)`, the same shape
+as `session_instructions`) records that the sweep ran, plus how many conversations it
+could not resolve. The sweep itself still only touches disk when there is at least one
+unresolved `agent-%` row — most project databases never dispatched a subagent — and it is
+`UPDATE`-only: `summary_messages.message_id` is `ON DELETE RESTRICT`, so a compacted
+conversation can never be deleted and re-ingested to pick up new columns.

--- a/src/daemon/routes/ingest.ts
+++ b/src/daemon/routes/ingest.ts
@@ -77,6 +77,10 @@ export interface IngestInput {
   client?: "claude" | "codex";
   source?: "live" | "import";
   replay?: boolean;
+  /** Subagent attribution, carried from the transcript's `.meta.json` sidecar. */
+  parent_session_id?: string;
+  subagent_type?: string;
+  subagent_desc?: string;
 }
 
 export function resolveIngestMessages(input: IngestInput, cwd: string): ParsedMessage[] {
@@ -202,7 +206,11 @@ export function createIngestHandler(config: DaemonConfig): RouteHandler {
               throw new TranscriptError(error instanceof Error ? error.message : "invalid transcript");
             }
           }
-          const conversation = await conversationStore.getOrCreateConversation(session_id);
+          const conversation = await conversationStore.getOrCreateConversation(session_id, undefined, {
+            parentSessionId: input.parent_session_id,
+            subagentType: input.subagent_type,
+            subagentDesc: input.subagent_desc,
+          });
           // A recovery scan may skip only a verified, already-stored prefix.
           // Valid suffix reads begin exactly at the database's message count.
           const newMessages = parsed.slice(Math.max(0, storedCount - sourceCount));

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -1,6 +1,13 @@
 import type { DatabaseSync } from "node:sqlite";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { getLcmDbFeatures } from "./features.js";
 import { ensureCodexCursorTable } from "./codex-cursor.js";
+import { walkSubagentTranscripts } from "../subagent-attribution.js";
+
+function defaultClaudeProjectsDir(): string {
+  return join(homedir(), ".claude", "projects");
+}
 
 /** Disable foreign keys around a migration sweep (SQLite forbids toggling inside a transaction). */
 export function withForeignKeysDisabled(db: DatabaseSync, fn: () => void): void {
@@ -110,6 +117,78 @@ function ensureSummaryMetadataColumns(db: DatabaseSync): void {
   if (!hasSourceMessageTokenCount) {
     db.exec(`ALTER TABLE summaries ADD COLUMN source_message_token_count INTEGER NOT NULL DEFAULT 0`);
   }
+}
+
+/** conversations.parent_session_id / subagent_type / subagent_desc — see docs/design/subagent-attribution-from-sidecar.md. */
+function ensureSubagentAttributionColumns(db: DatabaseSync): void {
+  const columns = db.prepare(`PRAGMA table_info(conversations)`).all() as SummaryColumnInfo[];
+  const wanted = ["parent_session_id", "subagent_type", "subagent_desc"];
+  for (const name of wanted) {
+    if (!columns.some((col) => col.name === name)) {
+      db.exec(`ALTER TABLE conversations ADD COLUMN ${name} TEXT DEFAULT NULL`);
+    }
+  }
+}
+
+/**
+ * Marks the one-time subagent-attribution backfill done, so it never re-walks
+ * `~/.claude/projects` again on this database. `unmatched_count` is the
+ * number of `agent-%` conversations whose transcript was no longer on disk
+ * when the sweep ran — those stay NULL forever, which is expected, not a bug.
+ */
+function ensureSubagentBackfillTable(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS subagent_attribution_backfill (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      unmatched_count INTEGER NOT NULL DEFAULT 0,
+      completed_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+
+function hasUnresolvedAgentConversations(db: DatabaseSync): boolean {
+  const row = db
+    .prepare(`SELECT 1 FROM conversations WHERE session_id LIKE 'agent-%' AND parent_session_id IS NULL LIMIT 1`)
+    .get();
+  return row !== undefined;
+}
+
+type UnresolvedAgentConversationRow = { conversation_id: number; session_id: string };
+
+function applySubagentAttributionBackfill(db: DatabaseSync, claudeProjectsDir: string): number {
+  const bySessionId = new Map(walkSubagentTranscripts(claudeProjectsDir).map((e) => [e.sessionId, e.attribution]));
+  const rows = db
+    .prepare(`SELECT conversation_id, session_id FROM conversations WHERE session_id LIKE 'agent-%' AND parent_session_id IS NULL`)
+    .all() as UnresolvedAgentConversationRow[];
+
+  const updateStmt = db.prepare(
+    `UPDATE conversations SET parent_session_id = ?, subagent_type = ?, subagent_desc = ? WHERE conversation_id = ?`,
+  );
+  let unmatched = 0;
+  for (const row of rows) {
+    const attribution = bySessionId.get(row.session_id);
+    if (!attribution) {
+      unmatched++; // transcript no longer on disk — stays NULL
+      continue;
+    }
+    updateStmt.run(attribution.parentSessionId, attribution.subagentType, attribution.subagentDesc, row.conversation_id);
+  }
+  return unmatched;
+}
+
+/**
+ * Runs once per database: re-walks `~/.claude/projects` to fill
+ * `parent_session_id` / `subagent_type` / `subagent_desc` for every
+ * `agent-%` conversation imported before those columns existed. `UPDATE`
+ * only — `summary_messages.message_id` is `ON DELETE RESTRICT`, so a
+ * compacted conversation can never be deleted and re-ingested.
+ */
+function backfillSubagentAttribution(db: DatabaseSync, claudeProjectsDir: string): void {
+  ensureSubagentBackfillTable(db);
+  if (db.prepare(`SELECT 1 FROM subagent_attribution_backfill WHERE id = 1`).get()) return;
+
+  const unmatched = hasUnresolvedAgentConversations(db) ? applySubagentAttributionBackfill(db, claudeProjectsDir) : 0;
+  db.prepare(`INSERT INTO subagent_attribution_backfill (id, unmatched_count) VALUES (1, ?)`).run(unmatched);
 }
 
 function parseTimestamp(value: string | null | undefined): Date | null {
@@ -406,19 +485,19 @@ function backfillSummaryMetadata(db: DatabaseSync): void {
   }
 }
 
-export function runLcmMigrations(
-  db: DatabaseSync,
-  options?: { fts5Available?: boolean },
-): void {
+export interface LcmMigrationOptions {
+  fts5Available?: boolean;
+  /** Override for `~/.claude/projects` — tests only, so the backfill never walks the real disk. */
+  claudeProjectsDir?: string;
+}
+
+export function runLcmMigrations(db: DatabaseSync, options?: LcmMigrationOptions): void {
   // Foreign keys can stall schema changes against legacy rows (e.g. FTS
   // rebuilds that reinsert messages) — disable them for the sweep.
   withForeignKeysDisabled(db, () => runLcmMigrationsInner(db, options));
 }
 
-function runLcmMigrationsInner(
-  db: DatabaseSync,
-  options?: { fts5Available?: boolean },
-): void {
+function runLcmMigrationsInner(db: DatabaseSync, options?: LcmMigrationOptions): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS conversations (
       conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -625,6 +704,9 @@ function runLcmMigrationsInner(
   if (!taggingColumns.some((col) => col.name === "role_tagging")) {
     db.exec(`ALTER TABLE conversations ADD COLUMN role_tagging TEXT DEFAULT NULL`);
   }
+
+  ensureSubagentAttributionColumns(db);
+  backfillSubagentAttribution(db, options?.claudeProjectsDir ?? defaultClaudeProjectsDir());
 
   // Add archived_at to promoted if not present
   const promotedColumns = db.prepare(`PRAGMA table_info(promoted)`).all() as Array<{ name?: string }>;

--- a/src/import.ts
+++ b/src/import.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, existsSync, lstatSync } from "node:fs";
+import { readdirSync, readFileSync, existsSync, lstatSync, type Dirent } from "node:fs";
 import { join, basename } from "node:path";
 import { homedir } from "node:os";
 import { DatabaseSync } from "node:sqlite";
@@ -8,6 +8,7 @@ import { findAllCodexTranscripts } from "./codex-transcript.js";
 import type { ProgressState } from "./cli/progress-state.js";
 import { projectDbPath, projectId } from "./daemon/project.js";
 import { defaultLcmPaths } from "./lcm-paths.js";
+import { readSubagentAttribution } from "./subagent-attribution.js";
 import {
   appendReplayManifestSessions,
   clearReplayState,
@@ -97,8 +98,78 @@ function buildProjectMap(lcmDir?: string): Map<string, string> {
   return map;
 }
 
-export function findSessionFiles(projectDir: string): { path: string; sessionId: string; mtime: number }[] {
-  const files: { path: string; sessionId: string; mtime: number }[] = [];
+export interface DiscoveredSessionFile {
+  path: string;
+  sessionId: string;
+  mtime: number;
+  /** Subagent transcripts only — carried from the `.meta.json` sidecar. Absent for ordinary sessions. */
+  parentSessionId?: string | null;
+  subagentType?: string | null;
+  subagentDesc?: string | null;
+}
+
+function findFlatSessionFile(projectDir: string, entry: Dirent): DiscoveredSessionFile | null {
+  if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.endsWith('.jsonl')) return null;
+  try {
+    const filePath = join(projectDir, entry.name);
+    const st = lstatSync(filePath);
+    if (st.isSymbolicLink()) return null; // skip symlinks
+    return { path: filePath, sessionId: basename(entry.name, '.jsonl'), mtime: st.mtimeMs };
+  } catch {
+    return null; // file deleted or permissions issue
+  }
+}
+
+function findNestedSessionFile(projectDir: string, sessionDirName: string): DiscoveredSessionFile | null {
+  // Layout A (nested): <projectDir>/<session-id>/<session-id>.jsonl
+  const nestedTranscript = join(projectDir, sessionDirName, `${sessionDirName}.jsonl`);
+  if (!existsSync(nestedTranscript)) return null;
+  try {
+    const nestedStat = lstatSync(nestedTranscript);
+    if (nestedStat.isSymbolicLink() || !nestedStat.isFile()) return null;
+    return { path: nestedTranscript, sessionId: sessionDirName, mtime: nestedStat.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Subagent transcripts: <projectDir>/<session-id>/subagents/<agent-id>.jsonl.
+ * Each one's `.meta.json` sidecar is read here, alongside file discovery, so
+ * the attribution travels with the file — nothing is re-derived from the
+ * path later (see docs/design/subagent-attribution-from-sidecar.md).
+ */
+function findOneSubagentSessionFile(subagentsDir: string, sessionDirName: string, name: string): DiscoveredSessionFile | null {
+  try {
+    const subPath = join(subagentsDir, name);
+    const subSt = lstatSync(subPath);
+    if (subSt.isSymbolicLink()) return null; // skip symlinks
+    return {
+      path: subPath,
+      sessionId: basename(name, '.jsonl'),
+      mtime: subSt.mtimeMs,
+      ...readSubagentAttribution(subPath, sessionDirName),
+    };
+  } catch {
+    return null; // couldn't be stat'd
+  }
+}
+
+function findSubagentSessionFiles(projectDir: string, sessionDirName: string): DiscoveredSessionFile[] {
+  const subagentsDir = join(projectDir, sessionDirName, 'subagents');
+  if (!existsSync(subagentsDir)) return [];
+
+  const files: DiscoveredSessionFile[] = [];
+  for (const sub of readdirSync(subagentsDir, { withFileTypes: true })) {
+    if (!sub.isFile() || sub.isSymbolicLink() || !sub.name.endsWith('.jsonl')) continue;
+    const found = findOneSubagentSessionFile(subagentsDir, sessionDirName, sub.name);
+    if (found) files.push(found);
+  }
+  return files;
+}
+
+export function findSessionFiles(projectDir: string): DiscoveredSessionFile[] {
+  const files: DiscoveredSessionFile[] = [];
   if (!existsSync(projectDir)) return files;
 
   // Track which session IDs have a flat (project-root) transcript so we can
@@ -106,66 +177,17 @@ export function findSessionFiles(projectDir: string): { path: string; sessionId:
   const flatSessionIds = new Set<string>();
 
   for (const entry of readdirSync(projectDir, { withFileTypes: true })) {
-    // Layout B (flat): <projectDir>/<session-id>.jsonl
-    if (entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith('.jsonl')) {
-      try {
-        const filePath = join(projectDir, entry.name);
-        const st = lstatSync(filePath);
-        if (st.isSymbolicLink()) continue; // skip symlinks
-        const sessionId = basename(entry.name, '.jsonl');
-        files.push({
-          path: filePath,
-          sessionId,
-          mtime: st.mtimeMs,
-        });
-        flatSessionIds.add(sessionId);
-      } catch {
-        // Skip entries that can't be stat'd (file deleted or permissions issue)
-        continue;
-      }
+    const flat = findFlatSessionFile(projectDir, entry);
+    if (flat) {
+      files.push(flat);
+      flatSessionIds.add(flat.sessionId);
+      continue;
     }
-    if (entry.isDirectory() && !entry.isSymbolicLink()) {
-      // Layout A (nested): <projectDir>/<session-id>/<session-id>.jsonl
-      const nestedTranscript = join(projectDir, entry.name, `${entry.name}.jsonl`);
-      if (existsSync(nestedTranscript)) {
-        try {
-          const nestedStat = lstatSync(nestedTranscript);
-          if (nestedStat.isSymbolicLink()) {
-            // skip symlinks
-          } else if (nestedStat.isFile()) {
-            files.push({
-              path: nestedTranscript,
-              sessionId: entry.name,
-              mtime: nestedStat.mtimeMs,
-            });
-          }
-        } catch {
-          // Skip entries that can't be stat'd
-        }
-      }
+    if (!entry.isDirectory() || entry.isSymbolicLink()) continue;
 
-      // Subagent transcripts: <projectDir>/<session-id>/subagents/<agent-id>.jsonl
-      const subagentsDir = join(projectDir, entry.name, 'subagents');
-      if (existsSync(subagentsDir)) {
-        for (const sub of readdirSync(subagentsDir, { withFileTypes: true })) {
-          if (sub.isFile() && !sub.isSymbolicLink() && sub.name.endsWith('.jsonl')) {
-            try {
-              const subPath = join(subagentsDir, sub.name);
-              const subSt = lstatSync(subPath);
-              if (subSt.isSymbolicLink()) continue; // skip symlinks
-              files.push({
-                path: subPath,
-                sessionId: basename(sub.name, '.jsonl'),
-                mtime: subSt.mtimeMs,
-              });
-            } catch {
-              // Skip entries that can't be stat'd
-              continue;
-            }
-          }
-        }
-      }
-    }
+    const nested = findNestedSessionFile(projectDir, entry.name);
+    if (nested) files.push(nested);
+    files.push(...findSubagentSessionFiles(projectDir, entry.name));
   }
 
   // Deduplicate: when a session has both a flat and nested transcript,
@@ -196,6 +218,10 @@ interface SessionEntry {
   sessionId: string;
   cwd: string;
   client?: "claude" | "codex";
+  /** Subagent sessions only — see DiscoveredSessionFile. */
+  parentSessionId?: string | null;
+  subagentType?: string | null;
+  subagentDesc?: string | null;
 }
 
 type CompactLlmUsage = {
@@ -369,7 +395,7 @@ async function ingestSessionList(
   const total = sessions.length + doneCount;
   const processedBase = doneCount;
 
-  for (const { path, sessionId, cwd, client: sourceClient = "claude" } of sessions) {
+  for (const { path, sessionId, cwd, client: sourceClient = "claude", parentSessionId, subagentType, subagentDesc } of sessions) {
     // Stop starting new work after SIGINT/SIGTERM; the renderer waits for the
     // in-flight session to settle before exiting.
     if (options.onBeforeSession && !options.onBeforeSession()) break;
@@ -415,6 +441,10 @@ async function ingestSessionList(
         ...(sourceClient === "codex" ? { client: "codex" } : {}),
         // A completed session's transcript may have grown; replay must ingest the tail.
         ...(options.replay ? { replay: true } : {}),
+        // Subagent attribution, carried from the sidecar findSessionFiles already read.
+        ...(parentSessionId ? { parent_session_id: parentSessionId } : {}),
+        ...(subagentType ? { subagent_type: subagentType } : {}),
+        ...(subagentDesc ? { subagent_desc: subagentDesc } : {}),
       });
       if (res.ingested === 0 && res.totalTokens === 0) {
         result.skippedEmpty++;

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -72,10 +72,20 @@ export type MessagePartRecord = {
   metadata: string | null;
 };
 
+/**
+ * Subagent attribution, carried from the transcript's `.meta.json` sidecar
+ * (see src/subagent-attribution.ts). Undefined/null for ordinary sessions.
+ */
+export type SubagentAttributionInput = {
+  parentSessionId?: string | null;
+  subagentType?: string | null;
+  subagentDesc?: string | null;
+};
+
 export type CreateConversationInput = {
   sessionId: string;
   title?: string;
-};
+} & SubagentAttributionInput;
 
 export type ConversationRecord = {
   conversationId: ConversationId;
@@ -86,6 +96,9 @@ export type ConversationRecord = {
   updatedAt: Date;
   /** "tagged" when the rows separate tool output from human text; null when unknown. */
   roleTagging: "tagged" | null;
+  parentSessionId: string | null;
+  subagentType: string | null;
+  subagentDesc: string | null;
 };
 
 export type MessageSearchInput = {
@@ -116,6 +129,9 @@ interface ConversationRow {
   created_at: string;
   updated_at: string;
   role_tagging: string | null;
+  parent_session_id: string | null;
+  subagent_type: string | null;
+  subagent_desc: string | null;
 }
 
 interface MessageRow {
@@ -159,6 +175,9 @@ interface MaxSeqRow {
   max_seq: number;
 }
 
+const CONVERSATION_SELECT_COLUMNS = `SELECT conversation_id, session_id, title, bootstrapped_at, created_at, updated_at,
+       role_tagging, parent_session_id, subagent_type, subagent_desc`;
+
 // ── Row mappers ───────────────────────────────────────────────────────────────
 
 function toConversationRecord(row: ConversationRow): ConversationRecord {
@@ -170,6 +189,9 @@ function toConversationRecord(row: ConversationRow): ConversationRecord {
     createdAt: parseSqliteDate(row.created_at),
     updatedAt: parseSqliteDate(row.updated_at),
     roleTagging: row.role_tagging === "tagged" ? "tagged" : null,
+    parentSessionId: row.parent_session_id,
+    subagentType: row.subagent_type,
+    subagentDesc: row.subagent_desc,
   };
 }
 
@@ -245,14 +267,20 @@ export class ConversationStore {
       // Every conversation opened from here on is parsed by the tagging
       // parser. Older ones keep NULL, which reads as unknown; they are never
       // re-tagged, so the marker states what is known rather than guessing.
-      .prepare(`INSERT INTO conversations (session_id, title, role_tagging) VALUES (?, ?, 'tagged')`)
-      .run(input.sessionId, input.title ?? null);
+      .prepare(
+        `INSERT INTO conversations (session_id, title, role_tagging, parent_session_id, subagent_type, subagent_desc)
+         VALUES (?, ?, 'tagged', ?, ?, ?)`,
+      )
+      .run(
+        input.sessionId,
+        input.title ?? null,
+        input.parentSessionId ?? null,
+        input.subagentType ?? null,
+        input.subagentDesc ?? null,
+      );
 
     const row = this.db
-      .prepare(
-        `SELECT conversation_id, session_id, title, bootstrapped_at, created_at, updated_at, role_tagging
-       FROM conversations WHERE conversation_id = ?`,
-      )
+      .prepare(`${CONVERSATION_SELECT_COLUMNS} FROM conversations WHERE conversation_id = ?`)
       .get(Number(result.lastInsertRowid)) as unknown as ConversationRow;
 
     return toConversationRecord(row);
@@ -264,10 +292,7 @@ export class ConversationStore {
 
   getConversationSync(conversationId: ConversationId): ConversationRecord | null {
     const row = this.db
-      .prepare(
-        `SELECT conversation_id, session_id, title, bootstrapped_at, created_at, updated_at, role_tagging
-       FROM conversations WHERE conversation_id = ?`,
-      )
+      .prepare(`${CONVERSATION_SELECT_COLUMNS} FROM conversations WHERE conversation_id = ?`)
       .get(conversationId) as unknown as ConversationRow | undefined;
 
     return row ? toConversationRecord(row) : null;
@@ -276,7 +301,7 @@ export class ConversationStore {
   async getConversationBySessionId(sessionId: string): Promise<ConversationRecord | null> {
     const row = this.db
       .prepare(
-        `SELECT conversation_id, session_id, title, bootstrapped_at, created_at, updated_at, role_tagging
+        `${CONVERSATION_SELECT_COLUMNS}
        FROM conversations
        WHERE session_id = ?
        ORDER BY created_at DESC
@@ -287,12 +312,16 @@ export class ConversationStore {
     return row ? toConversationRecord(row) : null;
   }
 
-  async getOrCreateConversation(sessionId: string, title?: string): Promise<ConversationRecord> {
+  async getOrCreateConversation(
+    sessionId: string,
+    title?: string,
+    attribution?: SubagentAttributionInput,
+  ): Promise<ConversationRecord> {
     const existing = await this.getConversationBySessionId(sessionId);
     if (existing) {
       return existing;
     }
-    return this.createConversation({ sessionId, title });
+    return this.createConversation({ sessionId, title, ...attribution });
   }
 
   async markConversationBootstrapped(conversationId: ConversationId): Promise<void> {
@@ -309,7 +338,7 @@ export class ConversationStore {
   async listConversations(): Promise<ConversationRecord[]> {
     const rows = this.db
       .prepare(
-        `SELECT conversation_id, session_id, title, bootstrapped_at, created_at, updated_at, role_tagging
+        `${CONVERSATION_SELECT_COLUMNS}
        FROM conversations
        ORDER BY created_at`,
       )

--- a/src/subagent-attribution.ts
+++ b/src/subagent-attribution.ts
@@ -1,0 +1,108 @@
+import { existsSync, readdirSync, readFileSync, type Dirent } from "node:fs";
+import { basename, join } from "node:path";
+
+/**
+ * What a subagent transcript's `.meta.json` sidecar can tell us about the
+ * dispatch that created it. All three are null together: either the sidecar
+ * is missing/unreadable, or the transcript is not a subagent transcript at
+ * all (findSessionFiles never calls this for flat/nested session files).
+ */
+export interface SubagentAttribution {
+  parentSessionId: string | null;
+  subagentType: string | null;
+  subagentDesc: string | null;
+}
+
+const EMPTY_ATTRIBUTION: SubagentAttribution = {
+  parentSessionId: null,
+  subagentType: null,
+  subagentDesc: null,
+};
+
+/**
+ * Reads the `.meta.json` sidecar next to a subagent transcript.
+ *
+ * `folderSessionId` is the session that owns the `subagents/` directory the
+ * transcript lives in — the parent for the common case (no `parentAgentId`
+ * in the sidecar). When the sidecar does carry `parentAgentId` (a nested
+ * dispatch), the immediate dispatcher is a sibling `agent-<id>.jsonl` in the
+ * same directory, not the owning session, so the id is prefixed with
+ * `agent-` to match that sibling's own `session_id`.
+ *
+ * A missing, unreadable, or invalid sidecar yields all three fields null —
+ * not an error, and no fallback to the folder name.
+ */
+export function readSubagentAttribution(
+  transcriptPath: string,
+  folderSessionId: string,
+): SubagentAttribution {
+  const metaPath = transcriptPath.replace(/\.jsonl$/, ".meta.json");
+  if (!existsSync(metaPath)) return EMPTY_ATTRIBUTION;
+
+  let meta: Record<string, unknown>;
+  try {
+    meta = JSON.parse(readFileSync(metaPath, "utf-8"));
+  } catch {
+    return EMPTY_ATTRIBUTION;
+  }
+
+  const parentAgentId = typeof meta.parentAgentId === "string" && meta.parentAgentId ? meta.parentAgentId : null;
+  return {
+    parentSessionId: parentAgentId ? `agent-${parentAgentId}` : folderSessionId,
+    subagentType: typeof meta.agentType === "string" ? meta.agentType : null,
+    subagentDesc: typeof meta.description === "string" ? meta.description : null,
+  };
+}
+
+export interface SubagentTranscriptEntry {
+  /** Matches a `conversations.session_id` value (e.g. `agent-<id>`). */
+  sessionId: string;
+  attribution: SubagentAttribution;
+}
+
+/**
+ * Walks every `<project>/<session>/subagents/*.jsonl` transcript under a
+ * `~/.claude/projects`-shaped directory, reading each one's sidecar. Used by
+ * the one-time migration backfill — `findSessionFiles` in `import.ts` reads
+ * sidecars inline during its own walk instead of calling this.
+ */
+export function walkSubagentTranscripts(claudeProjectsDir: string): SubagentTranscriptEntry[] {
+  const entries: SubagentTranscriptEntry[] = [];
+  if (!existsSync(claudeProjectsDir)) return entries;
+
+  for (const projectEntry of readdirSync(claudeProjectsDir, { withFileTypes: true })) {
+    if (!projectEntry.isDirectory()) continue;
+    collectProjectSubagentTranscripts(join(claudeProjectsDir, projectEntry.name), entries);
+  }
+
+  return entries;
+}
+
+function collectProjectSubagentTranscripts(projectDir: string, out: SubagentTranscriptEntry[]): void {
+  for (const sessionEntry of readdirSync(projectDir, { withFileTypes: true })) {
+    if (!sessionEntry.isDirectory()) continue;
+    collectSubagentTranscripts(projectDir, sessionEntry.name, out);
+  }
+}
+
+function collectSubagentTranscripts(
+  projectDir: string,
+  folderSessionId: string,
+  out: SubagentTranscriptEntry[],
+): void {
+  const subagentsDir = join(projectDir, folderSessionId, "subagents");
+  if (!existsSync(subagentsDir)) return;
+
+  for (const sub of readdirSync(subagentsDir, { withFileTypes: true })) {
+    if (!isSubagentTranscriptFile(sub)) continue;
+    const transcriptPath = join(subagentsDir, sub.name);
+    out.push({
+      sessionId: basename(sub.name, ".jsonl"),
+      attribution: readSubagentAttribution(transcriptPath, folderSessionId),
+    });
+  }
+}
+
+function isSubagentTranscriptFile(entry: Dirent): boolean {
+  return entry.isFile() && !entry.isSymbolicLink() && entry.name.endsWith(".jsonl");
+}

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -136,6 +136,70 @@ describe("findSessionFiles", () => {
     expect(sessionIds).toEqual(["agent-1", "session-parent"]);
   });
 
+  it("reads subagent attribution from the .meta.json sidecar", () => {
+    const dir = makeTmpDir();
+    const subDir = join(dir, "session-parent");
+    const subagentsDir = join(subDir, "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-child.jsonl"), "");
+    writeFileSync(
+      join(subagentsDir, "agent-child.meta.json"),
+      JSON.stringify({ agentType: "explorer", description: "look around" }),
+    );
+
+    const result = findSessionFiles(dir);
+    const child = result.find((f) => f.sessionId === "agent-child");
+    expect(child?.subagentType).toBe("explorer");
+    expect(child?.subagentDesc).toBe("look around");
+    // No parentAgentId in the sidecar: parent is the folder that owns subagents/.
+    expect(child?.parentSessionId).toBe("session-parent");
+  });
+
+  it("prefers the sidecar's parentAgentId over the owning folder, prefixed to match a sibling session id", () => {
+    const dir = makeTmpDir();
+    const subDir = join(dir, "session-parent");
+    const subagentsDir = join(subDir, "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-nested.jsonl"), "");
+    writeFileSync(
+      join(subagentsDir, "agent-nested.meta.json"),
+      JSON.stringify({ agentType: "worker", parentAgentId: "dispatcher-id" }),
+    );
+
+    const result = findSessionFiles(dir);
+    const nested = result.find((f) => f.sessionId === "agent-nested");
+    expect(nested?.parentSessionId).toBe("agent-dispatcher-id");
+  });
+
+  it("leaves attribution null when the sidecar is missing", () => {
+    const dir = makeTmpDir();
+    const subDir = join(dir, "session-parent");
+    const subagentsDir = join(subDir, "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-orphan.jsonl"), "");
+
+    const result = findSessionFiles(dir);
+    const orphan = result.find((f) => f.sessionId === "agent-orphan");
+    expect(orphan?.parentSessionId ?? null).toBeNull();
+    expect(orphan?.subagentType ?? null).toBeNull();
+    expect(orphan?.subagentDesc ?? null).toBeNull();
+  });
+
+  it("leaves attribution null when the sidecar has invalid JSON", () => {
+    const dir = makeTmpDir();
+    const subDir = join(dir, "session-parent");
+    const subagentsDir = join(subDir, "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-bad.jsonl"), "");
+    writeFileSync(join(subagentsDir, "agent-bad.meta.json"), "{not json");
+
+    const result = findSessionFiles(dir);
+    const bad = result.find((f) => f.sessionId === "agent-bad");
+    expect(bad?.parentSessionId ?? null).toBeNull();
+    expect(bad?.subagentType ?? null).toBeNull();
+    expect(bad?.subagentDesc ?? null).toBeNull();
+  });
+
   it("deduplicates when both flat and nested transcripts exist for the same session", () => {
     const dir = makeTmpDir();
     // Flat transcript at project root

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -370,6 +370,161 @@ describe("session_ingest_log table migration", () => {
     const info = db.prepare("PRAGMA table_info(session_ingest_log)").all() as Array<{ name: string }>;
     expect(info.length).toBeGreaterThan(0);
 
+    db.close();
+  });
+});
+
+describe("subagent attribution backfill", () => {
+  function makeFixtureDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "lossless-claude-subagent-fixture-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  function makeLegacyDb(): { db: ReturnType<typeof getLcmConnection>; dbPath: string } {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claude-subagent-backfill-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "legacy.db");
+    const db = getLcmConnection(dbPath);
+    // A conversations table shaped like it was before parent_session_id/subagent_type/subagent_desc existed.
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        title TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    return { db, dbPath };
+  }
+
+  it("adds the three attribution columns to a legacy conversations table", () => {
+    const { db } = makeLegacyDb();
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    const columns = (db.prepare(`PRAGMA table_info(conversations)`).all() as Array<{ name: string }>).map(
+      (c) => c.name,
+    );
+    expect(columns).toContain("parent_session_id");
+    expect(columns).toContain("subagent_type");
+    expect(columns).toContain("subagent_desc");
+    db.close();
+  });
+
+  it("fills attribution for an agent-% conversation from its sidecar, falling back to the owning folder", () => {
+    const { db } = makeLegacyDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'agent-child')`).run();
+
+    const fixture = makeFixtureDir();
+    const subagentsDir = join(fixture, "proj-hash", "owning-session", "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-child.jsonl"), "");
+    writeFileSync(
+      join(subagentsDir, "agent-child.meta.json"),
+      JSON.stringify({ agentType: "idea-explorer", description: "explore" }),
+    );
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: fixture });
+
+    const row = db
+      .prepare(`SELECT parent_session_id, subagent_type, subagent_desc FROM conversations WHERE conversation_id = 1`)
+      .get() as { parent_session_id: string | null; subagent_type: string | null; subagent_desc: string | null };
+    expect(row).toEqual({
+      parent_session_id: "owning-session",
+      subagent_type: "idea-explorer",
+      subagent_desc: "explore",
+    });
+    db.close();
+  });
+
+  it("resolves a nested dispatch's parentAgentId to the sibling's session id, not the owning session", () => {
+    const { db } = makeLegacyDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'agent-nested')`).run();
+
+    const fixture = makeFixtureDir();
+    const subagentsDir = join(fixture, "proj-hash", "owning-session", "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-nested.jsonl"), "");
+    writeFileSync(
+      join(subagentsDir, "agent-nested.meta.json"),
+      JSON.stringify({ agentType: "worker", parentAgentId: "dispatcher-id" }),
+    );
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: fixture });
+
+    const row = db
+      .prepare(`SELECT parent_session_id FROM conversations WHERE conversation_id = 1`)
+      .get() as { parent_session_id: string | null };
+    expect(row.parent_session_id).toBe("agent-dispatcher-id");
+    db.close();
+  });
+
+  it("leaves an agent-% conversation null and counts it unmatched when its transcript is gone from disk", () => {
+    const { db } = makeLegacyDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'agent-deleted')`).run();
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    const row = db
+      .prepare(`SELECT parent_session_id, subagent_type, subagent_desc FROM conversations WHERE conversation_id = 1`)
+      .get() as { parent_session_id: string | null; subagent_type: string | null; subagent_desc: string | null };
+    expect(row).toEqual({ parent_session_id: null, subagent_type: null, subagent_desc: null });
+
+    const marker = db
+      .prepare(`SELECT unmatched_count FROM subagent_attribution_backfill WHERE id = 1`)
+      .get() as { unmatched_count: number };
+    expect(marker.unmatched_count).toBe(1);
+    db.close();
+  });
+
+  it("never deletes a conversation row (UPDATE only, never DELETE)", () => {
+    const { db } = makeLegacyDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'agent-a'), (2, 'plain-session')`).run();
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    const count = db.prepare(`SELECT COUNT(*) AS n FROM conversations`).get() as { n: number };
+    expect(count.n).toBe(2);
+    db.close();
+  });
+
+  it("runs the disk walk only once: a transcript that appears after the first run is never backfilled", () => {
+    const { db } = makeLegacyDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'agent-late')`).run();
+
+    const fixture = makeFixtureDir();
+    // First run: no transcript on disk yet — stays null, marker gets written.
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: fixture });
+
+    // Transcript shows up on disk after the fact.
+    const subagentsDir = join(fixture, "proj-hash", "owning-session", "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-late.jsonl"), "");
+    writeFileSync(join(subagentsDir, "agent-late.meta.json"), JSON.stringify({ agentType: "late" }));
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: fixture }); // second run — should be a no-op
+
+    const row = db
+      .prepare(`SELECT parent_session_id, subagent_type FROM conversations WHERE conversation_id = 1`)
+      .get() as { parent_session_id: string | null; subagent_type: string | null };
+    expect(row).toEqual({ parent_session_id: null, subagent_type: null });
+
+    const markerCount = db.prepare(`SELECT COUNT(*) AS n FROM subagent_attribution_backfill`).get() as { n: number };
+    expect(markerCount.n).toBe(1);
+    db.close();
+  });
+
+  it("does not touch a conversation whose session_id does not start with agent-", () => {
+    const { db } = makeLegacyDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'plain-session')`).run();
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    const row = db
+      .prepare(`SELECT parent_session_id FROM conversations WHERE conversation_id = 1`)
+      .get() as { parent_session_id: string | null };
+    expect(row.parent_session_id).toBeNull();
     db.close();
   });
 });

--- a/test/subagent-attribution.test.ts
+++ b/test/subagent-attribution.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { readSubagentAttribution, walkSubagentTranscripts } from "../src/subagent-attribution.js";
+
+describe("readSubagentAttribution", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeTmpDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "lcm-subagent-attr-test-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  it("falls back to the folder session id when the sidecar has no parentAgentId", () => {
+    const dir = makeTmpDir();
+    const transcriptPath = join(dir, "agent-child.jsonl");
+    writeFileSync(transcriptPath, "");
+    writeFileSync(join(dir, "agent-child.meta.json"), JSON.stringify({ agentType: "explorer", description: "d" }));
+
+    const result = readSubagentAttribution(transcriptPath, "owning-session");
+    expect(result).toEqual({
+      parentSessionId: "owning-session",
+      subagentType: "explorer",
+      subagentDesc: "d",
+    });
+  });
+
+  it("prefixes parentAgentId with agent- to match the sibling's session id", () => {
+    const dir = makeTmpDir();
+    const transcriptPath = join(dir, "agent-nested.jsonl");
+    writeFileSync(transcriptPath, "");
+    writeFileSync(join(dir, "agent-nested.meta.json"), JSON.stringify({ parentAgentId: "abc123" }));
+
+    const result = readSubagentAttribution(transcriptPath, "owning-session");
+    expect(result.parentSessionId).toBe("agent-abc123");
+  });
+
+  it("returns all-null when the sidecar file is missing", () => {
+    const dir = makeTmpDir();
+    const transcriptPath = join(dir, "agent-orphan.jsonl");
+    writeFileSync(transcriptPath, "");
+
+    expect(readSubagentAttribution(transcriptPath, "owning-session")).toEqual({
+      parentSessionId: null,
+      subagentType: null,
+      subagentDesc: null,
+    });
+  });
+
+  it("returns all-null when the sidecar has invalid JSON, without throwing", () => {
+    const dir = makeTmpDir();
+    const transcriptPath = join(dir, "agent-bad.jsonl");
+    writeFileSync(transcriptPath, "");
+    writeFileSync(join(dir, "agent-bad.meta.json"), "{not json");
+
+    expect(() => readSubagentAttribution(transcriptPath, "owning-session")).not.toThrow();
+    expect(readSubagentAttribution(transcriptPath, "owning-session")).toEqual({
+      parentSessionId: null,
+      subagentType: null,
+      subagentDesc: null,
+    });
+  });
+});
+
+describe("walkSubagentTranscripts", () => {
+  const dirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  });
+
+  function makeTmpDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "lcm-subagent-walk-test-"));
+    dirs.push(dir);
+    return dir;
+  }
+
+  it("returns empty for a nonexistent projects dir", () => {
+    expect(walkSubagentTranscripts("/nonexistent/path")).toEqual([]);
+  });
+
+  it("finds subagent transcripts across projects and sessions", () => {
+    const root = makeTmpDir();
+    const subagentsDir = join(root, "project-a", "session-1", "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-x.jsonl"), "");
+    writeFileSync(join(subagentsDir, "agent-x.meta.json"), JSON.stringify({ agentType: "worker" }));
+
+    const entries = walkSubagentTranscripts(root);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].sessionId).toBe("agent-x");
+    expect(entries[0].attribution.subagentType).toBe("worker");
+    expect(entries[0].attribution.parentSessionId).toBe("session-1");
+  });
+});


### PR DESCRIPTION
Closes #419

## Where the attribution already was

Every subagent transcript has a `.meta.json` beside it. Measured across all of them:

| | |
|---|---|
| transcripts | 1204 |
| with a sidecar | **1204** |
| with `agentType` | **1204** |
| with `description` | 1203 |
| with `parentAgentId` | 37 |

```json
{"agentType":"autoimprove:idea-explorer","description":"Idea #3 — ...",
 "toolUseId":"toolu_01BEk...","spawnDepth":1,"model":"haiku"}
```

So this needs no join and no parsing of the parent's transcript. The three values become columns of `conversations`, read in the same walk that discovers the file, and travel with it through `SessionEntry` → `/ingest` → `getOrCreateConversation`.

`parent_session_id` is `agent-<parentAgentId>` when the sidecar carries one, the owning session's folder name otherwise. All 37 `parentAgentId` values resolve to a sibling transcript in the same folder, none to the owning session — so both branches are exact, not approximate.

A missing, unreadable or malformed sidecar leaves the three columns null and the session imports exactly as before. That is not an error.

## Two things the issue said that are not what this does

- **`message_parts.subtask_agent` is a dead end.** It holds zero rows, but the reason matters: the `INSERT` in `conversation-store.ts` does not list the `subtask_*` columns at all, and the only writer of parts is `compaction.ts`. No import path writes parts. The fields go to `conversations`.
- **The transcript header's `parentSessionId` is ignored on purpose.** 23 new-format transcripts carry it, and it is always the owning session — the same thing the folder name gives for all 1204. Reading a file for what the path already says is cost without gain.

`docs/design/subagent-attribution-from-sidecar.md` records both, plus why the backfill is marker-gated.

## The backfill

`UPDATE` only, never `DELETE` — `summary_messages.message_id` is `ON DELETE RESTRICT`. It runs once inside the migration, gated by a singleton marker table rather than by "are there still nulls": migrations run on almost every daemon route call, and a transcript deleted after import can never resolve, so a nulls-based guard would re-walk `~/.claude/projects` on every call, forever.

## Done when — measured twice, by two routes

Run against copies of the project databases that hold `agent-%` conversations, never a live store; then re-derived independently with a separate probe that indexes disk and database by different code paths and aborts if either side comes back empty.

Both routes agree: of 2100 `agent-%` conversations, **470** have a transcript still on disk, and all 470 receive `parent_session_id`, `subagent_type` and `subagent_desc`. Spot checks show real values (an agent type and its dispatch description, not placeholders). Re-running is a no-op. `COUNT(*)` is unchanged in every run — no row was deleted.

The remainder stay null and could not do otherwise: their transcripts are gone. The largest zero-match database was interrogated directly, and a brute-force filename search of the entire transcript tree finds nothing for its sample id. That is why the Done-when is worded "whose transcript still exists on disk"; a promise of zero nulls could never close.

Transcripts under `subagents/workflows/` are counted separately and left alone — that is #433's scope.

Full suite: **1726 passed, 6 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a

