### PR TITLE
feat(transcript): record skill and command invocations as message parts

### DIFF
--- a/.changeset/skill-command-message-parts.md
+++ b/.changeset/skill-command-message-parts.md
@@ -1,0 +1,14 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+feat: record skill invocations and slash commands as `message_parts` structure
+
+A skill's name arrives in the `Skill` tool_use's own `input.skill` field, and a slash
+command arrives as a `<command-name>` block — both already reach the database, but only
+as a substring of a message body, so nothing could filter on them. `parseTranscript` now
+extracts both into `message_parts` rows (`skill` / `command`), used by both CLI import and
+the daemon's `/ingest`. Existing databases get their `part_type` `CHECK` rebuilt to admit
+the two new values, then backfilled once, both straight from stored message content, no
+disk read: slash commands from the `<command-name>` block, and skill names from Claude
+Code's own "Launching skill: `<name>`" follow-up line, which is stored verbatim.

--- a/src/daemon/routes/ingest.ts
+++ b/src/daemon/routes/ingest.ts
@@ -8,9 +8,9 @@ import { sendJson } from "../server.js";
 import type { RouteHandler } from "../server.js";
 import { runLcmMigrations } from "../../db/migration.js";
 import { upsertRedactionCounts } from "../../db/redaction-stats.js";
-import { ConversationStore } from "../../store/conversation-store.js";
+import { ConversationStore, type CreateMessagePartInput, type MessageRecord } from "../../store/conversation-store.js";
 import { SummaryStore } from "../../store/summary-store.js";
-import { parseTranscript, type ParsedMessage } from "../../transcript.js";
+import { parseTranscript, type ParsedMessage, type MessagePart } from "../../transcript.js";
 import { extractCodexSessionMeta, parseCodexTranscript } from "../../codex-transcript.js";
 import { ScrubEngine } from "../../scrub.js";
 import { validateCwd } from "../validate-cwd.js";
