### PR TITLE
fix(import): ingest workflow subagent transcripts

### DIFF
--- a/.changeset/workflow-subagent-transcripts-ingested.md
+++ b/.changeset/workflow-subagent-transcripts-ingested.md
@@ -1,0 +1,13 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+fix: workflow subagent transcripts are now discovered and imported
+
+Subagent transcripts dispatched inside a workflow run live one directory deeper,
+under `subagents/workflows/<run>/`, and discovery only ever looked at files
+directly inside `subagents/`, so an entire class of subagent conversations was
+silently skipped. Discovery now walks into subdirectories of `subagents/` to
+find them, reading the same `.meta.json` sidecar attribution as a flat subagent
+transcript. Each workflow run also writes its own `journal.jsonl`, which is not
+a transcript and stays excluded by name.

--- a/src/import.ts
+++ b/src/import.ts
@@ -155,17 +155,37 @@ function findOneSubagentSessionFile(subagentsDir: string, sessionDirName: string
   }
 }
 
-function findSubagentSessionFiles(projectDir: string, sessionDirName: string): DiscoveredSessionFile[] {
-  const subagentsDir = join(projectDir, sessionDirName, 'subagents');
-  if (!existsSync(subagentsDir)) return [];
+/**
+ * A subagent transcript's `agent-<id>.jsonl` can sit directly under
+ * `subagents/`, or nested arbitrarily deeper — e.g.
+ * `subagents/workflows/wf_<id>/` for a workflow run's own subagents — with
+ * the same format and the same sidecar at every depth. Only `journal.jsonl`
+ * — a workflow run's own log, excluded by name, not by shape — is not a
+ * transcript.
+ */
+function findSubagentTranscriptEntry(dir: string, sessionDirName: string, entry: Dirent): DiscoveredSessionFile | null {
+  if (entry.name === 'journal.jsonl' || !entry.name.endsWith('.jsonl')) return null;
+  return findOneSubagentSessionFile(dir, sessionDirName, entry.name);
+}
 
+function walkSubagentDir(dir: string, sessionDirName: string): DiscoveredSessionFile[] {
   const files: DiscoveredSessionFile[] = [];
-  for (const sub of readdirSync(subagentsDir, { withFileTypes: true })) {
-    if (!sub.isFile() || sub.isSymbolicLink() || !sub.name.endsWith('.jsonl')) continue;
-    const found = findOneSubagentSessionFile(subagentsDir, sessionDirName, sub.name);
+  for (const sub of readdirSync(dir, { withFileTypes: true })) {
+    if (sub.isSymbolicLink()) continue;
+    if (sub.isDirectory()) {
+      files.push(...walkSubagentDir(join(dir, sub.name), sessionDirName));
+      continue;
+    }
+    const found = sub.isFile() ? findSubagentTranscriptEntry(dir, sessionDirName, sub) : null;
     if (found) files.push(found);
   }
   return files;
+}
+
+function findSubagentSessionFiles(projectDir: string, sessionDirName: string): DiscoveredSessionFile[] {
+  const subagentsDir = join(projectDir, sessionDirName, 'subagents');
+  if (!existsSync(subagentsDir)) return [];
+  return walkSubagentDir(subagentsDir, sessionDirName);
 }
 
 export function findSessionFiles(projectDir: string): DiscoveredSessionFile[] {

--- a/test/import.test.ts
+++ b/test/import.test.ts
@@ -200,6 +200,68 @@ describe("findSessionFiles", () => {
     expect(bad?.subagentDesc ?? null).toBeNull();
   });
 
+  it("discovers subagent transcripts nested under a workflow run directory", () => {
+    const dir = makeTmpDir();
+    const subDir = join(dir, "session-parent");
+    const subagentsDir = join(subDir, "subagents");
+    const workflowRunDir = join(subagentsDir, "workflows", "wf_123");
+    mkdirSync(workflowRunDir, { recursive: true });
+    writeFileSync(join(workflowRunDir, "agent-wf-child.jsonl"), "");
+    writeFileSync(
+      join(workflowRunDir, "agent-wf-child.meta.json"),
+      JSON.stringify({ agentType: "workflow-subagent" }),
+    );
+
+    const result = findSessionFiles(dir);
+    const child = result.find((f) => f.sessionId === "agent-wf-child");
+    expect(child).toBeDefined();
+    expect(child?.subagentType).toBe("workflow-subagent");
+    // Parent is the session that owns subagents/, not the wf_* run directory.
+    expect(child?.parentSessionId).toBe("session-parent");
+  });
+
+  it("does not discover journal.jsonl inside a workflow run directory", () => {
+    const dir = makeTmpDir();
+    const subDir = join(dir, "session-parent");
+    const workflowRunDir = join(subDir, "subagents", "workflows", "wf_123");
+    mkdirSync(workflowRunDir, { recursive: true });
+    writeFileSync(join(workflowRunDir, "agent-wf-child.jsonl"), "");
+    writeFileSync(join(workflowRunDir, "journal.jsonl"), "");
+
+    const result = findSessionFiles(dir);
+    const sessionIds = result.map((f) => f.sessionId).sort();
+    expect(sessionIds).toEqual(["agent-wf-child"]);
+  });
+
+  it("still discovers a flat subagent transcript, without duplicating it, alongside a workflow run", () => {
+    const dir = makeTmpDir();
+    const subDir = join(dir, "session-parent");
+    const subagentsDir = join(subDir, "subagents");
+    const workflowRunDir = join(subagentsDir, "workflows", "wf_123");
+    mkdirSync(workflowRunDir, { recursive: true });
+    writeFileSync(join(subagentsDir, "agent-flat.jsonl"), "");
+    writeFileSync(join(workflowRunDir, "agent-wf-child.jsonl"), "");
+
+    const result = findSessionFiles(dir);
+    const sessionIds = result.map((f) => f.sessionId).sort();
+    expect(sessionIds).toEqual(["agent-flat", "agent-wf-child"]);
+    // Each discovered exactly once.
+    expect(result.filter((f) => f.sessionId === "agent-flat")).toHaveLength(1);
+  });
+
+  it("leaves attribution null for a workflow subagent transcript with no sidecar", () => {
+    const dir = makeTmpDir();
+    const workflowRunDir = join(dir, "session-parent", "subagents", "workflows", "wf_123");
+    mkdirSync(workflowRunDir, { recursive: true });
+    writeFileSync(join(workflowRunDir, "agent-orphan.jsonl"), "");
+
+    const result = findSessionFiles(dir);
+    const orphan = result.find((f) => f.sessionId === "agent-orphan");
+    expect(orphan?.parentSessionId ?? null).toBeNull();
+    expect(orphan?.subagentType ?? null).toBeNull();
+    expect(orphan?.subagentDesc ?? null).toBeNull();
+  });
+
   it("deduplicates when both flat and nested transcripts exist for the same session", () => {
     const dir = makeTmpDir();
     // Flat transcript at project root


### PR DESCRIPTION
Closes #433

## The defect

The walk over `subagents/` filtered entries on `isFile()`, so a directory was skipped. Every transcript a workflow writes under `subagents/workflows/wf_*/` was therefore invisible to import — not mishandled, never reached.

Their format is the format of any other subagent transcript (`parentUuid`, `isSidechain`, `agentId`, `message`), and each has the same `.meta.json` beside it. Nothing about them needed different handling.

## What changed

The walk descends into subdirectories of `subagents/`. `journal.jsonl` is excluded **by name**, not by shape: recognising "not a transcript" from content would be a second, weaker copy of a decision the filename already makes exactly.

Attribution reuses the sidecar reader from #419 at each nesting level, so these arrive attributed on day one rather than needing a later backfill. `parent_session_id` resolves to the owning session's folder, never the `wf_*` folder — that is the value threaded through the recursion.

## Search behaviour — decided, not inherited

The issue asks for this explicitly, so: **a workflow subagent conversation gets exactly what any other subagent conversation gets.** Nothing distinguishes them but folder depth, which is how workflows lay their files out and not a difference in what the conversation is. Giving them a separate rule would encode a distinction that does not exist.

If these turn out to dilute recall, `subagent_type` is already a column — they carry `workflow-subagent` — so they can be filtered without a schema change. That is the tripwire, and it exists because #419 landed first.

## Done when — measured, two independent code paths

Side A is a fresh disk walk; side B is the shipped `findSessionFiles` against a real build. Agreement between a function and itself proves nothing, so the two sides share no code, and each aborts loudly if it comes back empty.

```
side A (disk walk):        flat=1205 nested=1343 journal=47 symlinks=5
side B (findSessionFiles): flat=1205 nested=1343 journal=0

nested on disk but not discovered: 0
flat on disk but not discovered:   0
journal.jsonl discovered:          0
ids appearing as both flat and nested (double count): 0
```

Every one of the 1343 is reached, none of the 47 journals is, the previously-discovered flat transcripts are all still found, and the new recursion introduces no path twice. Also checked: zero unclassified files slip through the now-unbounded recursion.

Full suite: **1753 passed, 6 skipped, 0 failed**.

## Pre-existing, not touched

- Five flat subagent transcripts are symlinks and are skipped by an existing `isSymbolicLink()` guard this PR does not change. That fully accounts for the small flat-count gap; verified by `lstat`.
- One `session_id` is shared by two different **flat** transcripts in different sessions of one project. Unrelated to workflow nesting, neither introduced nor worsened here.

## One thing worth knowing

The migration's one-time backfill walker stays flat-only, deliberately. It exists to attribute rows that already existed without attribution, and no workflow-nested session has ever been a row, so there is nothing there for it to match. The cost is that "subagent transcript" now has two walkers — worth knowing if a future change extends discovery again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
