### PR TITLE
docs: generic tag vocabulary, skills as one source, and the product is lcm

### DIFF
--- a/.agents/skills/lcm-context/SKILL.md
+++ b/.agents/skills/lcm-context/SKILL.md
@@ -1,135 +1,47 @@
 ---
 name: lcm-context
-description: "You MUST use this before any work to recall project memory, and to store durable insights. Lossless-claude (lcm) provides persistent cross-session memory via CLI commands."
+description: "Use before starting work in this repository to recall project memory with the lcm CLI, and when a durable insight should be stored. Covers lcm search, grep, describe, expand and store."
 ---
 
-# lcm Memory — Universal Agent Guide
+# lcm memory from the CLI
 
-Use the `lcm` CLI to retrieve and store project memory across sessions.
-Install: `npm install -g @lossless-claude/lcm`
+lcm keeps memory across sessions. This skill is the CLI form for agents whose host does not
+load the plugin. Tool choice and error recovery are in [skills/lcm-context/SKILL.md](../../../skills/lcm-context/SKILL.md);
+MCP parameters are in [docs/agent-tools.md](../../../docs/agent-tools.md); tags are in
+[docs/tag-schema.md](../../../docs/tag-schema.md). `lcm <command> --help` is the option reference.
 
-Memory is stored in SQLite (FTS5) and accessed via CLI commands or MCP tools.
+## When to recall
 
-## Workflow
+If the host injected memory at session start (the Claude Code plugin and the Codex hooks
+both do), do not query for what was injected. Otherwise, search before the first code
+change, and whenever the context lacks something a past session may hold.
 
-1. **Before Thinking:** Run `lcm search` or `lcm grep` to recall past decisions and context.
-2. **After Implementing:** If a durable insight emerged, run `lcm store` with a `type:` tag. One concise insight and its why per store.
-
-## Commands
-
-### 1. Search Memory (broad recall)
-
-Retrieve relevant context across all past sessions using full-text search.
-
-**Use when:**
-- You need to recall past decisions, patterns, or architectural context
-- Before performing any action, to check for relevant rules or preferences
-- Your context does not contain information you need
-
-**Do NOT use when:**
-- The information is already present in your current context
-- The query is about general knowledge, not project memory
+## Recall
 
 ```bash
-lcm search "how was auth implemented"
-lcm search "compaction architecture" --tag type:decision --tag scope:architecture
-lcm search "JWT token" --layer episodic
+lcm search "how was auth implemented"                       # broad, both layers
+lcm search "compaction" --tag type:decision --layer promoted  # filter by tag and layer
+lcm grep "socket.unref"                                      # exact keyword or regex
+lcm describe <nodeId>                                        # metadata before expanding
+lcm expand <nodeId> --depth 2                                # source content of a summary
 ```
 
-### 2. Grep Memory (exact match)
+`--tag` and `--layer` repeat; layers are `episodic` and `promoted`.
 
-Search raw conversation transcripts by keyword or regex.
+## Store
 
-**Use when:**
-- You need an exact keyword, error message, or function name from past sessions
-- Search returned too many broad results and you need to narrow down
-
-**Do NOT use when:**
-- You need conceptual recall (use `lcm search` instead)
+One concise insight and its why per store, tagged with `type:` and `project:` or `scope:`.
+Do not store what git, the docs or the instruction files already hold.
 
 ```bash
-lcm grep "socket.unref"
-lcm grep "JWT" --scope summaries
-lcm grep "ECONNREFUSED" --since 2026-03-20
+lcm store "SessionEnd only fires on a graceful exit, so a crashed session loses its tail." --tag type:gotcha --tag scope:lcm
 ```
 
-### 3. Expand a Summary Node
+## When something fails
 
-Decompress a summary node from the DAG into its full source content.
-
-**Use when:**
-- A search or grep result references a summary nodeId and you need more detail
-- Check with `lcm describe <nodeId>` first to see if it's worth expanding (saves tokens)
-
-```bash
-lcm describe <nodeId>    # check metadata first
-lcm expand <nodeId>      # decompress if relevant
-lcm expand <nodeId> --depth 2   # deeper traversal
-```
-
-### 4. Store a Decision or Finding
-
-Persist knowledge for retrieval in future sessions.
-
-**Use when:**
-- An architectural decision was made with rationale worth preserving
-- A bug root cause was identified (the "why", not just the fix)
-- User expressed a preference or feedback that affects future work
-- A non-obvious integration pattern was discovered
-
-**Do NOT use when:**
-- The information is already in git (code, commit messages)
-- It's a transient debugging step or ephemeral task detail
-- It's already documented in project instruction files (CLAUDE.md, AGENTS.md, etc.)
-- It's general knowledge, not project-specific
-
-```bash
-lcm store "Auth uses JWT with 24h expiry instead of server sessions: the API stays stateless across instances." --tag type:decision --tag scope:security
-lcm store "SessionEnd hook only fires on graceful /exit, not on crash or terminal close, so a crashed session loses its tail." --tag type:gotcha --tag scope:lcm
-```
-
-### 5. Check System Health
-
-```bash
-lcm doctor    # daemon, hooks, MCP, summarizer status
-lcm stats     # compression ratios and token savings
-```
-
-## Retrieval Chaining Pattern
-
-The retrieval tools compose from broad to deep:
-
-```
-lcm search "topic"       → broad conceptual matches
-    ↓ (find interesting nodeId)
-lcm grep "exact term"    → narrow to specific references
-    ↓ (find nodeId worth expanding)
-lcm describe <nodeId>    → check metadata (depth, tokens, promoted?)
-    ↓ (if worth it)
-lcm expand <nodeId>      → full decompressed content
-```
-
-## Error Handling
-
-**Agent-Fixable (handle automatically):**
-
-| Error | Recovery |
+| Symptom | Do |
 |---|---|
