### PR TITLE
ci(release): the tag and the npm version are the release boundary for every host

### DIFF
--- a/.changeset/plugin-installs-pin-to-the-release-tag.md
+++ b/.changeset/plugin-installs-pin-to-the-release-tag.md
@@ -1,0 +1,11 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+fix(plugin): a fresh plugin install fetches the released tag, not `main`
+
+The marketplace entry now carries `ref: vX.Y.Z` beside `version`, written by the
+same version sync that stamps `plugin.json`. Before, a new install cloned the
+default branch's HEAD under the released version's label, so two users on
+"0.11.0" could run different code. The publish workflow tags before it publishes
+to npm, so the ref is valid as soon as the version commit lands.

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,8 @@
       "name": "lcm",
       "source": {
         "source": "github",
-        "repo": "lossless-claude/lcm"
+        "repo": "lossless-claude/lcm",
+        "ref": "v0.11.0"
       },
       "description": "Lossless context management — DAG-based summarization that preserves every message",
       "version": "0.11.0",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,9 @@ name: Publish Package
 on:
   push:
     # `main` is the release branch: merging the changesets version PR bumps
-    # package.json, which publishes. The guard below skips a version that is
-    # already on npm or already tagged, so ordinary merges are no-ops.
+    # package.json, which runs this. Each step below runs only if its result
+    # is still missing (tag, npm version, GitHub release), so an ordinary merge
+    # is a no-op and a re-run after a partial failure finishes what is left.
     branches: [main]
     paths: [package.json]
   workflow_dispatch:
@@ -36,47 +37,62 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: npm
 
-      - name: Check if version already released
+      - name: What is still missing for this version
         id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           version="$(node -p "require('./package.json').version")"
           name="$(node -p "require('./package.json').name")"
           tag="v$version"
-          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
-          if npm view "$name@$version" version >/dev/null 2>&1; then
-            echo "Package $name@$version already published to npm — skipping publish"
-            printf 'skip=true\n' >> "$GITHUB_OUTPUT"
-          elif git rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1; then
-            echo "Git tag $tag already exists (but npm version not found) — skipping publish"
-            printf 'skip=true\n' >> "$GITHUB_OUTPUT"
-          else
-            printf 'skip=false\n' >> "$GITHUB_OUTPUT"
-          fi
+          tag_done=false; npm_done=false; release_done=false
+          git rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1 && tag_done=true
+          npm view "$name@$version" version >/dev/null 2>&1 && npm_done=true
+          gh release view "$tag" >/dev/null 2>&1 && release_done=true
+          echo "$tag: tag=$tag_done npm=$npm_done release=$release_done"
+          {
+            printf 'version=%s\n' "$version"
+            printf 'tag_done=%s\n' "$tag_done"
+            printf 'npm_done=%s\n' "$npm_done"
+            printf 'release_done=%s\n' "$release_done"
+          } >> "$GITHUB_OUTPUT"
+
+      # The tag comes first: the marketplace entry for this version points at
+      # it (sync-versions.mjs writes `ref: vX.Y.Z`), so a fresh plugin install
+      # resolves as soon as this step lands. CI already ran on this commit.
+      - name: Create and push release tag
+        if: steps.check.outputs.tag_done == 'false'
+        run: |
+          tag="v${{ steps.check.outputs.version }}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$tag" -m "$tag"
+          git push origin "$tag"
 
       - name: Install dependencies
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.npm_done == 'false'
         run: npm ci
 
       # Kept in step with ci.yml: the hook-process e2e tests exec dist/bin/lcm.js
       # and the bench baseline shells out to ripgrep, so both must exist first.
       - name: Install ripgrep (bench baseline)
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.npm_done == 'false'
         run: sudo apt-get update -qq && sudo apt-get install -y -qq ripgrep
 
       - name: Type-check
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.npm_done == 'false'
         run: npm run typecheck
 
       - name: Build
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.npm_done == 'false'
         run: npm run build
 
       - name: Check manifest
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.npm_done == 'false'
         run: npm run check-manifest
 
       - name: Run tests
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.npm_done == 'false'
         run: npm test
 
       # Trusted publishing (OIDC) needs npm 11.5.1+; Node 22 ships npm 10.x.
