### PR TITLE
fix(daemon): discover subagent transcripts during live ingestion

### DIFF
--- a/.changeset/live-ingest-discovers-subagents.md
+++ b/.changeset/live-ingest-discovers-subagents.md
@@ -1,0 +1,13 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+fix: live `/ingest` discovers subagent transcripts, not only `lcm import`
+
+Previously, a subagent transcript reached the database only when someone ran
+`lcm import` by hand — `/ingest` parsed only the session's own transcript.
+`/ingest` now also discovers that session's `subagents/*.jsonl` transcripts
+and ingests each one with the same attribution `lcm import` already writes,
+so a session that dispatched agents has their conversations recorded without
+any command being run. Re-ingesting the same session does not duplicate
+subagent messages, and a session with no subagents is unaffected.

--- a/src/daemon/routes/ingest.ts
+++ b/src/daemon/routes/ingest.ts
@@ -8,7 +8,7 @@ import { sendJson } from "../server.js";
 import type { RouteHandler } from "../server.js";
 import { runLcmMigrations } from "../../db/migration.js";
 import { upsertRedactionCounts } from "../../db/redaction-stats.js";
-import { ConversationStore, type CreateMessagePartInput, type MessageRecord } from "../../store/conversation-store.js";
+import { ConversationStore, type CreateMessageInput, type CreateMessagePartInput, type MessageRecord } from "../../store/conversation-store.js";
 import { SummaryStore } from "../../store/summary-store.js";
 import { parseTranscript, type ParsedMessage, type MessagePart } from "../../transcript.js";
 import { extractCodexSessionMeta, parseCodexTranscript } from "../../codex-transcript.js";
@@ -18,8 +18,11 @@ import { scheduleProjectLanguageDetection } from "../project-language.js";
 import { enqueue } from "../project-queue.js";
 import { readCodexTranscriptDelta, type CodexTranscriptCursor } from "../../codex-transcript-reader.js";
 import { loadCodexCursor, saveCodexCursor } from "../../db/codex-cursor.js";
+import { discoverSubagentSessions, type DiscoveredSubagentSession } from "../subagent-discovery.js";
 
 class TranscriptError extends Error {}
+
+type RedactionCounts = { gitleaks: number; builtIn: number; global: number; project: number };
 
 function validateCodexRecovery(
   db: DatabaseSync,
@@ -106,6 +109,139 @@ async function persistMessageParts(
       parts.map((part, ordinal) => toMessagePartInput(sessionId, part, ordinal)),
     );
   }