-| Daemon not running | Run `lcm daemon start --detach`, then retry |
-| "No results" from search | Try `lcm grep` with different keywords, or broaden query |
-| Node not found on expand | Use `lcm search` to find correct nodeId |
-
-**User Action Required:**
-
-| Error | What to tell the user |
-|---|---|
-| `lcm` command not found | Run `npm install -g @lossless-claude/lcm` |
-| Daemon won't start | Ask user to check `lcm doctor` output |
-| Database locked or corrupted | Ask user to run `lcm doctor` for diagnostics |
-
-### Quick Diagnosis
-
-```bash
-lcm doctor    # check daemon, hooks, config health
-lcm stats     # verify memory is being captured
-```
+| `lcm` not found | `npm install -g @lossless-claude/lcm` |
+| daemon not running | `lcm daemon start --detach`, retry |
+| no results | `lcm grep` with a different term, or broaden the query |
+| anything else | `lcm doctor` |

--- a/.changeset/tag-vocabulary-is-generic.md
+++ b/.changeset/tag-vocabulary-is-generic.md
@@ -1,0 +1,11 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+fix: the tag vocabulary is generic
+
+The learning instruction and the `lcm_store` tool description name five tag prefixes:
+`type:`, `scope:`, `project:`, `source:`, `priority:`. The `owner:` and `sprint:` prefixes,
+which described one organisation's process, are gone from the guidance; tags already stored
+with them are untouched. `lcm_store` describes its target as the promoted layer, the name
+`lcm_search` uses for the same layer.

--- a/.claude-plugin/commands/lcm-doctor.md
+++ b/.claude-plugin/commands/lcm-doctor.md
@@ -1,12 +1,12 @@
 ---
 name: lcm-doctor
-description: Run lossless-claude diagnostics — checks daemon, hooks, MCP server, and summarizer health.
+description: Run lcm diagnostics — checks daemon, hooks, MCP server, and summarizer health.
 user_invocable: true
 ---
 
 # /lcm-doctor
 
-Run diagnostics on the lossless-claude installation.
+Run diagnostics on the lcm installation.
 
 ## Instructions
 
@@ -17,7 +17,7 @@ The tool returns pre-formatted markdown with status tables per section. Display 
 If any check shows a failure icon, add a **Fix** section listing specific remediation steps for each failure.
 
 End with one of:
-- *All checks passed — lossless-claude is healthy.*
+- *All checks passed — lcm is healthy.*
 - *N check(s) need attention — see Fix section above.*
 
 If `lcm_doctor` is unavailable, run `lcm doctor` via Bash and display the output verbatim. If `lcm` is not on PATH (marketplace install), first try to install it by running `node "${CLAUDE_PLUGIN_ROOT}/lcm.mjs" install`, then retry `lcm doctor`. If `lcm` is still unavailable, run `node "${CLAUDE_PLUGIN_ROOT}/lcm.mjs" doctor` instead.

--- a/.claude-plugin/commands/lcm-sensitive.md
+++ b/.claude-plugin/commands/lcm-sensitive.md
@@ -1,12 +1,12 @@
 ---
 name: lcm-sensitive
-description: Manage sensitive patterns for lossless-claude secret redaction — list, add, remove, test, or purge patterns.
+description: Manage sensitive patterns for lcm secret redaction — list, add, remove, test, or purge patterns.
 user_invocable: true
 ---
 
 # /lcm-sensitive
 
-Manage the sensitive patterns used by lossless-claude to redact secrets before storing conversation messages.
+Manage the sensitive patterns used by lcm to redact secrets before storing conversation messages.
 
 ## Usage
 

--- a/.claude-plugin/commands/lcm-stats.md
+++ b/.claude-plugin/commands/lcm-stats.md
@@ -1,12 +1,12 @@
 ---
 name: lcm-stats
-description: Show lossless-claude memory inventory, compression ratios, and DAG statistics.
+description: Show lcm memory inventory, compression ratios, and DAG statistics.
 user_invocable: true
 ---
 
 # /lcm-stats
 
-Show memory and compression statistics from lossless-claude.
+Show memory and compression statistics from lcm.
 
 ## Instructions
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,4 +1,4 @@
-# Copilot Review Instructions — lossless-claude (lcm)
+# Copilot Review Instructions — lcm
 
 This repo is a TypeScript SQLite daemon that persists Claude session memories across context resets. It uses Node.js `DatabaseSync` (synchronous SQLite API) and exposes an HTTP daemon with REST routes.
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -24,7 +24,7 @@
 
 ## Copilot review focus areas
 
-> This repo is a TypeScript SQLite daemon (lossless-claude / lcm).
+> This repo is a TypeScript SQLite daemon (lcm).
 > Please pay extra attention to:
 
 - **DB connection pattern**: All DB access uses `getLcmConnection()`/`closeLcmConnection()`? No `new DatabaseSync()` directly?

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: code-review
-description: Review code changes in the lossless-claude/lcm repository. Use when asked to review a PR, diff, or code change. Encodes project-specific rules for the SQLite daemon, connection lifecycle, type safety, performance gates, test coverage, transactions, migrations, and error handling.
+description: Review code changes in the lcm repository. Use when asked to review a PR, diff, or code change. Encodes project-specific rules for the SQLite daemon, connection lifecycle, type safety, performance gates, test coverage, transactions, migrations, and error handling.
 ---
 
 # lcm Code Review

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,3 +40,20 @@ _Avoid_: caller, origin session
 The text a skill injects into the model's context when it is invoked. It arrives in
 the transcript as ordinary message text, not as a tool call.
 _Avoid_: skill prompt, skill body
