### PR TITLE
docs: name the internal CLI commands, and fts5.md describes the daemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,8 +259,8 @@ lcm codex-hook             # native Codex lifecycle hook — see docs/vscode-cod
 lcm mcp                    # start MCP server
 ```
 
-`lcm help [command]` prints this same reference from the CLI. `lcm bench` is a development-only
-search benchmarking tool, not shipped to npm; see [docs/search.md](docs/search.md).
+`lcm help [command]` prints this same reference from the CLI. `lcm bench` is a development tool: it
+benchmarks search against a local corpus, which the npm package does not include; see [docs/search.md](docs/search.md).
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -246,17 +246,21 @@ lcm daemon start --detach  # start daemon in background
 lcm daemon restart         # pick up changed LCM_* values
 lcm daemon stop --hold     # keep it down so hooks cannot respawn it (--minutes <n>, --reason <text>)
 
-# Hook handlers (internal — called by Claude Code hooks)
-lcm compact --hook         # PreCompact hook
-lcm restore                # SessionStart hook
-lcm session-end            # SessionEnd hook
-lcm user-prompt            # UserPromptSubmit hook
-lcm post-tool              # PostToolUse + PostToolUseFailure hooks (passive learning)
-lcm session-snapshot       # Stop hook (rolling ingest)
+# Hook handlers (internal — called by Claude Code and Codex hooks)
+lcm compact --hook         # PreCompact hook (Claude Code)
+lcm restore                # SessionStart hook (Claude Code)
+lcm session-end            # SessionEnd hook (Claude Code)
+lcm user-prompt            # UserPromptSubmit hook (Claude Code)
+lcm post-tool              # PostToolUse + PostToolUseFailure hooks (Claude Code, passive learning)
+lcm session-snapshot       # Stop hook (Claude Code, rolling ingest)
+lcm codex-hook             # native Codex lifecycle hook — see docs/vscode-codex.md
 
 # MCP server
 lcm mcp                    # start MCP server
 ```
+
+`lcm help [command]` prints this same reference from the CLI. `lcm bench` is a development-only
+search benchmarking tool, not shipped to npm; see [docs/search.md](docs/search.md).
 
 ## Configuration
 

--- a/docs/fts5.md
+++ b/docs/fts5.md
@@ -1,18 +1,24 @@
 # Optional: enable FTS5 for fast full-text search
 
-`lcm` works without FTS5 as of the current release. When FTS5 is unavailable in the
-Node runtime that runs the Claude Code gateway, the plugin:
+`lcm` works without FTS5. When FTS5 is unavailable in the Node runtime the daemon runs on, lcm:
 
 - keeps persisting messages and summaries
-- falls back from `"full_text"` search to a slower `LIKE`-based search
+- falls back from FTS5 search to a slower `LIKE`-based search
 - loses FTS ranking/snippet quality
 
-If you want native FTS5 search performance and ranking, the **exact Node runtime that runs the
-gateway** must have SQLite FTS5 compiled in.
+lcm uses Node's built-in `node:sqlite` module (`src/db/features.ts` probes it at startup), not
+`better-sqlite3`. Official Node 22 builds already compile SQLite with FTS5 enabled — most
+installs need nothing further. Run the probe below first; only build a custom Node (last
+section) if it reports `fts5: fail`.
 
-## Probe the gateway runtime
+The daemon always runs on `process.execPath` — the same Node binary that started it, whether
+that is a `lcm daemon start` you ran yourself or the one Claude Code's or Codex's hook command
+resolved from `PATH`. There is no separate runtime to point at; whichever Node is first on
+`PATH` when the daemon is (re)started is the one that must have FTS5.
 
-Run this with the same `node` binary your gateway uses:
+## Probe your Node runtime
+
+Run this with the same `node` binary that starts the daemon:
 
 ```bash
 node --input-type=module - <<'NODE'
@@ -39,11 +45,12 @@ ENABLE_FTS5
 fts5: ok
 ```
 
-If you get `fts5: fail`, build or install an FTS5-capable Node and point the gateway at that runtime.
+If you get `fts5: fail`, either switch to an official Node 22+ build (nodejs.org, Homebrew, or
+nvm all ship FTS5-enabled binaries) or build one yourself.
 
 ## Build an FTS5-capable Node on macOS
 
-This workflow was verified with Node `v22.15.0`.
+Only needed if your runtime lacks FTS5 — for example a distro-packaged Node built without it.
 
 ```bash
 cd ~/Projects
@@ -76,21 +83,10 @@ Build the runtime:
 make -j8 node
 ```
 