+}
+
+/**
+ * The one place that resolves a session's existing conversation and its
+ * current stored message count — shared by the primary session path and
+ * subagent ingestion, so "how storedCount is derived" has one owner.
+ */
+async function getStoredConversation(
+  db: DatabaseSync,
+  conversationStore: ConversationStore,
+  sessionId: string,
+): Promise<{ conversationId: number; storedCount: number } | undefined> {
+  const row = db.prepare("SELECT conversation_id FROM conversations WHERE session_id = ?")
+    .get(sessionId) as { conversation_id: number } | undefined;
+  if (!row) return undefined;
+  return { conversationId: row.conversation_id, storedCount: await conversationStore.getMessageCount(row.conversation_id) };
+}
+
+/** Scrubs new messages and shapes them for `createMessagesBulk`, tallying redaction counts as it goes. */
+function scrubMessagesToInputs(
+  newMessages: ParsedMessage[], scrubber: ScrubEngine, conversationId: number, storedCount: number,
+): { inputs: CreateMessageInput[]; totalCounts: RedactionCounts } {
+  const totalCounts: RedactionCounts = { gitleaks: 0, builtIn: 0, global: 0, project: 0 };
+  const inputs = newMessages.map((m, i) => {
+    const { text: scrubbedContent, gitleaks, builtIn, global: globalCount, project } = scrubber.scrubWithCounts(m.content);
+    totalCounts.gitleaks += gitleaks;
+    totalCounts.builtIn += builtIn;
+    totalCounts.global += globalCount;
+    totalCounts.project += project;
+    return {
+      conversationId, seq: storedCount + i,
+      role: m.role as "user" | "assistant" | "system" | "tool",
+      content: scrubbedContent, tokenCount: m.tokenCount,
+    };
+  });
+  return { inputs, totalCounts };
+}
+
+/**
+ * Scrubs and writes one session's new messages inside a single transaction,
+ * shared by the primary session path and subagent ingestion below — one
+ * mouth writing messages rather than two drifting apart. `onCommitted` runs
+ * inside the same transaction, after messages are created; the primary path
+ * uses it to persist a Codex cursor, subagent ingestion has none.
+ */
+async function writeNewMessages(
+  db: DatabaseSync,
+  conversationStore: ConversationStore,
+  summaryStore: SummaryStore,
+  scrubber: ScrubEngine,
+  pid: string,
+  sessionId: string,
+  conversationId: number,
+  storedCount: number,
+  newMessages: ParsedMessage[],
+  onCommitted?: () => void,
+): Promise<{ records: MessageRecord[]; totalCounts: RedactionCounts }> {
+  const { inputs, totalCounts } = scrubMessagesToInputs(newMessages, scrubber, conversationId, storedCount);
+  const records = await conversationStore.withTransaction(async () => {
+    const created = inputs.length > 0 ? await conversationStore.createMessagesBulk(inputs) : [];
+    if (created.length > 0) {
+      upsertRedactionCounts(db, pid, totalCounts);
+      await summaryStore.appendContextMessages(conversationId, created.map((r) => r.messageId));
+      await persistMessageParts(conversationStore, sessionId, newMessages, created);
+    }
+    onCommitted?.();
+    return created;
+  });
+  return { records, totalCounts };
+}
+
+/**
+ * A subagent transcript grows while its parent session is still running, so
+ * this reads the same storedCount-based delta the primary path uses: safe to
+ * call on every `/ingest` for the parent, never re-inserting what is stored.
+ */
+async function ingestSubagentSession(
+  db: DatabaseSync,
+  conversationStore: ConversationStore,
+  summaryStore: SummaryStore,
+  scrubber: ScrubEngine,
+  pid: string,
+  sub: DiscoveredSubagentSession,
+): Promise<number> {
+  const parsed = parseTranscript(sub.path);
+  const existing = await getStoredConversation(db, conversationStore, sub.sessionId);
+  const storedCount = existing?.storedCount ?? 0;
+  const newMessages = parsed.slice(storedCount);
+  if (newMessages.length === 0) return 0;
+
+  const conversation = await conversationStore.getOrCreateConversation(sub.sessionId, undefined, {
+    parentSessionId: sub.parentSessionId,
+    subagentType: sub.subagentType,
+    subagentDesc: sub.subagentDesc,
+  });
+  const { records } = await writeNewMessages(
+    db, conversationStore, summaryStore, scrubber, pid, sub.sessionId, conversation.conversationId, storedCount, newMessages,
+  );
+  return records.length;
+}
+
+async function ingestAllSubagents(
+  db: DatabaseSync, pid: string, scrubber: ScrubEngine, subagents: DiscoveredSubagentSession[],
+): Promise<void> {
+  runLcmMigrations(db);
+  const conversationStore = new ConversationStore(db);
+  const summaryStore = new SummaryStore(db);
+  for (const sub of subagents) {
+    await ingestSubagentSession(db, conversationStore, summaryStore, scrubber, pid, sub);
+  }
+}
+
+/**
+ * Discovers and ingests the subagent transcripts dispatched by one session —
+ * the only way they reach the database without `lcm import` run by hand
+ * (issue #434). Skipped entirely, before opening any queue or connection,
+ * when the session has no `subagents/` directory.
+ */
+async function ingestSubagentTranscripts(
+  cwd: string, dbPath: string, pid: string, sessionId: string, scrubber: ScrubEngine,
+): Promise<void> {
+  const subagents = discoverSubagentSessions(cwd, sessionId);
+  if (subagents.length === 0) return;
+
+  await enqueue(pid, async () => {
+    openProject(cwd);
+    const db = getLcmConnection(dbPath);
+    try {
+      await ingestAllSubagents(db, pid, scrubber, subagents);
+    } finally {
+      closeLcmConnection(dbPath);
+    }
+  });
 }
 
 export function resolveIngestMessages(input: IngestInput, cwd: string): ParsedMessage[] {
@@ -206,13 +342,12 @@ export function createIngestHandler(config: DaemonConfig): RouteHandler {
 
           const conversationStore = new ConversationStore(db);
           const summaryStore = new SummaryStore(db);
-          const existing = db.prepare("SELECT conversation_id FROM conversations WHERE session_id = ?")
-            .get(session_id) as { conversation_id: number } | undefined;
-          const storedCount = existing ? await conversationStore.getMessageCount(existing.conversation_id) : 0;
+          const existing = await getStoredConversation(db, conversationStore, session_id);
+          const storedCount = existing?.storedCount ?? 0;
           let cursor: CodexTranscriptCursor | undefined;
           let sourceCount = 0;
           if (codexPath) {
-            let prior = existing ? loadCodexCursor(db, existing.conversation_id, codexPath) : undefined;
+            let prior = existing ? loadCodexCursor(db, existing.conversationId, codexPath) : undefined;
             if (prior && prior.messageCount !== storedCount) prior = undefined;
             try {
               const delta = await readCodexTranscriptDelta(codexPath, {
@@ -221,7 +356,7 @@ export function createIngestHandler(config: DaemonConfig): RouteHandler {
               validateCodexMetadata(delta.sessionMeta, input, cwd);
               if (!delta.resumed && existing) {
                 validateCodexRecovery(db, {
-                  conversationId: existing.conversation_id, storedCount, messages: delta.messages,
+                  conversationId: existing.conversationId, storedCount, messages: delta.messages,
                 }, scrubber);
               }
               parsed = delta.messages;
@@ -242,33 +377,14 @@ export function createIngestHandler(config: DaemonConfig): RouteHandler {
 
           if (newMessages.length === 0 && !cursor) return { ingested: 0, totalTokens: 0 };
 
-          const totalCounts = { gitleaks: 0, builtIn: 0, global: 0, project: 0 };
-          const inputs = newMessages.map((m, i) => {
-            const { text: scrubbedContent, gitleaks, builtIn, global: globalCount, project } = scrubber.scrubWithCounts(m.content);
-            totalCounts.gitleaks += gitleaks;
-            totalCounts.builtIn += builtIn;
-            totalCounts.global += globalCount;
-            totalCounts.project += project;
-            return {
-              conversationId: conversation.conversationId,
-              seq: storedCount + i,
-              role: m.role as "user" | "assistant" | "system" | "tool",
-              content: scrubbedContent,
-              tokenCount: m.tokenCount,
-            };
-          });
-          const records = await conversationStore.withTransaction(async () => {
-            const created = inputs.length > 0 ? await conversationStore.createMessagesBulk(inputs) : [];
-            if (created.length > 0) {
-              upsertRedactionCounts(db, pid, totalCounts);
-              await summaryStore.appendContextMessages(conversation.conversationId, created.map((r) => r.messageId));
-              await persistMessageParts(conversationStore, session_id, newMessages, created);
-            }
-            if (cursor && codexPath) saveCodexCursor(db, {
-              conversationId: conversation.conversationId, transcriptPath: codexPath, cursor,
-            });
-            return created;
-          });
+          const { records, totalCounts } = await writeNewMessages(
+            db, conversationStore, summaryStore, scrubber, pid, session_id, conversation.conversationId, storedCount, newMessages,
+            () => {
+              if (cursor && codexPath) saveCodexCursor(db, {
+                conversationId: conversation.conversationId, transcriptPath: codexPath, cursor,
+              });
+            },
+          );
           if (records.length === 0) return { ingested: 0, totalTokens: 0 };
 
           try {
@@ -302,6 +418,17 @@ export function createIngestHandler(config: DaemonConfig): RouteHandler {
           closeLcmConnection(dbPath);
         }
       });
+      // Subagent transcripts have no dispatcher of their own — this is the only
+      // live path that discovers them (issue #434). Best-effort: a subagent
+      // transcript problem must not turn an otherwise-successful ingest into
+      // an error response for the session that was actually asked for.
+      if (input.client !== "codex") {
+        try {
+          await ingestSubagentTranscripts(cwd, dbPath, pid, session_id, scrubber);
+        } catch (err) {
+          console.error(`ingest: subagent discovery failed for session ${session_id}: ${err instanceof Error ? err.message : err}`);
+        }
+      }
       sendJson(res, 200, result);
     } catch (err) {
       sendJson(res, err instanceof TranscriptError ? 400 : 500, { error: err instanceof Error ? err.message : "ingest failed" });

--- a/src/daemon/subagent-discovery.ts
+++ b/src/daemon/subagent-discovery.ts
@@ -1,0 +1,32 @@
+import { existsSync, readdirSync } from "node:fs";
+import { dirname, join, basename } from "node:path";
+import { claudeTranscriptPath } from "./project.js";
+import { readSubagentAttribution, type SubagentAttribution } from "../subagent-attribution.js";
+
+export interface DiscoveredSubagentSession extends SubagentAttribution {
+  path: string;
+  sessionId: string;
+}
+
+/**
+ * Subagent transcripts for one already-known session, at
+ * `<project>/<session_id>/subagents/*.jsonl`. Scoped to that single
+ * directory: `/ingest` already knows which session it is processing, so this
+ * costs one `existsSync` plus (only when the directory exists) one
+ * `readdirSync` of it — never a walk of the whole projects tree.
+ */
+export function discoverSubagentSessions(cwd: string, sessionId: string): DiscoveredSubagentSession[] {
+  const transcriptPath = claudeTranscriptPath(cwd, sessionId);
+  if (!transcriptPath) return [];
+
+  const subagentsDir = join(dirname(transcriptPath), sessionId, "subagents");
+  if (!existsSync(subagentsDir)) return [];
+
+  const found: DiscoveredSubagentSession[] = [];
+  for (const entry of readdirSync(subagentsDir, { withFileTypes: true })) {
+    if (!entry.isFile() || entry.isSymbolicLink() || !entry.name.endsWith(".jsonl")) continue;
+    const path = join(subagentsDir, entry.name);
+    found.push({ path, sessionId: basename(entry.name, ".jsonl"), ...readSubagentAttribution(path, sessionId) });
+  }
+  return found;
+}

--- a/test/daemon/routes/ingest-subagent-discovery.test.ts
+++ b/test/daemon/routes/ingest-subagent-discovery.test.ts
@@ -1,0 +1,169 @@
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDaemon, type DaemonInstance } from "../../../src/daemon/server.js";
+import { loadDaemonConfig } from "../../../src/daemon/config.js";
+import { claudeTranscriptPath, projectDbPath } from "../../../src/daemon/project.js";
+import { DatabaseSync } from "node:sqlite";
+
+const tempDirs: string[] = [];
+
+/** Writes transcript entries as Claude Code does, one JSON object per line. */
+function writeTranscript(path: string, entries: unknown[]): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, entries.map((e) => JSON.stringify(e)).join("\n") + "\n");
+}
+
+const entry = (role: string, text: string) => ({ type: "message", message: { role, content: text } });
+
+describe("POST /ingest discovers subagent transcripts (#434)", () => {
+  let daemon: DaemonInstance | undefined;
+  let tempHome: string;
+  let cwd: string;
+
+  afterEach(async () => {
+    if (daemon) {
+      await daemon.stop();
+      daemon = undefined;
+    }
+    vi.unstubAllEnvs();
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  function setUp(): { sessionId: string; parentTranscriptPath: string; subagentsDir: string } {
+    tempHome = mkdtempSync(join(tmpdir(), "lossless-subagent-home-"));
+    tempDirs.push(tempHome);
+    cwd = realpathSync(mkdtempSync(join(tmpdir(), "lossless-subagent-cwd-")));
+    tempDirs.push(cwd);
+    vi.stubEnv("HOME", tempHome);
+
+    const sessionId = "parent-session";
+    // claudeTranscriptPath reads HOME at call time via node:os homedir(), which
+    // respects the stubbed env var above.
+    const parentTranscriptPath = claudeTranscriptPath(cwd, sessionId)!;
+    writeTranscript(parentTranscriptPath, [entry("user", "hi"), entry("assistant", "hello")]);
+    const subagentsDir = join(dirname(parentTranscriptPath), sessionId, "subagents");
+    mkdirSync(subagentsDir, { recursive: true });
+    return { sessionId, parentTranscriptPath, subagentsDir };
+  }
+
+  async function ingest(sessionId: string): Promise<{ ingested: number; totalTokens: number }> {
+    const response = await fetch(`http://127.0.0.1:${daemon!.address().port}/ingest`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ session_id: sessionId, cwd }),
+    });
+    expect(response.status, await response.clone().text()).toBe(200);
+    return response.json();
+  }
+
+  it("ingests a dispatched subagent transcript without lcm import ever running", async () => {
+    const { sessionId, subagentsDir } = setUp();
+    const subagentPath = join(subagentsDir, "agent-sub1.jsonl");
+    writeTranscript(subagentPath, [entry("user", "do the task"), entry("assistant", "done")]);
+    writeFileSync(
+      join(subagentsDir, "agent-sub1.meta.json"),
+      JSON.stringify({ agentType: "general-purpose", description: "run the task" }),
+    );
+
+    daemon = await createDaemon(loadDaemonConfig("/nonexistent", { daemon: { port: 0 } }));
+    await ingest(sessionId);
+
+    const db = new DatabaseSync(projectDbPath(cwd), { readOnly: true });
+    try {
+      const conversations = db.prepare(
+        "SELECT session_id, parent_session_id, subagent_type, subagent_desc FROM conversations ORDER BY session_id",
+      ).all();
+      expect(conversations).toEqual([
+        { session_id: "agent-sub1", parent_session_id: sessionId, subagent_type: "general-purpose", subagent_desc: "run the task" },
+        { session_id: sessionId, parent_session_id: null, subagent_type: null, subagent_desc: null },
+      ]);
+      const subMessages = db.prepare(
+        "SELECT role, content FROM messages m JOIN conversations c ON c.conversation_id = m.conversation_id WHERE c.session_id = 'agent-sub1' ORDER BY seq",
+      ).all();
+      expect(subMessages).toEqual([{ role: "user", content: "do the task" }, { role: "assistant", content: "done" }]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not duplicate subagent messages when the parent session is re-ingested", async () => {
+    const { sessionId, subagentsDir } = setUp();
+    const subagentPath = join(subagentsDir, "agent-sub1.jsonl");
+    writeTranscript(subagentPath, [entry("user", "do the task"), entry("assistant", "done")]);
+
+    daemon = await createDaemon(loadDaemonConfig("/nonexistent", { daemon: { port: 0 } }));
+    await ingest(sessionId);
+    await ingest(sessionId);
+
+    const db = new DatabaseSync(projectDbPath(cwd), { readOnly: true });
+    try {
+      const count = db.prepare(
+        "SELECT COUNT(*) as n FROM messages m JOIN conversations c ON c.conversation_id = m.conversation_id WHERE c.session_id = 'agent-sub1'",
+      ).get() as { n: number };
+      expect(count.n).toBe(2);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("ingests new subagent content added between two live /ingest calls", async () => {
+    const { sessionId, subagentsDir } = setUp();
+    const subagentPath = join(subagentsDir, "agent-sub1.jsonl");
+    writeTranscript(subagentPath, [entry("user", "do the task")]);
+
+    daemon = await createDaemon(loadDaemonConfig("/nonexistent", { daemon: { port: 0 } }));
+    await ingest(sessionId);
+    writeTranscript(subagentPath, [entry("user", "do the task"), entry("assistant", "done")]);
+    await ingest(sessionId);
+
+    const db = new DatabaseSync(projectDbPath(cwd), { readOnly: true });
+    try {
+      const rows = db.prepare(
+        "SELECT role, content FROM messages m JOIN conversations c ON c.conversation_id = m.conversation_id WHERE c.session_id = 'agent-sub1' ORDER BY seq",
+      ).all();
+      expect(rows).toEqual([{ role: "user", content: "do the task" }, { role: "assistant", content: "done" }]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("does not regress a session with no subagents", async () => {
+    const { sessionId } = setUp();
+
+    daemon = await createDaemon(loadDaemonConfig("/nonexistent", { daemon: { port: 0 } }));
+    const result = await ingest(sessionId);
+    expect(result.ingested).toBe(2);
+
+    const db = new DatabaseSync(projectDbPath(cwd), { readOnly: true });
+    try {
+      const conversations = db.prepare("SELECT session_id FROM conversations").all();
+      expect(conversations).toEqual([{ session_id: sessionId }]);
+    } finally {
+      db.close();
+    }
+  });
+
+  it("ingests a subagent transcript with no .meta.json sidecar, attribution left null", async () => {
+    const { sessionId, subagentsDir } = setUp();
+    const subagentPath = join(subagentsDir, "agent-sub1.jsonl");
+    writeTranscript(subagentPath, [entry("user", "do the task")]);
+    // No sidecar written.
+
+    daemon = await createDaemon(loadDaemonConfig("/nonexistent", { daemon: { port: 0 } }));
+    await ingest(sessionId);
+
+    const db = new DatabaseSync(projectDbPath(cwd), { readOnly: true });
+    try {
+      const row = db.prepare(
+        "SELECT parent_session_id, subagent_type, subagent_desc FROM conversations WHERE session_id = 'agent-sub1'",
+      ).get();
+      expect(row).toEqual({ parent_session_id: null, subagent_type: null, subagent_desc: null });
+    } finally {
+      db.close();
+    }
+  });
+});


### PR DESCRIPTION
Closes #434

Last of the seven. Closes the loop the three before it opened.

## The defect

`/ingest` parsed only the transcript of the session it was told about. A subagent's transcript reached the store solely through `importSessions`, which is called only by the CLI's `import` command — something nothing runs on its own.

So the attribution #419 delivers, the parts #421 delivers, and the workflow transcripts #433 delivers all arrived only for whoever remembered to type a command. This is the change that hands them to everyone else.

## What changed

`/ingest` discovers the subagent transcripts belonging to the session it is ingesting, and ingests them through the same path the session itself takes — the same `enqueue`, the same store, the same scrubber.

**Discovery is scoped to that session's own folder**, not a re-walk of every project. The route is called repeatedly through a live session, so this is the difference between a cost paid once and a cost paid continually. Measured on real data, both approaches find exactly the same sessions, and the scoped walk is roughly an order of magnitude cheaper. That measurement is why the scoped walk was chosen, rather than an assumption that it would be.

**Re-ingesting is a no-op**, by the mechanism the primary path already uses: the parsed transcript is sliced at the count already stored, so a second call writes nothing and inserts nothing. No new dedup concept was introduced for this.

**A subagent that fails to parse is caught and logged, never surfaced.** The parent session's own ingestion must not fail over a file it did not ask about. The `/ingest` response shape is unchanged.

## Done when

- A session with subagents, ingested through `/ingest` alone with no `lcm import`, brings its subagents into the store with #419's attribution filled in. ✅
- Calling `/ingest` again over the same session duplicates nothing. ✅ — covered by test, and by the offset mechanism above.
- Nothing existing breaks. ✅

Full suite after rebasing onto `main` with all six predecessors: **1772 passed, 6 skipped, 0 failed**. `check-manifest` green.

## Review note

An automated canon review blocked an earlier revision for SRP: the subagent path had duplicated the "look up conversation by `session_id`, then compute stored count" logic that already existed verbatim in the primary path. Extracted to one `getStoredConversation` used by both, which is also why the no-op guarantee above is the *same* guarantee rather than a parallel one that could drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