+
+### What lcm keeps
+
+**Episodic memory**:
+The captured messages and the summaries compacted from them, in the order they happened.
+_Avoid_: history, transcript store
+
+**Promoted memory**:
+A statement kept on its own, apart from any session: stored by an agent through
+`lcm store` / `lcm_store`, or promoted from passive capture. Search reports the two
+layers separately.
+_Avoid_: semantic memory, knowledge base
+
+**Tag**:
+A `<prefix>:<value>` label on a promoted memory, the only thing a filter selects on.
+`docs/tag-schema.md` lists the prefixes.
+_Avoid_: category, label

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <strong>lossless-claude</strong><br>
+  <strong>lcm</strong><br>
   Shared memory infrastructure for coding agents
 </p>
 
@@ -24,7 +24,7 @@
 
 ---
 
-`lossless-claude` replaces sliding-window forgetfulness with a persistent memory runtime for both humans and agents.
+`lcm` replaces sliding-window forgetfulness with a persistent memory runtime for both humans and agents.
 
 - Every message is stored in a project SQLite database.
 - Older context is compacted into a DAG of summaries instead of being dropped.
@@ -43,7 +43,7 @@ flowchart LR
     CC["Claude Code<br/>hooks + MCP"]
   end
 
-  CC --> D["lossless-claude daemon"]
+  CC --> D["lcm daemon"]
 
   D --> DB[("project SQLite DAG")]
   D --> PM[("promoted memory FTS5")]
@@ -56,7 +56,7 @@ flowchart LR
 |---|---|---|---|---|---|
 | Claude Code | Yes | Yes | Yes, via transcript/hooks | Yes | Primary hook-based integration |
 | GitHub Copilot (VS Code) | No | Yes, via skill/rules | No | No | Repo-local skill can teach Copilot to call `lcm`, but there is no automatic restore or turn capture yet |
-| Codex | No | Yes, via skill/rules | No | No | Repo-local or global skill plus `lcm import --codex`; MCP config in `.codex/config.toml` is still manual, and first-class runtime support is tracked in issue #232 |
+| Codex | Yes | Yes | Yes, via native lifecycle hooks | LCM memory compacts on `PreCompact`; native compaction continues | `lcm connectors install codex` installs the hooks; see [docs/vscode-codex.md](docs/vscode-codex.md). MCP config in `.codex/config.toml` is still manual |
 
 ## LCM Model
 
@@ -321,7 +321,7 @@ test/
 
 All conversation data is stored locally in `~/.lossless-claude/`. Nothing is sent to any lossless-claude server.
 
-If you configure an external summarizer (`claude-process`, `anthropic`, `openai`, etc.), messages are sent to that provider for summarization — after built-in secret redaction. lossless-claude scrubs common secret patterns (API keys, tokens, passwords) from message content before writing to SQLite and before sending to the summarizer.
+If you configure an external summarizer (`claude-process`, `anthropic`, `openai`, etc.), messages are sent to that provider for summarization — after built-in secret redaction. lcm scrubs common secret patterns (API keys, tokens, passwords) from message content before writing to SQLite and before sending to the summarizer.
 
 Add project-specific patterns with `lcm sensitive add "MY_PATTERN"`. See [docs/privacy.md](docs/privacy.md) for full details.
 
