### PR TITLE
fix(connectors): the skill is installed where Codex and Copilot read it

### DIFF
--- a/.changeset/connector-skills-live-where-hosts-read-them.md
+++ b/.changeset/connector-skills-live-where-hosts-read-them.md
@@ -2,4 +2,6 @@
 "@lossless-claude/lcm": patch
 ---
 
+fix: the skill connector installs where Codex and Copilot read it
+
 The `skill` connector for Codex and GitHub Copilot now installs to `.agents/skills/lcm-memory/SKILL.md`, the location both hosts actually read (Codex only scans `.agents/skills`; Copilot also accepts it). One installed file now serves both hosts in a repository that uses both. Installing or removing the skill connector also clears a pre-existing copy at the old location (`.codex/skills/` or `.github/skills/`) so the two copies never coexist.

--- a/.changeset/connector-skills-live-where-hosts-read-them.md
+++ b/.changeset/connector-skills-live-where-hosts-read-them.md
@@ -1,0 +1,5 @@
+---
+"@lossless-claude/lcm": patch
+---
+
+The `skill` connector for Codex and GitHub Copilot now installs to `.agents/skills/lcm-memory/SKILL.md`, the location both hosts actually read (Codex only scans `.agents/skills`; Copilot also accepts it). One installed file now serves both hosts in a repository that uses both. Installing or removing the skill connector also clears a pre-existing copy at the old location (`.codex/skills/` or `.github/skills/`) so the two copies never coexist.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ lcm connectors install github-copilot
 lcm connectors doctor github-copilot
 ```
 
-This creates a workspace skill under `.github/skills/lcm-memory/SKILL.md` so Copilot can search and store memory through the `lcm` CLI.
+This creates a workspace skill under `.agents/skills/lcm-memory/SKILL.md`. Both Codex and Copilot read that directory, so one installed file serves either host.
 
 ### Codex
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -42,7 +42,7 @@ lcm connectors install github-copilot
 lcm connectors doctor github-copilot
 ```
 
-This writes `.github/skills/lcm-memory/SKILL.md` in the current repository.
+This writes `.agents/skills/lcm-memory/SKILL.md` in the current repository. Codex and Copilot both read that directory.
 
 ### Codex
 