@@ -85,27 +101,18 @@ jobs:
       # below 12, whose install defaults (allowScripts off) would change how
       # dependencies install.
       - name: Upgrade npm for trusted publishing
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.npm_done == 'false'
         run: npm install -g npm@^11.5.1
 
       # No NODE_AUTH_TOKEN: the registry authenticates the workflow itself
       # through the OIDC token granted by `id-token: write`. 2FA-bypass
       # automation tokens lose direct publish around January 2027.
       - name: Publish to npm via trusted publishing
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.npm_done == 'false'
         run: npm publish --access public
 
-      - name: Create and push release tag
-        if: steps.check.outputs.skip == 'false'
-        run: |
-          tag="v${{ steps.check.outputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "$tag" -m "$tag"
-          git push origin "$tag"
-
       - name: Create GitHub release
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.release_done == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -113,7 +120,7 @@ jobs:
           gh release create "$tag" --generate-notes --verify-tag
 
       - name: Enrich release notes
-        if: steps.check.outputs.skip == 'false'
+        if: steps.check.outputs.release_done == 'false'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/.github/workflows/version-pr.yml
+++ b/.github/workflows/version-pr.yml
@@ -1,9 +1,9 @@
 name: Version Packages
 
 on:
-  push:
-    branches:
-      - main
+  # Manual: run it when a release is wanted. It opens or refreshes the changesets
+  # version PR from the changesets on main; merging that PR publishes.
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ A skill, command or agent that exists to work **on** lcm goes under `.claude/` o
 - Design notes go in `docs/design/`. There is no roadmap source; do not invent one.
 - Any PR that changes published behaviour carries a changeset (`npm run changeset`).
 - Bot reviews (Copilot, Codex) only when asked explicitly, one per round.
-- `main` is the only long-lived branch. PRs target it. Every push to `main` refreshes the changesets version PR; merging that PR changes `package.json`, which runs `publish.yml`, which publishes unless the version is already on npm or tagged.
+- `main` is the only long-lived branch; there is no release branch. PRs target it. `version-pr.yml` is run by hand when a release is wanted; merging the version PR it opens changes `package.json`, which runs `publish.yml`: tag, then npm, then GitHub release, each only if still missing. The marketplace entry pins plugin installs to that tag; npm pins every other host.
 
 ## Verification
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -33,18 +33,35 @@ there is no way to lock yourself out.
 
 ## Cutting a release
 
-1. Merge the changesets version PR (opened automatically by `version-pr.yml`),
-   or bump the version by hand across `package.json`, `package-lock.json`,
-   `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json`, and move
-   the CHANGELOG's top section to the release date.
+1. Run `gh workflow run version-pr.yml --ref main`. It opens or refreshes the
+   changesets version PR from the changesets on `main`. Merge it. (By hand
+   instead: bump `package.json` and `package-lock.json`, run
+   `node scripts/sync-versions.mjs`, and move the CHANGELOG's top section to
+   the release date.)
 2. The push to `main` publishes, because the workflow watches `package.json`.
    Run it manually with `gh workflow run publish.yml --ref main` when the
    version file did not change in that push.
-3. The workflow skips a version already on npm or already tagged, so an
-   ordinary merge is a no-op and a re-run after a failure is safe.
+3. The workflow does each step only if it is still missing: tag, npm, GitHub
+   release. An ordinary merge is a no-op, and a re-run after a partial failure
+   finishes what is left.
 
