### PR TITLE
ci: validate the plugin manifest, and write down what typecheck:hooks cannot do

### DIFF
--- a/.changeset/validate-plugin-manifest-in-ci.md
+++ b/.changeset/validate-plugin-manifest-in-ci.md
@@ -1,0 +1,24 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+fix: the four bundled agents now load with their frontmatter, and CI validates the plugin
+
+`agents/memory-explorer.md`, `agents/compaction-reviewer.md`,
+`agents/transcript-debugger.md` and `agents/health-investigator.md` each wrote a
+multi-line `description` as a plain YAML scalar, which does not parse. Every one
+of them had been loading with its name taken from the filename and every other
+field — description, model, color, tools — silently dropped, since the first
+release that shipped them. The descriptions are now literal block scalars, byte
+for byte the same text, and they parse.
+
+`ci.yml` runs `claude plugin validate` after `check-manifest`: strictly against
+`.claude-plugin/marketplace.json`, and, naming `.claude-plugin/plugin.json`, a
+full walk of the plugin's agents, skills, commands and hooks module. That walk is
+what found the frontmatter defect above. `.claude-plugin/marketplace.json` also
+gains the top-level `description` that `--strict` asks for.
+
+This does not replace `npm run typecheck:hooks`, which stays local-only:
+`plugin validate` checks structure, not whether a `$` method still exists on the
+running build. Both reasons are now written down, in `docs/ci-runner.md` and
+`docs/hook-protocol.md`.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,6 @@
 {
   "name": "lossless-claude",
+  "description": "Lossless context management — DAG-based summarization that preserves every message",
   "owner": {
     "name": "Pedro",
     "url": "https://github.com/ipedro"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,24 @@ jobs:
       - name: Check manifest
         run: npm run check-manifest
 
+      - name: Validate plugin manifest
+        # Two invocations, because they validate different things: the repo root
+        # holds both manifests and marketplace.json wins there, so the plugin's
+        # own agents, skills, commands and hooks are only walked when plugin.json
+        # is named. --strict on that walk would fail on one structural warning:
+        # CLAUDE.md at the root is this repo's project-instruction file, not
+        # plugin context, and this repo is both a project and a plugin. Errors
+        # still fail without it — that walk is what caught four agents whose
+        # frontmatter never parsed. Fork runners have no `claude`, so a missing
+        # binary skips loudly rather than going red. See docs/ci-runner.md.
+        run: |
+          if ! command -v claude >/dev/null 2>&1; then
+            echo "::warning title=plugin validate skipped::claude CLI not on PATH on this runner; the plugin and marketplace manifests were not structurally validated this run (see docs/ci-runner.md)"
+            exit 0
+          fi
+          claude plugin validate --strict .
+          claude plugin validate .claude-plugin/plugin.json
+
       - name: Run tests
         run: npm test
 

--- a/agents/compaction-reviewer.md
+++ b/agents/compaction-reviewer.md
@@ -1,6 +1,7 @@
 ---
 name: compaction-reviewer
-description: Use this agent to review compaction quality — checks whether summaries accurately preserve important information from source messages. Use proactively after compaction completes, or when the user asks about summary quality. Examples:
+description: |-
+  Use this agent to review compaction quality — checks whether summaries accurately preserve important information from source messages. Use proactively after compaction completes, or when the user asks about summary quality. Examples:
 
   <example>
   Context: A compaction just finished and the user wants to verify quality

--- a/agents/health-investigator.md
+++ b/agents/health-investigator.md
@@ -1,6 +1,7 @@
 ---
 name: health-investigator
-description: Use this agent for deep investigation of lossless-claude health issues — goes beyond the doctor checklist to find root causes. Examples:
+description: |-
+  Use this agent for deep investigation of lossless-claude health issues — goes beyond the doctor checklist to find root causes. Examples:
 
   <example>
   Context: Doctor shows failures but the cause isn't obvious

--- a/agents/memory-explorer.md
+++ b/agents/memory-explorer.md
@@ -1,6 +1,7 @@
 ---
 name: memory-explorer
-description: Use this agent when the user wants to search conversation history, find past decisions, or recall what was discussed in previous sessions. Examples:
+description: |-
+  Use this agent when the user wants to search conversation history, find past decisions, or recall what was discussed in previous sessions. Examples:
 
   <example>
   Context: User wants to find a past architectural decision

--- a/agents/transcript-debugger.md
+++ b/agents/transcript-debugger.md
@@ -1,6 +1,7 @@
 ---
 name: transcript-debugger
-description: Use this agent when transcript ingestion fails, messages are missing after ingest, or JSONL parsing errors occur. Examples:
+description: |-
+  Use this agent when transcript ingestion fails, messages are missing after ingest, or JSONL parsing errors occur. Examples:
 
   <example>
   Context: The compact hook failed during transcript parsing

--- a/docs/ci-runner.md
+++ b/docs/ci-runner.md
@@ -10,6 +10,43 @@ The job retains the `ci` check name and runs dependency installation, typecheck,
 build, tests, and workspace-artifact checks. Superseded runs for the same ref are
 cancelled, and each run has a 30-minute timeout.
 
+## Validate plugin manifest
+
+The step runs `claude plugin validate` twice, because the two invocations
+validate different things:
+
+```sh
+claude plugin validate --strict .
+claude plugin validate .claude-plugin/plugin.json
+```
+
+The repo root holds both `marketplace.json` and `plugin.json`, and the
+marketplace manifest wins there — so the first call checks only that manifest,
+strictly: unrecognized fields, missing metadata, and other issues the runtime
+tolerates. The plugin's own agents, skills, commands and hooks module are walked
+only when `plugin.json` is named, which is what the second call does.
+
+That second call is deliberately **not** `--strict`. Under `--strict` it fails
+on one structural warning — that root `CLAUDE.md` is not loaded as plugin
+context — which is true and not worth acting on: this repository is both a
+project and a plugin, and `CLAUDE.md` is its project-instruction file. Errors
+still fail the step without `--strict`, and errors are what matter here: this
+walk is what found four `agents/*.md` files whose YAML frontmatter had never
+parsed, so each of those agents had been loading with every field but the
+filename-derived name silently dropped.
+
+Both calls need the `claude` CLI, which a fork PR's GitHub-hosted Linux box does
+not have. The step therefore checks `command -v claude` first and, when absent,
+prints a `::warning::` annotation and exits `0` rather than failing red — loud,
+not silent. On the self-hosted Mac mini the binary is on the saved runner PATH
+(`~/actions-runner-lcm/.path` includes `~/.local/bin`); if that file is ever
+regenerated, re-add that entry or the step goes quiet on every run.
+
+What this step does **not** do: it does not know whether a given
+`$.noun.method(...)` call still exists on any particular Claude Code build. See
+`docs/hook-protocol.md` for what it validates instead, and why it does not
+replace `npm run typecheck:hooks`.
+
 ## Isolation
 
 Fork pull requests run on GitHub-hosted Linux. Same-repository branches execute
@@ -28,7 +65,8 @@ The LCM instance lives in `~/actions-runner-lcm`. Use its own `svc.sh` to inspec
 or restart it; do not reconfigure or stop dwigt's instance. Runner credentials
 stay outside this repository. A fresh registration requires a short-lived token
 from this repository and the additional `lcm` label. Verify the service's `.path`
-contains `/opt/homebrew/bin` before starting it.
+contains `/opt/homebrew/bin` (ripgrep) and `~/.local/bin` (the `claude` CLI, for
+the plugin-manifest step) before starting it.
 
 ```sh
 gh api repos/lossless-claude/lcm/actions/runners \

--- a/docs/hook-protocol.md
+++ b/docs/hook-protocol.md
@@ -145,6 +145,8 @@ Both halves are load-bearing. The claim is what proves the module actually regis
 
 **Types:** run `/plugin-types` in a session with the flag on; it writes `claude-code.d.ts` for the running build. Regenerate after a Claude Code update rather than editing. `claude plugin validate` reads the module statically: `$` may only be passed to a top-level function, and calls must be spelled `$.noun.method(...)`.
 
+**Type-checking `hooks/` (`npm run typecheck:hooks`, not run in CI):** `scripts/typecheck-hooks.sh` compiles `hooks/lcm-hooks.ts` against `.claude/types/claude-code.d.ts`, the declarations written by `/plugin-types`. Those declarations are early access, gitignored, and describe whatever build wrote them — a committed copy would compile clean against an API a later release removed, which is the exact failure this check exists to catch. So it only runs locally, on demand, compared against the Claude Code build installed on the machine running it: before touching `hooks/lcm-hooks.ts`, and again after any Claude Code update. `claude plugin validate` (wired into CI, see `docs/ci-runner.md`) checks the module's structure — declared hooks, `$.noun.method(...)` call shape — but not whether a given `$` method still exists on the running build; it does not catch a renamed or removed method, and does not substitute for `typecheck:hooks`.
+
 ## SessionSnapshot Hook
 
 **Command:** `lcm session-snapshot`


### PR DESCRIPTION
Closes #435

## The half that cannot run in CI, and now says so

`typecheck:hooks` needs `.claude/types/claude-code.d.ts`, which `/plugin-types` writes from a live session and which is gitignored deliberately. Committing it to get the check into CI is the obvious move and it is the wrong one: the `plugin-authoring` skill states the declarations are the authority of the **running** build, and that the response to an update is *"regenerate rather than edit"*. A committed copy becomes a stale authority that compiles clean against an API a later release removed — the exact failure the check exists to catch. `tsconfig.hooks.json` already refused this in a comment; the reason is now in `docs/hook-protocol.md`, where a contributor reads it.

## The half that can

`claude plugin validate`, whose `--strict` help says "Use in CI". Wired up twice, because the two calls check different things:

```sh
claude plugin validate --strict .                    # marketplace.json only
claude plugin validate .claude-plugin/plugin.json    # agents, skills, commands, hooks
```

The repo root holds both manifests and `marketplace.json` wins there, so the plugin's own contents are walked only when `plugin.json` is named.

The second call is **not** `--strict` on purpose. Under `--strict` one structural warning fails it — root `CLAUDE.md` is not plugin context — which is true and not worth acting on: this repository is both a project and a plugin, and `CLAUDE.md` is its project-instruction file. Errors still fail without it, and errors are the point.

## It found four real ones on its first run

`agents/memory-explorer.md`, `agents/compaction-reviewer.md`, `agents/transcript-debugger.md`, `agents/health-investigator.md`:

```
✘ frontmatter: YAML frontmatter failed to parse: YAML Parse error: Unexpected token.
  At runtime this agent loads with its name taken from the filename and every
  other frontmatter field silently dropped.
```

Each wrote a multi-line `description` as a plain YAML scalar. Every one of these agents has been shipping with `description`, `model`, `color` and `tools` silently dropped since the release that introduced them. Fixed as literal block scalars — the same text, byte for byte.

`marketplace.json` also gains the top-level `description` that `--strict` asks for.

## Behaviour, verified

| scenario | exit |
|---|---|
| both calls, `claude` on PATH | 0 |
| any agent's frontmatter unparseable | **1** |
| `claude` absent from PATH | 0, with a `::warning::` annotation |

The failing row is the one that matters: a check that cannot go red is decoration. A fork pull request's runner has no `claude`, so the step skips **loudly** rather than silently or red. On the self-hosted runner the binary must be on the saved runner PATH or the step skips on every run — `docs/ci-runner.md` states that next to the ripgrep requirement it already carried.

Full suite: **1732 passed, 6 skipped, 0 failed**. `check-manifest` stays green.

## What this deliberately does not claim

`plugin validate` does not know whether a `$` method still exists on the running build. A hooks module calling `$.fs.bogusMethod("x")` and `$.nonsense.thing()` validates `✔ Validation passed`, exit 0, and the invented calls do not even appear in its `calls:` line. It checks structure, not API existence. It complements `typecheck:hooks`; it does not replace it, and neither doc says otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