--- a/docs/vscode-codex.md
+++ b/docs/vscode-codex.md
@@ -24,7 +24,7 @@ lcm connectors install github-copilot
 lcm connectors doctor github-copilot
 ```
 
-This writes a repo-local skill file at `.github/skills/lcm-memory/SKILL.md`.
+This writes a repo-local skill file at `.agents/skills/lcm-memory/SKILL.md`. Codex and Copilot both read that directory.
 
 ## Install the Codex connector
 

--- a/src/connectors/installer.ts
+++ b/src/connectors/installer.ts
@@ -1,11 +1,11 @@
-import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync } from "node:fs";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, unlinkSync, rmdirSync } from "node:fs";
 import { join, dirname } from "node:path";
 import { homedir } from "node:os";
 import type { ConnectorType } from "./types.js";
 import { requiresRestart } from "./types.js";
 import { LCM_MARKERS } from "./constants.js";
 import { generateContent } from "./template-service.js";
-import { findAgent, AGENTS } from "./registry.js";
+import { findAgent, AGENTS, LEGACY_SKILL_PATHS } from "./registry.js";
 import { mcpServerEntry } from "../installer/mcp-server-entry.js";
 import {
   diagnoseCodexHooks,
@@ -73,6 +73,18 @@ function installMcpJson(filePath: string): void {
   }
   existing.mcpServers.lcm = { type: 'stdio', ...mcpServerEntry() };
   writeFileSync(filePath, JSON.stringify(existing, null, 2) + '\n');
+}
+
+// Removes the skill file (and its now-empty lcm-memory directory) at an
+// agent's previous skill config path, if one still exists there.
+function removeLegacySkill(agentId: string, cwd: string): void {
+  const legacyBase = LEGACY_SKILL_PATHS[agentId];
+  if (!legacyBase) return;
+  const legacyDir = join(resolveConfigPath(legacyBase, cwd), 'lcm-memory');
+  const legacyPath = join(legacyDir, 'SKILL.md');
+  if (!existsSync(legacyPath)) return;
+  unlinkSync(legacyPath);
+  try { rmdirSync(legacyDir); } catch { /* not empty or already gone */ }
 }
 
 function removeMcpJson(filePath: string): boolean {
@@ -145,6 +157,7 @@ export function installConnector(
     const content = generateContent(agent, connectorType);
     const skillPath = join(resolvedPath, 'lcm-memory', 'SKILL.md');
     installMarkdown(content, skillPath, 'overwrite');
+    removeLegacySkill(agent.id, cwd);
     return { success: true, path: skillPath, requiresRestart: requiresRestart(connectorType) };
   }
 
@@ -175,11 +188,12 @@ export function removeConnector(agentIdOrName: string, type?: ConnectorType, cwd
 
   if (connectorType === 'skill') {
     const skillPath = join(resolvedPath, 'lcm-memory', 'SKILL.md');
-    if (existsSync(skillPath)) {
-      unlinkSync(skillPath);
-      return true;
-    }
-    return false;
+    const existed = existsSync(skillPath);
+    if (existed) unlinkSync(skillPath);
+    const legacyBase = LEGACY_SKILL_PATHS[agent.id];
+    const hadLegacy = !!legacyBase && existsSync(join(resolveConfigPath(legacyBase, cwd), 'lcm-memory', 'SKILL.md'));
+    removeLegacySkill(agent.id, cwd);
+    return existed || hadLegacy;
   }
 
   // rules: remove markers from file

--- a/src/connectors/registry.ts
+++ b/src/connectors/registry.ts
@@ -26,7 +26,7 @@ export const AGENTS: Agent[] = [
       rules: 'AGENTS.md',
       hooks: '.codex/hooks.json',
       mcp: '.codex/config.toml',
-      skill: '.codex/skills/',
+      skill: '.agents/skills/',
     },
   },
   {
@@ -176,7 +176,7 @@ export const AGENTS: Agent[] = [
     supportedTypes: ['rules', 'skill'],
     configPaths: {
       rules: '.github/copilot-instructions.md',
-      skill: '.github/skills/',
+      skill: '.agents/skills/',
     },
     writeMode: 'append',
   },
@@ -260,6 +260,13 @@ export const AGENTS: Agent[] = [
     },
   },
 ];
+
+// Agents whose skill config path moved. Installing/removing a skill connector
+// also clears the file at the old location so the two copies do not coexist.
+export const LEGACY_SKILL_PATHS: Record<string, string> = {
+  codex: '.codex/skills/',
+  'github-copilot': '.github/skills/',
+};
 
 export function findAgent(idOrName: string): Agent | undefined {
   const lower = idOrName.toLowerCase();

--- a/test/connectors/installer.test.ts
+++ b/test/connectors/installer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
 import { join, isAbsolute } from 'node:path';
 import { tmpdir } from 'node:os';
 import { installConnector, removeConnector, listConnectors } from '../../src/connectors/installer.js';
@@ -109,6 +109,70 @@ describe('installConnector — skill', () => {
   it('returns requiresRestart: true for skill', () => {
     const result = installConnector('claude-code', 'skill', tmpDir);
     expect(result.requiresRestart).toBe(true);
+  });
+});
+
+describe('installConnector — skill shared path (codex/github-copilot)', () => {
+  it('writes codex skill to .agents/skills/lcm-memory/SKILL.md', () => {
+    const result = installConnector('codex', 'skill', tmpDir);
+    expect(result.path).toBe(join(tmpDir, '.agents', 'skills', 'lcm-memory', 'SKILL.md'));
+    expect(existsSync(result.path)).toBe(true);
+  });
+
+  it('writes github-copilot skill to .agents/skills/lcm-memory/SKILL.md', () => {
+    const result = installConnector('github-copilot', 'skill', tmpDir);
+    expect(result.path).toBe(join(tmpDir, '.agents', 'skills', 'lcm-memory', 'SKILL.md'));
+    expect(existsSync(result.path)).toBe(true);
+  });
+
+  it('removes a pre-existing legacy codex skill copy on install', () => {
+    const legacyDir = join(tmpDir, '.codex', 'skills', 'lcm-memory');
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, 'SKILL.md'), 'stale content');
+
+    installConnector('codex', 'skill', tmpDir);
+
+    expect(existsSync(join(legacyDir, 'SKILL.md'))).toBe(false);
+    expect(existsSync(legacyDir)).toBe(false);
+    expect(existsSync(join(tmpDir, '.agents', 'skills', 'lcm-memory', 'SKILL.md'))).toBe(true);
+  });
+
+  it('removes a pre-existing legacy github-copilot skill copy on install', () => {
+    const legacyDir = join(tmpDir, '.github', 'skills', 'lcm-memory');
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, 'SKILL.md'), 'stale content');
+
+    installConnector('github-copilot', 'skill', tmpDir);
+
+    expect(existsSync(join(legacyDir, 'SKILL.md'))).toBe(false);
+    expect(existsSync(legacyDir)).toBe(false);
+    expect(existsSync(join(tmpDir, '.agents', 'skills', 'lcm-memory', 'SKILL.md'))).toBe(true);
+  });
+});
+
+describe('removeConnector — skill shared path (codex/github-copilot)', () => {
+  it('removes both the current and legacy codex skill locations', () => {
+    installConnector('codex', 'skill', tmpDir);
+    const legacyDir = join(tmpDir, '.codex', 'skills', 'lcm-memory');
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, 'SKILL.md'), 'stale content');
+
+    const removed = removeConnector('codex', 'skill', tmpDir);
+
+    expect(removed).toBe(true);
+    expect(existsSync(join(tmpDir, '.agents', 'skills', 'lcm-memory', 'SKILL.md'))).toBe(false);
+    expect(existsSync(join(legacyDir, 'SKILL.md'))).toBe(false);
+  });
+
+  it('removes only a lingering legacy github-copilot copy when the new one is absent', () => {
+    const legacyDir = join(tmpDir, '.github', 'skills', 'lcm-memory');
+    mkdirSync(legacyDir, { recursive: true });
+    writeFileSync(join(legacyDir, 'SKILL.md'), 'stale content');
+
+    const removed = removeConnector('github-copilot', 'skill', tmpDir);
+
+    expect(removed).toBe(true);
+    expect(existsSync(join(legacyDir, 'SKILL.md'))).toBe(false);
   });
 });
 

--- a/test/connectors/registry.test.ts
+++ b/test/connectors/registry.test.ts
@@ -66,4 +66,11 @@ describe("connector registry", () => {
     expect(codex?.supportedTypes).toContain("skill");
     expect(codex?.configPaths.hooks).toBe(".codex/hooks.json");
   });
+
+  it("codex and github-copilot share the same skill config path", () => {
+    const codex = findAgent("codex");
+    const githubCopilot = findAgent("github-copilot");
+    expect(codex?.configPaths.skill).toBe(".agents/skills/");
+    expect(githubCopilot?.configPaths.skill).toBe(".agents/skills/");
+  });
 });


### PR DESCRIPTION
Changeset: patch.

## Bug

`lcm connectors install codex --type skill` wrote the skill to `.codex/skills/lcm-memory/SKILL.md`. Codex's documentation ("Where Codex loads local skills") lists repository skills only under `.agents/skills`, scanned from the working directory up to the repository root. The file was never loaded.

## Fix

- Codex and GitHub Copilot skill connectors both install to `.agents/skills/lcm-memory/SKILL.md`. Copilot's documentation lists `.github/skills`, `.claude/skills` and `.agents/skills`, so one file serves both hosts in a repository that uses both.
- Installing or removing the skill connector also clears a copy left at the old location (`.codex/skills/`, `.github/skills/`), so two copies never coexist. `LEGACY_SKILL_PATHS` next to the registry is the only place that knows the old paths.
- README, `docs/configuration.md` and `docs/vscode-codex.md` name the new path.

## Tests

`test/connectors/registry.test.ts` and `test/connectors/installer.test.ts`: both hosts install to `.agents/skills/`; install removes a pre-existing legacy copy; remove deletes both locations and reports whether either existed. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