-It publishes, then tags `vX.Y.Z`, then opens the GitHub release with the
-CHANGELOG section. A failure before the publish step leaves no tag behind.
+The tag comes first, because the marketplace entry for the same version points
+at it: `sync-versions.mjs` writes `ref: vX.Y.Z` next to the version, so a fresh
+plugin install fetches the released commit rather than the current `main`.
+Between the merge and the tag step there is a window of about a minute in which
+that install fails; the workflow closes it on its own.
+
+## Release channels
+
+| Host | Installs from | Pinned by |
+|---|---|---|
+| Claude Code plugin | this repository, marketplace `source.ref` | the tag `vX.Y.Z` and `version` in `.claude-plugin/marketplace.json` |
+| Codex, Copilot, CLI | npm `@lossless-claude/lcm` | the published version |
+
+Codex also reads `.claude-plugin/marketplace.json` as a compatible marketplace; a
+Codex entry there would use `source: npm` with the exact version, which
+`sync-versions.mjs` writes when such an entry exists. There is no release branch:
+the tag and the npm version are the release boundary for every host.
 
 ## Why not a token
 

--- a/scripts/check-manifest.mjs
+++ b/scripts/check-manifest.mjs
@@ -141,14 +141,25 @@ function checkVersionParity(root, pkg) {
 
   const pkgVersion = pkg.version;
   const pluginVersion = plugin.version;
-  const inStep = pkgVersion === pluginVersion && pkgVersion === marketplaceVersion;
-  if (inStep) return [];
+  const findings = [];
+  if (!(pkgVersion === pluginVersion && pkgVersion === marketplaceVersion)) {
+    findings.push(
+      `Version mismatch: package.json=${pkgVersion}, .claude-plugin/plugin.json=${pluginVersion}, ` +
+      `.claude-plugin/marketplace.json plugins[0].version=${marketplaceVersion}. ` +
+      `Run "node scripts/sync-versions.mjs" to bring plugin.json and marketplace.json in line with package.json.`,
+    );
+  }
 
-  return [
-    `Version mismatch: package.json=${pkgVersion}, .claude-plugin/plugin.json=${pluginVersion}, ` +
-    `.claude-plugin/marketplace.json plugins[0].version=${marketplaceVersion}. ` +
-    `Run "node scripts/sync-versions.mjs" to bring plugin.json and marketplace.json in line with package.json.`,
-  ];
+  // A github source installs from `ref`; it must name this version's tag, or a
+  // fresh install fetches the default branch under the released version's label.
+  const source = marketplace.plugins[0].source;
+  if (source?.source === "github" && source.ref !== `v${pkgVersion}`) {
+    findings.push(
+      `Marketplace ref mismatch: .claude-plugin/marketplace.json plugins[0].source.ref=${source.ref ?? "(unset)"}, ` +
+      `expected v${pkgVersion}. Run "node scripts/sync-versions.mjs".`,
+    );
+  }
+  return findings;
 }
 
 function checkManifest(root) {

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,8 +1,14 @@
 #!/usr/bin/env node
 // Writes package.json's version into the two other manifests that
 // check-manifest.mjs's version-parity rule reads: .claude-plugin/plugin.json
-// and .claude-plugin/marketplace.json (plugins[0].version). Reads and writes
-// the same paths that rule reads, so syncing and checking never drift apart.
+// and .claude-plugin/marketplace.json (every plugin entry's version). Reads and
+// writes the same paths that rule reads, so syncing and checking never drift apart.
+//
+// A marketplace entry also carries the selector its host installs from, and that
+// selector names the release: a github source gets `ref: v<version>` (the tag
+// publish.yml creates for that commit), an npm source gets the exact version.
+// Without the pin, a fresh install would fetch the default branch's HEAD under
+// the released version's label.
 //
 // Called from "version-packages" (changeset version && node
 // scripts/sync-versions.mjs), so it runs right after changesets bumps
@@ -40,7 +46,11 @@ function syncVersions(root, version) {
     if (!manifest.plugins?.[0]) {
       throw new Error(`${marketplacePath} has no plugins[0] to write a version onto.`);
     }
-    manifest.plugins[0].version = version;
+    for (const entry of manifest.plugins) {
+      entry.version = version;
+      if (entry.source?.source === "github") entry.source.ref = `v${version}`;
+      if (entry.source?.source === "npm") entry.source.version = version;
+    }
   });
 
   return { pluginPath, marketplacePath };