@@ -333,7 +333,7 @@ Add project-specific patterns with `lcm sensitive add "MY_PATTERN"`. See [docs/p
 
 ## Acknowledgments
 
-`lossless-claude` stands on the shoulders of [lossless-claw](https://github.com/Martian-Engineering/lossless-claude), the original implementation by [Martian Engineering](https://martian.engineering). The DAG-based compaction architecture, the LCM memory model, and the foundational design decisions all originate there.
+`lcm` stands on the shoulders of [lossless-claw](https://github.com/Martian-Engineering/lossless-claude), the original implementation by [Martian Engineering](https://martian.engineering). The DAG-based compaction architecture, the LCM memory model, and the foundational design decisions all originate there.
 
 The underlying theory comes from the [LCM paper](https://papers.voltropy.com/LCM) by [Voltropy](https://x.com/Voltropy).
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ flowchart LR
 
 | Tool | Purpose |
 |---|---|
-| `lcm_search` | Hybrid search across episodic memory (SQLite) and semantic memory |
+| `lcm_search` | Search across episodic memory (messages and summaries) and promoted memory |
 | `lcm_grep` | Regex or full-text search across raw messages and summaries |
 | `lcm_expand` | Decompress a summary node into its source content by traversing the DAG |
 | `lcm_describe` | Inspect metadata and lineage of a memory node (depth, token count, parent/child links) |

--- a/agents/compaction-reviewer.md
+++ b/agents/compaction-reviewer.md
@@ -25,7 +25,7 @@ model: haiku
 color: yellow
 ---
 
-You are a compaction quality reviewer for lossless-claude. Your job is to verify that summaries accurately preserve important information from their source messages.
+You are a compaction quality reviewer for lcm. Your job is to verify that summaries accurately preserve important information from their source messages.
 
 **Your Core Responsibilities:**
 1. Compare summaries against their source content

--- a/agents/health-investigator.md
+++ b/agents/health-investigator.md
@@ -1,7 +1,7 @@
 ---
 name: health-investigator
 description: |-
-  Use this agent for deep investigation of lossless-claude health issues — goes beyond the doctor checklist to find root causes. Examples:
+  Use this agent for deep investigation of lcm health issues — goes beyond the doctor checklist to find root causes. Examples:
 
   <example>
   Context: Doctor shows failures but the cause isn't obvious
@@ -34,7 +34,7 @@ model: inherit
 color: green
 ---
 
-You are a health investigation agent for lossless-claude. Your job is to find the root cause of issues that the basic doctor check can't explain.
+You are a health investigation agent for lcm. Your job is to find the root cause of issues that the basic doctor check can't explain.
 
 **Your Core Responsibilities:**
 1. Investigate daemon, database, and hook health issues

--- a/agents/memory-explorer.md
+++ b/agents/memory-explorer.md
@@ -34,7 +34,7 @@ model: inherit
 color: cyan
 ---
 
-You are a memory exploration agent for lossless-claude. Your job is to search conversation history and promoted knowledge to answer questions about past discussions, decisions, and work.
+You are a memory exploration agent for lcm. Your job is to search conversation history and promoted knowledge to answer questions about past discussions, decisions, and work.
 
 **Your Core Responsibilities:**
 1. Search episodic memory (summaries) and promoted knowledge for relevant context

--- a/agents/transcript-debugger.md
+++ b/agents/transcript-debugger.md
@@ -34,7 +34,7 @@ model: inherit
 color: red
 ---
 
-You are a transcript debugging agent for lossless-claude. Your job is to diagnose why transcript ingestion failed or produced unexpected results.
+You are a transcript debugging agent for lcm. Your job is to diagnose why transcript ingestion failed or produced unexpected results.
 
 **Your Core Responsibilities:**
 1. Inspect raw JSONL transcript files for parse errors

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -130,7 +130,7 @@ lcm_expand(nodeId: "sum_def456", depth: 2)
 
 ### lcm_store
 
-Store a memory into lossless-claude's semantic layer. Use to persist decisions, findings, reasoning outcomes, or any knowledge worth retrieving in future sessions.
+Store a memory into the promoted layer. Use to persist decisions, findings, reasoning outcomes, or any knowledge worth retrieving in future sessions.
 
 **Parameters:**
 

--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -99,6 +99,7 @@ Inspect metadata and lineage of a memory node without expanding content. Returns
 | Param | Type | Required | Default | Description |
 |-------|------|----------|---------|-------------|
 | `nodeId` | string | ✅ | — | Node ID to describe (e.g. `sum_abc123`) |
+| `projectId` | string | | current project | The `project.id` of the search result the node came from. Required whenever the node did not come from this project, since node ids are only unique within one project |
 
 **Examples:**
 
@@ -117,6 +118,7 @@ Decompress a summary node into its full source content by traversing the DAG. Us
 |-------|------|----------|---------|-------------|
 | `nodeId` | string | ✅ | — | Summary node ID to expand |
 | `depth` | number | | `1` | How many levels of the DAG to traverse |
+| `projectId` | string | | current project | The `project.id` of the search result the node came from. Required whenever the node did not come from this project, since node ids are only unique within one project |
 
 **Examples:**
 
@@ -158,7 +160,7 @@ lcm_store(
 
 ### lcm_stats
 
-Show token savings, compression ratios, and usage statistics across all lossless-claude projects.
+Show token savings, compression ratios, and usage statistics across all lcm projects.
 
 **Parameters:**
 
@@ -168,7 +170,7 @@ Show token savings, compression ratios, and usage statistics across all lossless
 
 ### lcm_doctor
 
-Run diagnostics on the lossless-claude installation. Checks daemon, hooks, MCP config, and summarizer health.
+Run diagnostics on the lcm installation. Checks daemon, hooks, MCP config, and summarizer health.
 
 **Parameters:** none.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-This document describes how lossless-claude works internally — the data model, compaction lifecycle, context assembly, and expansion system.
+This document describes how lcm works internally — the data model, compaction lifecycle, context assembly, and expansion system.
 
 ## Data model
 
@@ -15,7 +15,7 @@ Messages are stored with:
 - **tokenCount** — Estimated token count (~4 chars/token)
 - **createdAt** — Insertion timestamp
 
-Each message also has **message_parts** — structured content blocks that preserve the original shape (text blocks, tool calls, tool results, reasoning, file content, etc.). This allows the assembler to reconstruct rich content when building model context, not just flat text.
+Each message also has **message_parts** — structured content blocks that preserve the original shape. The part types are `text`, `reasoning`, `tool`, `patch`, `file`, `subtask`, `compaction`, `step_start`, `step_finish`, `snapshot`, `agent`, `retry`, `skill` (a skill expansion) and `command` (a slash command invocation); see `MessagePartType` in `src/store/conversation-store.ts`. This allows the assembler to reconstruct rich content when building model context, not just flat text.
 
 ### The summary DAG
 
@@ -58,6 +58,8 @@ When Claude Code processes a turn, it calls the context engine's lifecycle hooks
 2. **ingest** / **ingestBatch** — Persists new messages to the database and appends them to context_items.
 3. **afterTurn** — After the model responds, ingests new messages, then evaluates whether compaction should run.
 
+When `/ingest` processes a session it also looks for that session's subagent transcripts at `<project>/<session_id>/subagents/*.jsonl` (`discoverSubagentSessions` in `src/daemon/subagent-discovery.ts`). The lookup is scoped to that one directory, never a walk of the projects tree. Each subagent transcript is captured as its own session and attributed to the parent session (see CONTEXT.md for the terms).
+
 ### Leaf compaction
 
 The **leaf pass** converts raw messages into leaf summaries:
@@ -68,7 +70,7 @@ The **leaf pass** converts raw messages into leaf summaries:
 4. Resolve the most recent prior summary for continuity (passed as `previous_context` so the LLM avoids repeating known information).
 5. Send to the LLM with the leaf prompt.
 6. Normalize provider response blocks (Anthropic/OpenAI text, output_text, and nested content/summary shapes) into plain text.
-7. If normalization is empty, log provider/model/block-type diagnostics and fall back to deterministic truncation.
+7. If normalization is empty, re-run it against the whole response envelope (some providers put the text in a top-level field), then retry the request once at temperature 0.05, and only then fall back to deterministic truncation, logging provider/model/block-type diagnostics.
 8. If the summary is larger than the input (LLM failure), retry with the aggressive prompt. If still too large, fall back to deterministic truncation.
 9. Persist the summary, link to source messages, and replace the message range in context_items.
 
@@ -150,7 +152,7 @@ Every summarization attempt follows this escalation:
 
 1. **Normal** — Standard prompt, temperature 0.2
 2. **Aggressive** — Tighter prompt requesting only durable facts, temperature 0.1, lower target tokens
-3. **Fallback** — Deterministic truncation to ~512 tokens with `[Truncated for context management]` marker
+3. **Fallback** — Deterministic truncation to ~512 tokens, ending in a `[Truncated from N tokens]` marker (N is the input size)
 
 This ensures compaction always makes progress, even if the LLM produces poor output.
 
@@ -218,8 +220,8 @@ For broader recall, agents can first use `lcm_grep` or `lcm_search` to find rele
 ## Large file handling — planned, not implemented
 
 Nothing below runs today. The storage layer exists — a `large_files` table and
-`insertLargeFile`/`getLargeFile` on the summary store — and `largeFileTokenThreshold` is a
-resolved config key, but no ingestion path reads that threshold or writes such a record.
+`insertLargeFile`/`getLargeFile` on the summary store — but no config key, threshold or
+ingestion path writes such a record.
 Ingestion scrubs and stores messages whole. This section describes the intended design, so
 that the half already built is not mistaken for a working feature.
 

--- a/docs/fts5.md
+++ b/docs/fts5.md
@@ -1,6 +1,6 @@
 # Optional: enable FTS5 for fast full-text search
 
-`lossless-claude` works without FTS5 as of the current release. When FTS5 is unavailable in the
+`lcm` works without FTS5 as of the current release. When FTS5 is unavailable in the
 Node runtime that runs the Claude Code gateway, the plugin:
 
 - keeps persisting messages and summaries
@@ -130,7 +130,7 @@ You should see:
 program = /Users/youruser/Projects/node-fts5/bin/node-22.15.0
 ```
 
-## Verify `lossless-claude`
+## Verify `lcm`
 
 Check the logs:
 

--- a/docs/passive-learning.md
+++ b/docs/passive-learning.md
@@ -25,6 +25,7 @@ Events are written to a **sidecar SQLite database** (`~/.lossless-claude/events/
 | File access | Read/Edit/Write/Glob/Grep with file paths | 3 (pattern-only) |
 | MCP tools | Which MCP tools are used (tool name only) | 3 (pattern-only) |
 | Skills | Which skills are invoked | 3 (pattern-only) |
+| Subagents | Which subagent was dispatched, with its task description | 3 (pattern-only) |
 
 ### What Is NOT Captured
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -1,6 +1,6 @@
 # Privacy & Data Handling
 
-lossless-claude stores your conversation history locally to enable memory across sessions. This document explains exactly what is stored, what leaves your machine, and how to control sensitive data.
+lcm stores your conversation history locally to enable memory across sessions. This document explains exactly what is stored, what leaves your machine, and how to control sensitive data.
 
 ## What is stored locally
 
@@ -11,11 +11,11 @@ All storage is on your machine:
 - **`~/.lossless-claude/config.json`** — Global configuration including the optional `security.sensitivePatterns` array.
 - **`~/.lossless-claude/daemon.pid`** — Daemon process ID (transient).
 
-No data is sent to any lossless-claude server. There is no telemetry.
+No data is sent to any lcm server. There is no telemetry.
 
 ## What leaves your machine
 
-lossless-claude is a local runtime. By default, **nothing leaves your machine**.
+lcm is a local runtime. By default, **nothing leaves your machine**.
 
 The exception is the summarizer, which you configure explicitly:
 
@@ -32,21 +32,16 @@ When using an external summarizer, only the text being summarized is sent — no
 
 ## Secret redaction
 
-lossless-claude scrubs secrets from message content **before writing to SQLite** and **before sending to the summarizer**. Redaction happens at both write points to ensure secrets are never persisted or transmitted.
+lcm scrubs secrets from message content **before writing to SQLite** and **before sending to the summarizer**. Redaction happens at both write points to ensure secrets are never persisted or transmitted.
 
 ### Built-in patterns
 
-These patterns are always active, regardless of configuration:
+Two sets are always active, regardless of configuration:
 
-| Pattern | Example match |
-|---------|--------------|
-| OpenAI secret key | `sk-...` |
-| Anthropic API key | `sk-ant-...` |
-| GitHub personal access token | `ghp_...` |
-| AWS access key ID | `AKIA...` |
-| PEM private key | `-----BEGIN ... KEY-----` |
-| Bearer token | `Authorization: Bearer ...` |
-| Password assignment | `password=...`, `PASSWORD: ...` |
+- The **gitleaks** rule set, generated into `src/generated-patterns.ts` (221 patterns at the time of writing; `lcm sensitive list` prints the current count).
+- A **native** set in `src/scrub.ts` that fills the gaps gitleaks covers only with surrounding context: bare OpenAI, Anthropic, GitHub, AWS, npm, Slack, Stripe, Google, SendGrid, Twilio, Shopify, Vault and Doppler tokens, PEM key headers, bearer tokens, password assignments, and database connection strings with embedded credentials.
+
+Patterns are applied in this order: gitleaks, native, global user patterns, then project patterns. `lcm sensitive list` shows every active pattern with its source.
 
 ### Project-specific patterns
 
@@ -77,7 +72,7 @@ Messages and summaries persist until you explicitly remove them:
 # Remove data for the current project
 lcm sensitive purge --yes
 
-# Remove all lossless-claude data
+# Remove all lcm data
 lcm uninstall
 ```
 

--- a/docs/tag-schema.md
+++ b/docs/tag-schema.md
@@ -1,107 +1,86 @@
-# LCM Canonical Tag Schema
+# Tag schema
 
-> **Status:** Canonical — all agents and tools must follow this schema.
-> **Source of truth:** This file. The `lcm_store` MCP tool description references it.
+Tags are what `lcm search --tag` and the `tags` filter of `lcm_search` select on. This file
+defines the shape a tag has and the prefixes the guidance recommends. The `lcm_store`
+description and the learning instruction point here.
 
-## Why a schema?
+## Shape
 
-Without a canonical schema, the same decision gets stored as `decision:X`, `category:decision`, or just `decision` — making `lcm_search` with tag filters unreliable. The canonical schema enforces consistent `<prefix>:<value>` pairs so any agent can construct a precise search filter.
+A tag is `<prefix>:<value>`. A tag without a colon is stored and full-text searchable, but
+no filter can select it by category: `decision`, `category:decision` and `type:decision`
+are three different tags. Use the prefixed form for anything you intend to filter on later.
 
-## Schema
+Values are lower-case, with `-` between words. Nothing enforces this at runtime; the schema
+holds by convention, and a filter only finds what was stored with the exact same tag.
 
-All tags follow the `<prefix>:<value>` format. Free-text tags (no colon) are allowed but are not searchable by category — prefer canonical tags for anything you intend to filter on later.
+## Recommended prefixes
 
-### `type:` — what kind of insight is this?
+### `type:` — what kind of insight this is
 
 | Value | When to use |
 |-------|-------------|
-| `type:decision` | An architectural or process decision with trade-offs evaluated |
-| `type:preference` | A user or team preference ("always do X", "never do Y") |
-| `type:root-cause` | The identified cause of a bug, failure, or incident |
-| `type:pattern` | A recurring pattern worth reusing (code structure, workflow, etc.) |
-| `type:gotcha` | A non-obvious pitfall, footgun, or surprising behavior |
+| `type:decision` | An architectural or process decision, with the trade-off that settled it |
+| `type:preference` | How the user or the team wants things done ("always X", "never Y") |
+| `type:root-cause` | The identified cause of a bug, failure or incident |
+| `type:pattern` | A recurring structure worth reusing: code shape, workflow, convention |
+| `type:gotcha` | A non-obvious pitfall or surprising behaviour |
 | `type:solution` | A specific fix or answer to a concrete problem |
-| `type:workflow` | A step-by-step process or runbook |
-| `type:feat` | A feature addition or enhancement |
-| `type:fix` | A bug fix |
-| `type:chore` | Maintenance, refactoring, or tooling work |
+| `type:workflow` | A step-by-step process that works |
+| `type:feat`, `type:fix`, `type:chore` | The kind of change a piece of work was |
 
-### `scope:` — what domain does this belong to?
+Passive promotion (`docs/passive-learning.md`) also produces `type:user-context` (from role
+and identity statements) and `type:environment` (from install and setup commands). They
+are valid filter values; a hand-written store rarely needs them.
+
+### `scope:` — which domain the insight belongs to
 
 | Value | When to use |
 |-------|-------------|
-| `scope:token-budget` | Token window management, quota, efficiency |
-| `scope:model-selection` | Haiku vs Sonnet vs Opus routing decisions |
 | `scope:architecture` | System design, component structure, data flow |
-| `scope:process` | Team workflow, governance, sprint cadence |
-| `scope:xgh` | Anything in or about the xgh repo |
-| `scope:autoimprove` | Anything in or about the autoimprove repo |
-| `scope:lcm` | Anything in or about lossless-claude itself |
 | `scope:security` | Secret scanning, auth, access control |
 | `scope:testing` | Test strategy, test infrastructure, test failures |
-| `scope:ci` | CI/CD pipelines, GitHub Actions, release automation |
+| `scope:ci` | CI pipelines, release automation |
+| `scope:process` | Team workflow and governance |
+| `scope:token-budget` | Context window management, quota, efficiency |
+| `scope:model-selection` | Which model to route a task to |
+| `scope:<name>` | Any other domain; keep one spelling per domain |
 
-### `priority:` — how urgent or important?
+### `project:` — which repository or project
 
-| Value | When to use |
-|-------|-------------|
-| `priority:P0` | Critical — system broken, data loss, security issue |
-| `priority:P1` | High — blocks a sprint or a release |
-| `priority:P2` | Normal — should be addressed in current or next sprint |
-| `priority:P3` | Low — nice-to-have, no deadline |
+A free identifier that matches the repository or project name, for example `project:lcm`.
+Use it when a memory would be misleading outside that project.
 
-### `owner:` — who is responsible for acting on this?
-
-| Value | When to use |
-|-------|-------------|
-| `owner:CTO` | Technical architecture, code quality, test coverage |
-| `owner:COO` | Process, coordination, sprint management |
-| `owner:team-lead-xgh` | xgh repo work |
-| `owner:team-lead-autoimprove` | autoimprove repo work |
-| `owner:team-lead-lcm` | lcm repo work |
-| `owner:co-ceo` | Governance, strategic decisions, both Co-CEOs needed |
-
-### `project:` — which project/repo?
-
-Freeform identifier matching the repo or project name. Examples:
-- `project:lcm`
-- `project:xgh`
-- `project:autoimprove`
-- `project:claudinho`
-
-### `sprint:` — which sprint?
-
-Format: `sprint:spN` (e.g. `sprint:sp3`). Use the sprint declared in the current triage file header. Fallback: `sprint:YYYY-MM-DD`.
-
-### `source:` — where did this insight come from?
+### `source:` — where the insight came from
 
 | Value | When to use |
 |-------|-------------|
-| `source:adversarial-review` | From an Enthusiast/Adversary/Judge review cycle |
-| `source:session` | From a Co-CEO working session |
+| `source:session` | From a working session with the user |
+| `source:review` | From a code or design review |
 | `source:ci` | From automated CI output |
-| `source:agent` | From a teammate or subagent |
-| `source:retrospective` | From a sprint retrospective |
+| `source:agent` | From a subagent's report |
+
+### `priority:` — how urgent
+
+`priority:P0` (system broken, data loss, security) through `priority:P3` (nice-to-have).
+Most memories carry no priority.
 
 ## Combining tags
 
-A single `lcm_store` entry should use 2–4 canonical tags, covering at minimum `type:` and one of `project:` or `scope:`. Sprint and source tags are recommended for traceability.
+A store carries two to four tags: `type:` plus one of `project:` or `scope:`, and `source:`
+when the origin matters for trust.
 
-**Example — good:**
 ```
-["type:solution", "scope:lcm", "project:lcm", "sprint:sp3", "source:session"]
+["type:solution", "scope:lcm", "project:lcm", "source:session"]
 ```
 
-**Example — bad (avoid):**
-```
-["solution", "lcm", "sp3"]
-```
-The bad form still works for full-text search but cannot be filtered by tag category.
+## Reserved tags
 
-## Migration note
+Two tags carry protocol meaning and are not categories:
 
-Existing entries tagged with legacy formats (e.g. `category:decision`, `decision`, `category:gotcha`) are not retroactively migrated — the schema applies to new stores only. The `promote-events` AUTO_TAGS mapping uses `category:*` as an internal convention; those are separate from the canonical user-facing schema defined here.
+- `signal:memory_used` together with `memory_id:<id>` marks a store as a usage report for
+  the memory `<id>`. The stale memory review (`docs/configuration.md`, section "Stale memory review") counts
+  these reports as uses of that memory. The learning instruction tells the model to emit them when it acts
+  on a surfaced memory.
 
-## Validation
-
-There is no runtime enforcement today — the schema is normative by convention. A future `lcm doctor` check may warn on tag-less entries or non-canonical formats.
+Passive promotion tags an event whose category has no `type:` mapping as
+`category:<category>`. Those are internal; filter on `type:` instead.

--- a/hooks/lcm-hooks.ts
+++ b/hooks/lcm-hooks.ts
@@ -45,7 +45,7 @@ When you recognize a durable insight, call lcm_store immediately:
 - solution: non-trivial fix worth remembering
 - workflow: multi-step process that works
 
-Tag prefixes: type: | scope: | project: | sprint: | source: | priority: | owner: | signal:
+Tag prefixes: type: | scope: | project: | source: | priority:
 Usage: lcm_store(text: "concise insight with why", tags: ["type:decision", "project:<repo>"])
 
 When you act on a surfaced memory (use it to inform a decision, avoid a known pitfall, or reference it in your work), emit:

--- a/skills/lcm-context/SKILL.md
+++ b/skills/lcm-context/SKILL.md
@@ -5,7 +5,7 @@ description: "Use when deciding which lcm MCP tool to call — lcm_search, lcm_g
 
 # lcm Memory Tool Guide
 
-Lossless-claude provides 7 MCP tools. This skill helps you pick the right one and recover from errors.
+lcm provides 7 MCP tools. This skill helps you pick the right one and recover from errors.
 
 > **Hooks already inject memory at session start.** Do NOT re-query what was already injected. This skill is for active retrieval, storage, and error recovery — not session initialization.
 
@@ -17,8 +17,8 @@ These three tools **chain** from broad to deep:
 
 1. **lcm_search** — Broad concept recall across sessions
    - Use: "how was auth implemented?", "what decisions were made about compaction?"
-   - Returns: ranked results from FTS5 + semantic layers
-   - Options: `tags` to filter, `layers` to scope (episodic/semantic)
+   - Returns: ranked results from the episodic and promoted layers
+   - Options: `tags` to filter, `layers` to scope (`episodic`, `promoted`)
 
 2. **lcm_grep** — Exact keyword/regex in raw transcripts
    - Use: "JWT", "socket.unref", specific error messages
@@ -42,7 +42,7 @@ These three tools **chain** from broad to deep:
 
 5. **lcm_store** — Persist a decision or finding for future sessions
    - Use: architectural decisions, bug root causes, user preferences, integration patterns
-   - Options: `tags` for categorization, `metadata` for project/session context
+   - Options: `tags` following `docs/tag-schema.md` (`type:` plus `project:` or `scope:`), `metadata` for project/session context
 
 ### Operational Tools
 
@@ -109,7 +109,7 @@ If install succeeds, `lcm` should now be available on PATH. If it is still not a
 ## Quick Reference
 
 ```
-lcm_search  → broad concept recall (FTS5 + semantic)
+lcm_search  → broad concept recall (episodic + promoted)
 lcm_grep    → exact keyword/regex match
 lcm_expand  → decompress a summary node
 lcm_describe → inspect node metadata (check before expanding)

--- a/src/connectors/templates/sections/mcp-workflow.md
+++ b/src/connectors/templates/sections/mcp-workflow.md
@@ -1,6 +1,6 @@
 # Workflow Instruction
 
-You are a coding agent integrated with lossless-claude via MCP (Model Context Protocol).
+You are a coding agent integrated with lcm via MCP (Model Context Protocol).
 
 ## Core Rules
 

--- a/src/hooks/learning-instruction.ts
+++ b/src/hooks/learning-instruction.ts
@@ -14,7 +14,7 @@ When you recognize a durable insight, call lcm_store immediately:
 - solution: non-trivial fix worth remembering
 - workflow: multi-step process that works
 
-Tag prefixes: type: | scope: | project: | sprint: | source: | priority: | owner: | signal:
+Tag prefixes: type: | scope: | project: | source: | priority:
 Usage: lcm_store(text: "concise insight with why", tags: ["type:decision", "project:<repo>"])
 
 When you act on a surfaced memory (use it to inform a decision, avoid a known pitfall, or reference it in your work), emit:

--- a/src/mcp/tools/lcm-store.ts
+++ b/src/mcp/tools/lcm-store.ts
@@ -1,6 +1,6 @@
 export const lcmStoreTool = {
   name: "lcm_store",
-  description: "Store a memory into lossless-claude's semantic layer. Use to persist decisions, findings, reasoning outcomes, or any knowledge worth retrieving in future sessions. Stored memories are searchable via lcm_search.",
+  description: "Store a memory into the promoted layer. Use to persist decisions, findings, reasoning outcomes, or any knowledge worth retrieving in future sessions. Stored memories are searchable via lcm_search.",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -8,7 +8,7 @@ export const lcmStoreTool = {
       tags: {
         type: "array",
         items: { type: "string" },
-        description: "Canonical tags following the <prefix>:<value> schema (see docs/tag-schema.md). Use at least type: and one of project: or scope:. Examples: ['type:solution', 'scope:lcm', 'project:lcm', 'sprint:sp3', 'source:session']. Valid prefixes: type, scope, priority, owner, project, sprint, source.",
+        description: "Canonical tags following the <prefix>:<value> schema (see docs/tag-schema.md). Use at least type: and one of project: or scope:. Examples: ['type:solution', 'scope:lcm', 'project:lcm', 'source:session']. Prefixes: type, scope, project, source, priority.",
       },
       metadata: {
         type: "object",


### PR DESCRIPTION
Third PR of the documentation audit, after #449 (plugin and contract) and #451 (config knobs). Four commits, each reviewable alone.

## 1. The tag vocabulary is generic (published behaviour, changeset: patch)

The learning instruction (both copies) and the `lcm_store` description name five prefixes: `type:`, `scope:`, `project:`, `source:`, `priority:`. `owner:` and `sprint:` described one organisation's process and are gone from the guidance; stored tags are untouched. `lcm_store` says "promoted layer", the name `lcm_search` already uses.

## 2. `docs/tag-schema.md` rewritten; `CONTEXT.md` names the layers

The schema keeps the generic prefixes, drops roles, sprints and the other repositories (the old file broke the "no consumer repository names" invariant on `main`), documents the passive-promotion values `type:user-context` / `type:environment`, and gives the reserved `signal:memory_used` + `memory_id:` pair its real meaning: usage reports the stale-memory review counts. `CONTEXT.md` gains **Episodic memory**, **Promoted memory** and **Tag**.

## 3. Skills

`skills/lcm-context` (the plugin skill) names the real layer values (`episodic`, `promoted`) and points tags at the schema. `.agents/skills/lcm-context` (loaded by agents working in this repo without the plugin) shrinks to the CLI form: recall policy true for its host, the five invocations with the real repeatable `--tag`/`--layer`, and pointers to the plugin skill, `docs/agent-tools.md` and the schema for everything else. The connector template stays self-contained.

## 4. Truth fixes and the product name

- README capability table: Codex has restore, prompt hints and turn capture through native lifecycle hooks (`lcm connectors install codex`); the closed issue #232 is no longer cited.
- `docs/architecture.md`: the real `MessagePartType` list (with `skill`, `command`); subagent transcript discovery during ingestion; envelope → retry → fallback for an empty summary; the fallback marker is `[Truncated from N tokens]`; `largeFileTokenThreshold` is no longer a config key.
- `docs/privacy.md`: redaction is the gitleaks set (221) plus the native gap-fill, applied gitleaks → native → global → project.
- `docs/passive-learning.md`: subagent dispatches are captured. `docs/agent-tools.md`: `projectId` on `lcm_describe` and `lcm_expand`.
- The product is called `lcm` in every doc, command, agent and template. The legacy name remains only where it is a contract: the npm scope, `~/.lossless-claude`, the marketplace and GitHub org, the website, the upstream fork URL.

No `package.json` change, so no publish on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