-Expose the binary under a Node-compatible basename that Claude Code recognizes:
+Verify the new binary directly:
 
 ```bash
-mkdir -p ~/Projects/node-fts5/bin
-ln -sfn ~/Projects/node-fts5/out/Release/node ~/Projects/node-fts5/bin/node-22.15.0
-```
-
-Use a basename like `node-22.15.0`, `node`, or `nodejs`. Names like
-`node-v22.15.0-fts5` may not be recognized correctly by Claude Code's CLI/runtime parsing.
-
-Verify the new runtime:
-
-```bash
-~/Projects/node-fts5/bin/node-22.15.0 --version
-~/Projects/node-fts5/bin/node-22.15.0 --input-type=module - <<'NODE'
+./out/Release/node --input-type=module - <<'NODE'
 import { DatabaseSync } from 'node:sqlite';
 const db = new DatabaseSync(':memory:');
 db.exec("CREATE VIRTUAL TABLE t USING fts5(content)");
@@ -98,58 +94,27 @@ console.log("fts5: ok");
 NODE
 ```
 
-## Point the Claude Code gateway at that runtime on macOS
+## Point lcm at that runtime
 
-Back up the existing LaunchAgent plist first:
-
-```bash
-cp ~/Library/LaunchAgents/ai.claude.gateway.plist \
-  ~/Library/LaunchAgents/ai.claude.gateway.plist.bak-$(date +%Y%m%d-%H%M%S)
-```
-
-Replace the runtime path, then reload the agent:
+Put the FTS5-capable `node` first on `PATH` for whatever process starts the daemon — your shell
+profile for a manual `lcm daemon start`, or the environment the hook's shell command inherits for
+Claude Code or Codex. Then restart the daemon so it re-spawns under the new binary:
 
 ```bash
-/usr/libexec/PlistBuddy -c 'Set :ProgramArguments:0 /Users/youruser/Projects/node-fts5/bin/node-22.15.0' \
-  ~/Library/LaunchAgents/ai.claude.gateway.plist
-
-launchctl bootout gui/$UID ~/Library/LaunchAgents/ai.claude.gateway.plist 2>/dev/null || true
-launchctl bootstrap gui/$UID ~/Library/LaunchAgents/ai.claude.gateway.plist
-launchctl kickstart -k gui/$UID/ai.claude.gateway
+lcm daemon restart
 ```
 
-Verify the live runtime:
+## Verify
 
 ```bash
-launchctl print gui/$UID/ai.claude.gateway | sed -n '1,80p'
+tail -n 60 ~/.lossless-claude/daemon.log
 ```
 
-You should see:
-
-```text
-program = /Users/youruser/Projects/node-fts5/bin/node-22.15.0
-```
-
-## Verify `lcm`
-
-Check the logs:
+Confirm the daemon is up (`lcm status` reports its version and uptime), then run a search and
+check `~/.lossless-claude/projects/<hash>/db.sqlite` fills as expected:
 
 ```bash
-tail -n 60 ~/.claude/logs/gateway.log
-tail -n 60 ~/.claude/logs/gateway.err.log
-```
-
-You want:
-
-- `[gateway] [lcm] Plugin loaded ...`
-- no new `no such module: fts5`
-
-Then force one turn through the gateway and verify the DB fills:
-
-```bash
-/Users/youruser/Projects/node-fts5/bin/node-22.15.0 \
-  /path/to/claude/dist/index.js \
-  agent --session-id fts5-smoke --message 'Reply with exactly: ok' --timeout 60
+lcm search "some prior conversation"
 
 sqlite3 ~/.lossless-claude/projects/<hash>/db.sqlite '
   select count(*) as conversations from conversations;
@@ -157,5 +122,3 @@ sqlite3 ~/.lossless-claude/projects/<hash>/db.sqlite '
   select count(*) as summaries from summaries;
 '
 ```
-
-Those counts should increase after a real turn.


### PR DESCRIPTION
Last two items of the documentation audit. Docs only; no changeset.

## README §CLI names the internal commands

The hook-handler block now says which host calls each handler and lists `lcm codex-hook`, the entry point the native Codex hooks call. One sentence after the block covers `lcm help [command]` (prints the same reference) and `lcm bench` (a development tool: it benchmarks search against a local corpus the npm package does not include; documented in `docs/search.md`).

## `docs/fts5.md` describes the daemon, not a gateway

The guide told the reader to probe and repoint a "Claude Code gateway" through a LaunchAgent plist and to read `~/.claude/logs/gateway.log`. None of that exists in the code. What the code does: the daemon runs on `process.execPath`, the Node that started it (`src/daemon/lifecycle.ts`), and `src/db/features.ts` probes `node:sqlite` for FTS5 at startup; without it, search falls back to LIKE (`src/store/full-text-fallback.ts`). The doc now says that, keeps the FTS5 probe (it matches the code's own), keeps the build-your-own-Node section as the fallback for a runtime without FTS5, and points at `~/.lossless-claude/daemon.log` and `lcm status` for verification. Node is "22 or later" as `package.json` requires, not a pinned build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