--- a/test/check-manifest.test.ts
+++ b/test/check-manifest.test.ts
@@ -204,6 +204,36 @@ describe("syncVersions", () => {
     expect(findings).toEqual([]);
   });
 
+  it("pins a github source to the version tag and an npm source to the exact version", () => {
+    const root = makeFixture();
+    writePackageJson(root, { version: "2.3.4" });
+    writeFileSync(join(root, ".claude-plugin", "plugin.json"), JSON.stringify({ name: "lcm", version: "1.0.0" }, null, 2) + "\n");
+    const marketplacePath = join(root, ".claude-plugin", "marketplace.json");
+    writeFileSync(
+      marketplacePath,
+      JSON.stringify({
+        name: "lossless-claude",
+        plugins: [
+          { name: "lcm", version: "1.0.0", source: { source: "github", repo: "lossless-claude/lcm" } },
+          { name: "lcm-codex", version: "1.0.0", source: { source: "npm", package: "@lossless-claude/lcm", version: "1.0.0" } },
+        ],
+      }, null, 2) + "\n",
+    );
+
+    syncVersions(root, "2.3.4");
+
+    const after = JSON.parse(readFileSync(marketplacePath, "utf8"));
+    expect(after.plugins[0]).toMatchObject({ version: "2.3.4", source: { ref: "v2.3.4" } });
+    expect(after.plugins[1]).toMatchObject({ version: "2.3.4", source: { version: "2.3.4" } });
+
+    // check-manifest reads the same ref back, and objects when it lags.
+    writeDistFile(root, "index.js", `export const x = 1;\n`);
+    expect(checkManifest(root).filter((f) => f.includes("ref mismatch"))).toEqual([]);
+    after.plugins[0].source.ref = "v1.0.0";
+    writeFileSync(marketplacePath, JSON.stringify(after, null, 2) + "\n");
+    expect(checkManifest(root).some((f) => f.includes("ref mismatch"))).toBe(true);
+  });
+
   it("throws a clear error when marketplace.json has no plugins[0]", () => {
     const root = makeFixture();
     writePackageJson(root, { version: "2.3.4" });


### PR DESCRIPTION
The release boundary is the tag and the npm version, for every host. No release branch.

## Plugin installs pin to the released tag

`.claude-plugin/marketplace.json` now carries `source.ref: vX.Y.Z` beside `version`. Before, a fresh install cloned `main`'s HEAD under the released version's label, so two users on "0.11.0" could run different code. `scripts/sync-versions.mjs` writes the ref (and, for an npm-sourced entry, the exact version) in the same version commit; `check-manifest` objects when the ref lags. Codex reads the same marketplace file as a compatible source; today it gets lcm through npm, which already pins.

## `publish.yml` tags first, and heals a partial release

The tag is created before the npm publish, so the marketplace ref resolves as soon as the version commit lands. Each step (tag, npm, GitHub release) runs only if its result is still missing, instead of one guard that skipped everything when either the tag or the npm version existed.

## `version-pr.yml` runs by hand

`gh workflow run version-pr.yml --ref main` opens or refreshes the changesets version PR when a release is wanted. It no longer rewrites that PR on every merge to `main`.

`docs/releasing.md` and `AGENTS.md` describe the flow as it now is. Changeset included.

## Checks

`npm run check-manifest`, `test/check-manifest.test.ts` (14), `npm run typecheck`, `npm run check-docs`, `npm run check-agents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