@@ -81,6 +81,31 @@ export interface IngestInput {
   parent_session_id?: string;
   subagent_type?: string;
   subagent_desc?: string;
+}
+
+function toMessagePartInput(sessionId: string, part: MessagePart, ordinal: number): CreateMessagePartInput {
+  return { sessionId, partType: part.type, ordinal, toolName: part.name, toolInput: part.args };
+}
+
+/**
+ * `parseTranscript` is the only place that extracts skill/command structure
+ * (see src/transcript.ts) — this just writes what it found, for whichever
+ * newly-inserted message carried it.
+ */
+async function persistMessageParts(
+  conversationStore: ConversationStore,
+  sessionId: string,
+  sourceMessages: ParsedMessage[],
+  created: MessageRecord[],
+): Promise<void> {
+  for (let i = 0; i < created.length; i++) {
+    const parts = sourceMessages[i]?.parts;
+    if (!parts || parts.length === 0) continue;
+    await conversationStore.createMessageParts(
+      created[i].messageId,
+      parts.map((part, ordinal) => toMessagePartInput(sessionId, part, ordinal)),
+    );
+  }
 }
 
 export function resolveIngestMessages(input: IngestInput, cwd: string): ParsedMessage[] {
@@ -237,6 +262,7 @@ export function createIngestHandler(config: DaemonConfig): RouteHandler {
             if (created.length > 0) {
               upsertRedactionCounts(db, pid, totalCounts);
               await summaryStore.appendContextMessages(conversation.conversationId, created.map((r) => r.messageId));
+              await persistMessageParts(conversationStore, session_id, newMessages, created);
             }
             if (cursor && codexPath) saveCodexCursor(db, {
               conversationId: conversation.conversationId, transcriptPath: codexPath, cursor,

--- a/src/db/migration.ts
+++ b/src/db/migration.ts
@@ -1,9 +1,11 @@
 import type { DatabaseSync } from "node:sqlite";
+import { randomUUID } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { getLcmDbFeatures } from "./features.js";
 import { ensureCodexCursorTable } from "./codex-cursor.js";
 import { walkSubagentTranscripts } from "../subagent-attribution.js";
+import { extractCommandParts, type MessagePart } from "../transcript.js";
 
 function defaultClaudeProjectsDir(): string {
   return join(homedir(), ".claude", "projects");
@@ -485,6 +487,179 @@ function backfillSummaryMetadata(db: DatabaseSync): void {
   }
 }
 
+/**
+ * `message_parts.part_type` gained `'skill'` and `'command'` in #421. A fresh
+ * database is created with both already in its `CHECK`; this rebuilds an
+ * existing table that predates them, preserving every row (compaction events
+ * included) — see docs/design/message-parts-vs-events-db.md.
+ */
+function ensureMessagePartsSkillCommandTypes(db: DatabaseSync): void {
+  const existing = db
+    .prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='message_parts'`)
+    .get() as { sql?: string } | undefined;
+  if (!existing?.sql || existing.sql.includes("'skill'")) return;
+
+  const columns = (db.prepare(`PRAGMA table_info(message_parts)`).all() as Array<{ name: string }>)
+    .map((c) => c.name)
+    .join(", ");
+
+  // A SAVEPOINT, not a bare sequence of statements: CREATE/INSERT/DROP/RENAME
+  // each auto-commit on their own, so a crash between DROP and RENAME would
+  // otherwise strand every row (compaction events included) in an orphaned
+  // `message_parts_new`, invisible to the `'skill'`-in-CHECK guard above.
+  db.exec("SAVEPOINT message_parts_rebuild");
+  try {
+    db.exec(`
+      CREATE TABLE message_parts_new (
+        part_id TEXT PRIMARY KEY,
+        message_id INTEGER NOT NULL REFERENCES messages(message_id) ON DELETE CASCADE,
+        session_id TEXT NOT NULL,
+        part_type TEXT NOT NULL CHECK (part_type IN (
+          'text', 'reasoning', 'tool', 'patch', 'file',
+          'subtask', 'compaction', 'step_start', 'step_finish',
+          'snapshot', 'agent', 'retry', 'skill', 'command'
+        )),
+        ordinal INTEGER NOT NULL,
+        text_content TEXT,
+        is_ignored INTEGER,
+        is_synthetic INTEGER,
+        tool_call_id TEXT,
+        tool_name TEXT,
+        tool_status TEXT,
+        tool_input TEXT,
+        tool_output TEXT,
+        tool_error TEXT,
+        tool_title TEXT,
+        patch_hash TEXT,
+        patch_files TEXT,
+        file_mime TEXT,
+        file_name TEXT,
+        file_url TEXT,
+        subtask_prompt TEXT,
+        subtask_desc TEXT,
+        subtask_agent TEXT,
+        step_reason TEXT,
+        step_cost REAL,
+        step_tokens_in INTEGER,
+        step_tokens_out INTEGER,
+        snapshot_hash TEXT,
+        compaction_auto INTEGER,
+        metadata TEXT,
+        UNIQUE (message_id, ordinal)
+      );
+    `);
+    db.exec(`INSERT INTO message_parts_new (${columns}) SELECT ${columns} FROM message_parts;`);
+    db.exec("DROP TABLE message_parts;");
+    db.exec("ALTER TABLE message_parts_new RENAME TO message_parts;");
+    db.exec(`
+      CREATE INDEX IF NOT EXISTS message_parts_message_idx ON message_parts (message_id);
+      CREATE INDEX IF NOT EXISTS message_parts_type_idx ON message_parts (part_type);
+    `);
+    db.exec("RELEASE SAVEPOINT message_parts_rebuild");
+  } catch (err) {
+    db.exec("ROLLBACK TO SAVEPOINT message_parts_rebuild");
+    db.exec("RELEASE SAVEPOINT message_parts_rebuild");
+    throw err;
+  }
+}
+
+function ensureMessagePartsBackfillTable(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS message_parts_skill_command_backfill (
+      id INTEGER PRIMARY KEY CHECK (id = 1),
+      unmatched_skill_count INTEGER NOT NULL DEFAULT 0,
+      completed_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+}
+
+function insertMessagePart(
+  db: DatabaseSync,
+  input: { messageId: number; sessionId: string; ordinal: number; part: MessagePart },
+): void {
+  db.prepare(
+    `INSERT INTO message_parts (part_id, message_id, session_id, part_type, ordinal, tool_name, tool_input)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(randomUUID(), input.messageId, input.sessionId, input.part.type, input.ordinal, input.part.name, input.part.args);
+}
+
+/**
+ * Slash-command parts are fully recoverable from `messages.content`: the
+ * `<command-name>`/`<command-args>` block is stored verbatim, so no disk
+ * read is needed — same extractor `parseTranscript` uses, applied to what is
+ * already in the database.
+ */
+function backfillCommandParts(db: DatabaseSync): void {
+  const rows = db
+    .prepare(
+      `SELECT m.message_id, m.content, c.session_id
+       FROM messages m JOIN conversations c ON c.conversation_id = m.conversation_id
+       WHERE m.content LIKE '%<command-name>%'`,
+    )
+    .all() as Array<{ message_id: number; content: string; session_id: string }>;
+
+  for (const row of rows) {
+    extractCommandParts(row.content).forEach((part, ordinal) =>
+      insertMessagePart(db, { messageId: row.message_id, sessionId: row.session_id, ordinal, part }),
+    );
+  }
+}
+
+const LAUNCHING_SKILL_PREFIX = "Launching skill: ";
+
+/**
+ * The bare tool name ("Skill") that `toolContent` keeps for a tool-only turn
+ * loses the invocation's name, but Claude Code's own follow-up turn does not:
+ * it opens with `Launching skill: <name>` verbatim (measured across every
+ * project database: 1434 such rows, 33 projects, 128 distinct names), stored
+ * as-is because that turn's content is a plain string, not a content-block
+ * array `extractText`/`toolContent` would otherwise process. So this is
+ * recoverable straight from `messages.content`, the same shape as commands —
+ * no disk read needed. The name may itself contain a colon (`plugin:skill`);
+ * only the newline that ends the line is the terminator.
+ */
+function backfillSkillParts(db: DatabaseSync): number {
+  const rows = db
+    .prepare(
+      `SELECT m.message_id, m.content, c.session_id
+       FROM messages m JOIN conversations c ON c.conversation_id = m.conversation_id
+       WHERE m.content LIKE ?`,
+    )
+    .all(`${LAUNCHING_SKILL_PREFIX}%`) as Array<{ message_id: number; content: string; session_id: string }>;
+
+  let unmatched = 0;
+  for (const row of rows) {
+    const name = row.content.slice(LAUNCHING_SKILL_PREFIX.length).split("\n")[0].trim();
+    if (!name) {
+      unmatched++;
+      continue;
+    }
+    insertMessagePart(db, {
+      messageId: row.message_id,
+      sessionId: row.session_id,
+      ordinal: 0,
+      part: { type: "skill", name, args: null },
+    });
+  }
+  return unmatched;
+}
+
+/**
+ * Runs once per database: fills `message_parts` with `skill` and `command`
+ * rows for every message already in the store, both recoverable straight
+ * from `messages.content` — see backfillCommandParts and backfillSkillParts.
+ * Pure `INSERT`: no existing row is ever deleted or rewritten.
+ */
+function backfillMessagePartsSkillCommand(db: DatabaseSync): void {
+  ensureMessagePartsBackfillTable(db);
+  if (db.prepare(`SELECT 1 FROM message_parts_skill_command_backfill WHERE id = 1`).get()) return;
+
+  backfillCommandParts(db);
+  const unmatchedSkillCount = backfillSkillParts(db);
+  db.prepare(`INSERT INTO message_parts_skill_command_backfill (id, unmatched_skill_count) VALUES (1, ?)`)
+    .run(unmatchedSkillCount);
+}
+
 export interface LcmMigrationOptions {
   fts5Available?: boolean;
   /** Override for `~/.claude/projects` — tests only, so the backfill never walks the real disk. */
@@ -542,7 +717,7 @@ function runLcmMigrationsInner(db: DatabaseSync, options?: LcmMigrationOptions):
       part_type TEXT NOT NULL CHECK (part_type IN (
         'text', 'reasoning', 'tool', 'patch', 'file',
         'subtask', 'compaction', 'step_start', 'step_finish',
-        'snapshot', 'agent', 'retry'
+        'snapshot', 'agent', 'retry', 'skill', 'command'
       )),
       ordinal INTEGER NOT NULL,
       text_content TEXT,
@@ -634,6 +809,7 @@ function runLcmMigrationsInner(db: DatabaseSync, options?: LcmMigrationOptions):
   ensureSummaryMetadataColumns(db);
   backfillSummaryDepths(db);
   backfillSummaryMetadata(db);
+  ensureMessagePartsSkillCommandTypes(db);
 
   // Redaction stats (counts of secrets scrubbed per project per category).
   // v0.7.0 created this table with CHECK(category IN ('built_in', 'global', 'project')).
@@ -707,6 +883,7 @@ function runLcmMigrationsInner(db: DatabaseSync, options?: LcmMigrationOptions):
 
   ensureSubagentAttributionColumns(db);
   backfillSubagentAttribution(db, options?.claudeProjectsDir ?? defaultClaudeProjectsDir());
+  backfillMessagePartsSkillCommand(db);
 
   // Add archived_at to promoted if not present
   const promotedColumns = db.prepare(`PRAGMA table_info(promoted)`).all() as Array<{ name?: string }>;

--- a/src/store/conversation-store.ts
+++ b/src/store/conversation-store.ts
@@ -26,7 +26,9 @@ export type MessagePartType =
   | "step_finish"
   | "snapshot"
   | "agent"
-  | "retry";
+  | "retry"
+  | "skill"
+  | "command";
 
 export type CreateMessageInput = {
   conversationId: ConversationId;

--- a/src/transcript.ts
+++ b/src/transcript.ts
@@ -6,6 +6,8 @@ interface ContentBlock {
   name?: string;
   is_error?: boolean;
   content?: string | ContentBlock[];
+  /** `tool_use` input — only read when `name === "Skill"`, for the skill's name and args. */
+  input?: { skill?: unknown; args?: unknown };
 }
 
 interface TranscriptLine {
@@ -16,10 +18,20 @@ interface TranscriptLine {
   };
 }
 
+/**
+ * A skill invocation or slash command, recorded as structure rather than as a
+ * substring of a message body. Never the expanded skill prompt or command
+ * output — that stays in the message's own content.
+ */
+export type MessagePart =
+  | { type: "skill"; name: string; args: string | null }
+  | { type: "command"; name: string; args: string | null };
+
 export interface ParsedMessage {
   role: string;
   content: string;
   tokenCount: number;
+  parts?: MessagePart[];
 }
 
 function extractText(content: string | ContentBlock[] | unknown): string {
@@ -92,6 +104,38 @@ function toolContent(blocks: ContentBlock[]): string {
   return lines.filter(line => line.trim() !== "").join("\n");
 }
 
+/**
+ * A `Skill` tool_use already carries its name in a structured field — the
+ * expansion that follows is what arrives as text, not the invocation itself.
+ */
+function extractSkillParts(blocks: ContentBlock[]): MessagePart[] {
+  const parts: MessagePart[] = [];
+  for (const block of blocks) {
+    if (block.type !== "tool_use" || block.name !== "Skill") continue;
+    const skill = typeof block.input?.skill === "string" ? block.input.skill.trim() : "";
+    if (!skill) continue;
+    const args = typeof block.input?.args === "string" ? block.input.args.trim() : "";
+    parts.push({ type: "skill", name: skill, args: args || null });
+  }
+  return parts;
+}
+
+const COMMAND_NAME_RE = /<command-name>([^<]*)<\/command-name>/;
+const COMMAND_ARGS_RE = /<command-args>([^<]*)<\/command-args>/;
+
+/** A slash command block quoted inside a code fence is documentation, not an invocation. */
+function stripCodeFences(text: string): string {
+  return text.replace(/```[\s\S]*?```/g, "");
+}
+
+export function extractCommandParts(text: string): MessagePart[] {
+  const searchable = stripCodeFences(text);
+  const name = searchable.match(COMMAND_NAME_RE)?.[1]?.trim();
+  if (!name) return [];
+  const args = searchable.match(COMMAND_ARGS_RE)?.[1]?.trim() ?? "";
+  return [{ type: "command", name, args: args || null }];
+}
+
 export function parseTranscript(transcriptPath: string): ParsedMessage[] {
   let raw: string;
   try {
@@ -110,12 +154,12 @@ export function parseTranscript(transcriptPath: string): ParsedMessage[] {
       if (!entryRole || !["user", "assistant", "system"].includes(entryRole)) continue;
       // One transcript entry stays one message, whatever it holds. Splitting a
       // turn into several would break the sequence every reader depends on.
+      const blocks = blocksOf(obj.message?.content);
       const role = roleOf(entryRole, obj.message?.content);
-      const content = role === "tool"
-        ? toolContent(blocksOf(obj.message?.content))
-        : extractText(obj.message?.content);
+      const content = role === "tool" ? toolContent(blocks) : extractText(obj.message?.content);
       if (!content.trim()) continue;
-      messages.push({ role, content, tokenCount: estimateTokens(content) });
+      const parts = [...extractSkillParts(blocks), ...extractCommandParts(content)];
+      messages.push({ role, content, tokenCount: estimateTokens(content), ...(parts.length ? { parts } : {}) });
     } catch {
       // skip malformed lines
     }

--- a/test/daemon/routes/ingest.test.ts
+++ b/test/daemon/routes/ingest.test.ts
@@ -252,6 +252,55 @@ describe("POST /ingest", () => {
     }
   });
 
+  it("writes skill and command message_parts for messages carrying them", async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-ingest-parts-"));
+    tempDirs.push(tempDir);
+
+    daemon = await createDaemon(loadDaemonConfig("/nonexistent", { daemon: { port: 0 } }));
+    const res = await fetch(`http://127.0.0.1:${daemon.address().port}/ingest`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        session_id: "parts-test-1",
+        cwd: tempDir,
+        messages: [
+          { role: "user", content: "roda os testes", tokenCount: 3 },
+          {
+            role: "user",
+            content: "<command-name>/model</command-name><command-args>opus</command-args>",
+            tokenCount: 4,
+            parts: [{ type: "command", name: "/model", args: "opus" }],
+          },
+          {
+            role: "tool",
+            content: "Skill",
+            tokenCount: 1,
+            parts: [{ type: "skill", name: "grilling", args: null }],
+          },
+        ],
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ingested: 3, totalTokens: 8 });
+
+    const db = new DatabaseSync(projectDbPath(tempDir));
+    try {
+      const parts = db
+        .prepare(
+          `SELECT part_type, tool_name, tool_input FROM message_parts mp
+           JOIN messages m ON m.message_id = mp.message_id
+           ORDER BY m.seq`,
+        )
+        .all();
+      expect(parts).toEqual([
+        { part_type: "command", tool_name: "/model", tool_input: "opus" },
+        { part_type: "skill", tool_name: "grilling", tool_input: null },
+      ]);
+    } finally {
+      db.close();
+    }
+  });
+
   it("accepts messages[] as an alternative to transcript_path", async () => {
     const tempDir = mkdtempSync(join(tmpdir(), "lossless-ingest-"));
     tempDirs.push(tempDir);

--- a/test/migration.test.ts
+++ b/test/migration.test.ts
@@ -528,3 +528,217 @@ describe("subagent attribution backfill", () => {
     db.close();
   });
 });
+
+describe("message_parts skill/command backfill (#421)", () => {
+  function makeFixtureDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "lossless-claude-parts-fixture-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  /** A recent-legacy DB: every table modern except message_parts, whose CHECK predates 'skill'/'command'. */
+  function makeLegacyMessagePartsDb(): { db: ReturnType<typeof getLcmConnection>; dbPath: string } {
+    const tempDir = mkdtempSync(join(tmpdir(), "lossless-claude-parts-backfill-"));
+    tempDirs.push(tempDir);
+    const dbPath = join(tempDir, "legacy.db");
+    const db = getLcmConnection(dbPath);
+    db.exec(`
+      CREATE TABLE conversations (
+        conversation_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        title TEXT,
+        bootstrapped_at TEXT,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        role_tagging TEXT DEFAULT NULL,
+        parent_session_id TEXT DEFAULT NULL,
+        subagent_type TEXT DEFAULT NULL,
+        subagent_desc TEXT DEFAULT NULL
+      );
+
+      CREATE TABLE messages (
+        message_id INTEGER PRIMARY KEY AUTOINCREMENT,
+        conversation_id INTEGER NOT NULL REFERENCES conversations(conversation_id) ON DELETE CASCADE,
+        seq INTEGER NOT NULL,
+        role TEXT NOT NULL CHECK (role IN ('system', 'user', 'assistant', 'tool')),
+        content TEXT NOT NULL,
+        token_count INTEGER NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE (conversation_id, seq)
+      );
+
+      CREATE TABLE message_parts (
+        part_id TEXT PRIMARY KEY,
+        message_id INTEGER NOT NULL REFERENCES messages(message_id) ON DELETE CASCADE,
+        session_id TEXT NOT NULL,
+        part_type TEXT NOT NULL CHECK (part_type IN (
+          'text', 'reasoning', 'tool', 'patch', 'file',
+          'subtask', 'compaction', 'step_start', 'step_finish',
+          'snapshot', 'agent', 'retry'
+        )),
+        ordinal INTEGER NOT NULL,
+        text_content TEXT,
+        is_ignored INTEGER,
+        is_synthetic INTEGER,
+        tool_call_id TEXT,
+        tool_name TEXT,
+        tool_status TEXT,
+        tool_input TEXT,
+        tool_output TEXT,
+        tool_error TEXT,
+        tool_title TEXT,
+        patch_hash TEXT,
+        patch_files TEXT,
+        file_mime TEXT,
+        file_name TEXT,
+        file_url TEXT,
+        subtask_prompt TEXT,
+        subtask_desc TEXT,
+        subtask_agent TEXT,
+        step_reason TEXT,
+        step_cost REAL,
+        step_tokens_in INTEGER,
+        step_tokens_out INTEGER,
+        snapshot_hash TEXT,
+        compaction_auto INTEGER,
+        metadata TEXT,
+        UNIQUE (message_id, ordinal)
+      );
+    `);
+    return { db, dbPath };
+  }
+
+  it("rebuilds the part_type CHECK to admit 'skill' and 'command', keeping the existing row", () => {
+    const { db } = makeLegacyMessagePartsDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'sess-compact')`).run();
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count) VALUES (1, 1, 0, 'system', 'compacted', 5)`,
+    ).run();
+    db.prepare(
+      `INSERT INTO message_parts (part_id, message_id, session_id, part_type, ordinal, text_content)
+       VALUES ('p1', 1, 'sess-compact', 'compaction', 0, 'compacted')`,
+    ).run();
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    const checkSql = (
+      db.prepare(`SELECT sql FROM sqlite_master WHERE type='table' AND name='message_parts'`).get() as { sql: string }
+    ).sql;
+    expect(checkSql).toContain("'skill'");
+    expect(checkSql).toContain("'command'");
+
+    // The pre-existing compaction row must survive the rebuild untouched.
+    const preserved = db.prepare(`SELECT part_type, text_content FROM message_parts WHERE part_id = 'p1'`).get();
+    expect(preserved).toEqual({ part_type: "compaction", text_content: "compacted" });
+
+    // And the new enum values are actually usable now.
+    expect(() =>
+      db
+        .prepare(
+          `INSERT INTO message_parts (part_id, message_id, session_id, part_type, ordinal, tool_name)
+           VALUES ('p2', 1, 'sess-compact', 'skill', 1, 'grilling')`,
+        )
+        .run(),
+    ).not.toThrow();
+    db.close();
+  });
+
+  it("backfills a command part straight from stored message content — no disk read", () => {
+    const { db } = makeLegacyMessagePartsDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'sess-cmd')`).run();
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count)
+       VALUES (1, 1, 0, 'user', '<command-name>/model</command-name>
+            <command-message>model</command-message>
+            <command-args></command-args>', 5)`,
+    ).run();
+
+    // claudeProjectsDir points at an empty directory: nothing on disk to read for this part.
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    const rows = db
+      .prepare(`SELECT part_type, tool_name, tool_input, message_id FROM message_parts WHERE part_type = 'command'`)
+      .all() as Array<{ part_type: string; tool_name: string; tool_input: string | null; message_id: number }>;
+    expect(rows).toEqual([{ part_type: "command", tool_name: "/model", tool_input: null, message_id: 1 }]);
+    db.close();
+  });
+
+  it("backfills a skill part straight from stored message content — no disk read", () => {
+    const { db } = makeLegacyMessagePartsDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'sess-skill')`).run();
+    // Claude Code's own follow-up turn opens with this line verbatim, stored as a
+    // plain string (not a content-block array), so it survives import untouched.
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count)
+       VALUES (1, 1, 0, 'user', 'Launching skill: grilling
+Full skill prompt follows...', 5)`,
+    ).run();
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    const rows = db
+      .prepare(`SELECT part_type, tool_name, tool_input, message_id FROM message_parts WHERE part_type = 'skill'`)
+      .all() as Array<{ part_type: string; tool_name: string; tool_input: string | null; message_id: number }>;
+    expect(rows).toEqual([{ part_type: "skill", tool_name: "grilling", tool_input: null, message_id: 1 }]);
+    db.close();
+  });
+
+  it("keeps the colon in a plugin:skill name — it is part of the name, not a separator", () => {
+    const { db } = makeLegacyMessagePartsDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'sess-plugin-skill')`).run();
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count)
+       VALUES (1, 1, 0, 'user', 'Launching skill: superpowers:writing-plans', 5)`,
+    ).run();
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    const rows = db
+      .prepare(`SELECT tool_name FROM message_parts WHERE part_type = 'skill'`)
+      .all() as Array<{ tool_name: string }>;
+    expect(rows).toEqual([{ tool_name: "superpowers:writing-plans" }]);
+    db.close();
+  });
+
+  it("never deletes an existing message_parts row while backfilling", () => {
+    const { db } = makeLegacyMessagePartsDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'sess-mixed')`).run();
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count) VALUES (1, 1, 0, 'system', 'compacted', 5)`,
+    ).run();
+    db.prepare(
+      `INSERT INTO message_parts (part_id, message_id, session_id, part_type, ordinal, text_content)
+       VALUES ('p1', 1, 'sess-mixed', 'compaction', 0, 'compacted')`,
+    ).run();
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    const count = db.prepare(`SELECT COUNT(*) AS n FROM message_parts`).get() as { n: number };
+    expect(count.n).toBeGreaterThanOrEqual(1);
+    const preserved = db.prepare(`SELECT part_type FROM message_parts WHERE part_id = 'p1'`).get() as { part_type: string } | undefined;
+    expect(preserved?.part_type).toBe("compaction");
+    db.close();
+  });
+
+  it("runs the backfill only once: a command added to disk after the first run is never picked up", () => {
+    const { db } = makeLegacyMessagePartsDb();
+    db.prepare(`INSERT INTO conversations (conversation_id, session_id) VALUES (1, 'sess-once')`).run();
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count) VALUES (1, 1, 0, 'user', 'plain text', 5)`,
+    ).run();
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() });
+
+    // A command message shows up afterward — as if written by a path this backfill doesn't own.
+    db.prepare(
+      `INSERT INTO messages (message_id, conversation_id, seq, role, content, token_count)
+       VALUES (2, 1, 1, 'user', '<command-name>/model</command-name><command-args></command-args>', 5)`,
+    ).run();
+
+    runLcmMigrations(db, { fts5Available: false, claudeProjectsDir: makeFixtureDir() }); // second run — backfill is a no-op
+
+    const rows = db.prepare(`SELECT COUNT(*) AS n FROM message_parts WHERE part_type = 'command'`).get() as { n: number };
+    expect(rows.n).toBe(0);
+    db.close();
+  });
+});

--- a/test/transcript-message-parts.test.ts
+++ b/test/transcript-message-parts.test.ts
@@ -1,0 +1,74 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { parseTranscript } from "../src/transcript.js";
+
+const tempDirs: string[] = [];
+afterEach(() => { for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true }); });
+
+/** Writes transcript entries as Claude Code does, one JSON object per line. */
+function transcript(entries: unknown[]): string {
+  const dir = mkdtempSync(join(tmpdir(), "lcm-parts-"));
+  tempDirs.push(dir);
+  const path = join(dir, "session.jsonl");
+  writeFileSync(path, entries.map(e => JSON.stringify(e)).join("\n") + "\n");
+  return path;
+}
+
+const entry = (role: string, content: unknown) => ({ type: "message", message: { role, content } });
+
+const commandBlock = (name: string, args = "") =>
+  `<command-name>${name}</command-name>\n            <command-message>x</command-message>\n            <command-args>${args}</command-args>`;
+
+describe("skill and command parts", () => {
+  it("records a Skill tool_use as a skill part, by its structured name", () => {
+    const path = transcript([
+      entry("assistant", [{ type: "tool_use", name: "Skill", input: { skill: "grilling" } }]),
+    ]);
+    const [message] = parseTranscript(path);
+    expect(message.parts).toEqual([{ type: "skill", name: "grilling", args: null }]);
+  });
+
+  it("carries the Skill tool_use's args field when present", () => {
+    const path = transcript([
+      entry("assistant", [{ type: "tool_use", name: "Skill", input: { skill: "release-plugin", args: "autoimprove" } }]),
+    ]);
+    const [message] = parseTranscript(path);
+    expect(message.parts).toEqual([{ type: "skill", name: "release-plugin", args: "autoimprove" }]);
+  });
+
+  it("does not treat an ordinary tool_use as a skill part", () => {
+    const path = transcript([
+      entry("assistant", [{ type: "tool_use", name: "Bash", input: { command: "ls" } }]),
+    ]);
+    const [message] = parseTranscript(path);
+    expect(message.parts).toBeUndefined();
+  });
+
+  it("records a slash command block with args", () => {
+    const path = transcript([entry("user", commandBlock("/goal", "monitora e roda os testes"))]);
+    const [message] = parseTranscript(path);
+    expect(message.parts).toEqual([{ type: "command", name: "/goal", args: "monitora e roda os testes" }]);
+  });
+
+  it("records a slash command block with no args as null, not empty string", () => {
+    const path = transcript([entry("user", commandBlock("/model"))]);
+    const [message] = parseTranscript(path);
+    expect(message.parts).toEqual([{ type: "command", name: "/model", args: null }]);
+  });
+
+  it("does not turn a command block quoted inside a code fence into a part", () => {
+    const path = transcript([
+      entry("user", "Example:\n```\n" + commandBlock("/model") + "\n```\nthat's the format"),
+    ]);
+    const [message] = parseTranscript(path);
+    expect(message.parts).toBeUndefined();
+  });
+
+  it("leaves parts undefined for a transcript with neither a skill nor a command", () => {
+    const path = transcript([entry("user", "roda os testes")]);
+    const [message] = parseTranscript(path);
+    expect(message.parts).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Closes #421

## A premise in the issue that had to be corrected first

The issue says *"neither a skill expansion nor a slash command is a tool call — both arrive as user-role text"*. That is false for skills. Measured over 90 days of history:

| | |
|---|---|
| `Skill` `tool_use` blocks carrying `input.skill` | **302** |
| `<command-name>` blocks | **349**, every one named |
| blocks inside a code fence (false positives) | **0** |

The skill's name already arrives in a structured field. Only the expansion that follows it is prose. Panel commands leave a block too — checked for `/model`, `/reload-plugins`, `/clear`, `/compact`, `/plugin-types` — so there is no command that only a hook would see.

## One mouth

The extractor lives **only** inside `parseTranscript`, which both the CLI `import` and the daemon's `/ingest` already go through. Two detections writing the same table is how they drift apart without anyone noticing.

The function hooks (`skill.prompt`, `command.run`) are deliberately unused: they are off by default and cannot reach the 651 invocations already on disk.

## The `CHECK` stays

`part_type` gains `'skill'` and `'command'`, rebuilding the table once — a cost already accepted in `docs/design/message-parts-vs-events-db.md`. Dropping the `CHECK` to avoid future rebuilds would remove a verifier to save work, which is precisely the defect this issue belongs to. The rebuild runs inside a `SAVEPOINT`: a rebuild interrupted halfway would strand rows, which is worse than the rebuild.

## Neither backfill reads disk

A command's tag is stored verbatim. A skill's name **also** survives in stored content — in the launch line the invocation leaves behind.

This was nearly got wrong in the obvious way. Looking at the `tool_use` side shows only the bare name `"Skill"`; `input.skill` never reaches content, and from there the honest-looking conclusion is that the name is unrecoverable and the backfill must re-read every transcript from disk, with a session-alignment guard to avoid misattributing rows on sessions whose role tagging has drifted. Measured across every project database — 8380 databases, 1.4M messages, 794k `role='tool'` rows — that conclusion is wrong:

```
rows whose content is bare "Skill":     31     <- the side that looks empty
"Launching skill: <name>" rows:       1434, across 33 project dbs
distinct skill names:                  128
```

So the plan's "the backfill never reads disk" holds for skills too, and the disk walk and the alignment guard are both gone rather than kept as insurance — a guard whose premise is false is weight the next reader will trust.

`UPDATE`, never `DELETE`, once, behind a marker table.

## Done when — measured

Against a copy of a real 85 MB project database (196 conversations, 18274 messages):

| | inserted | cross-checked against source content | mismatches |
|---|---|---|---|
| command parts | 84 | 84 | **0** |
| skill parts | 43 | 43 | **0** |

`unmatched_skill_count: 0`. The 130 pre-existing `message_parts` rows survive the rebuild. No row is deleted in any run.

That database's 43 is its share of the 1434 measured globally, not the whole population — the backfill is per-database and runs wherever a database is opened.

**Caveat kept from the plan:** 349/349 with zero false positives is a measurement of *this* history. Measurement does not transfer between corpora. The parts-versus-source comparison in the Done-when is the guard against that, which is why it is a comparison and not a count.

Full suite: **1763 passed, 6 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
