### PR TITLE
chore(check-docs): command sources are bin/lcm.ts and src/cli/*.ts

### DIFF
--- a/scripts/check-doc-claims.mjs
+++ b/scripts/check-doc-claims.mjs
@@ -28,18 +28,24 @@
 // Both sides abort when empty: an empty code side would pass every claim, which is the
 // exact failure this script exists to catch.
 //
-// CLI extraction (bin/lcm.ts): a small bracket-depth scanner reads the exact statement that
-// follows each recognised chain root — `new Command("name")`, `<ident>.command("name")`,
-// or a bare `<ident>.option(...)` / `.addOption(...)` / `.requiredOption(...)` not part of a
-// `.command()` chain — so options are attributed to the command path they were actually
-// declared on, not to every `lcm` invocation on the line. `src/cli-help.ts` is hand-written
-// help for hand-parsed subcommands (e.g. `sensitive purge --yes`, which Commander never sees
-// as its own command): an option line there whose text starts with a bare word before its
-// `[--flags]` attaches those flags to `lcm <section> <word>`; a line starting directly with
-// a flag attaches to the bare `lcm <section>`, but only when bin/lcm.ts gives that section no
-// subcommands of its own — a group command's (`daemon`, `connectors`) flattened help list is
-// for the reader, not a declaration, and Commander itself accepts none of it on the bare
-// group command.
+// CLI extraction (bin/lcm.ts, plus every src/cli/*.ts): a small bracket-depth scanner reads
+// the exact statement that follows each recognised chain root — `new Command("name")`,
+// `<ident>.command("name")`, or a bare `<ident>.option(...)` / `.addOption(...)` /
+// `.requiredOption(...)` not part of a `.command()` chain — so options are attributed to the
+// command path they were actually declared on, not to every `lcm` invocation on the line. An
+// identifier that receives `.command(...)` but was never declared with `new Command(...)` in
+// that file (e.g. a `register<Group>Commands(program)` function whose `program` is a
+// parameter, not a local `new Command()`) is treated as the root — empty path — so commands
+// registered from a file split out of bin/lcm.ts still attach to the right path. Each command
+// source file is parsed independently and the per-file surfaces (command paths, their
+// options, global flags) are merged by path before `src/cli-help.ts` is read.
+// `src/cli-help.ts` is hand-written help for hand-parsed subcommands (e.g. `sensitive purge
+// --yes`, which Commander never sees as its own command): an option line there whose text
+// starts with a bare word before its `[--flags]` attaches those flags to `lcm <section>
+// <word>`; a line starting directly with a flag attaches to the bare `lcm <section>`, but
+// only when the merged command surface gives that section no subcommands of its own — a
+// group command's (`daemon`, `connectors`) flattened help list is for the reader, not a
+// declaration, and Commander itself accepts none of it on the bare group command.
 //
 // Usage: node scripts/check-doc-claims.mjs [root]
 
@@ -49,7 +55,6 @@ import { join } from "node:path";
 
 const root = process.argv[2] ?? process.cwd();
 
-const CLI_SOURCES = ["bin/lcm.ts", "src/cli-help.ts"];
 const PRODUCTION_DIRS = ["src", "bin", "hooks", "installer"];
 const CODE_DIRS = [...PRODUCTION_DIRS, "scripts", "test", ".github/workflows"];
 const EXCLUDED_DOCS = /^(CHANGELOG\.md|\.changeset\/|docs\/design\/|plans\/)/;
@@ -315,10 +320,52 @@ function parseCliHelp(text, binPathSet) {
   return { pathOptions, pathSet };
 }
 
+// bin/lcm.ts, plus every src/cli/<name>.ts (sorted, only ones that exist) — the files a
+// future PR moves command registrations into. `src/cli-help.ts` is deliberately excluded:
+// it is the hand-written help source, never a command declaration.
+function commandSourceFiles(rootDir) {
+  const files = ["bin/lcm.ts"];
+  let cliDirEntries;
+  try {
+    cliDirEntries = readdirSync(join(rootDir, "src/cli"), { withFileTypes: true });
+  } catch {
+    cliDirEntries = [];
+  }
+  const cliFiles = cliDirEntries
+    .filter((e) => e.isFile() && e.name.endsWith(".ts"))
+    .map((e) => `src/cli/${e.name}`)
+    .sort();
+  files.push(...cliFiles);
+  return files.filter((rel) => existsSync(join(rootDir, rel)));
+}
+
+// Adds `flags` to `pathOptions[path]`, creating that path's option set on first use.
+function addFlagsToPath(pathOptions, path, flags) {
+  if (!pathOptions.has(path)) pathOptions.set(path, new Set());
+  for (const f of flags) pathOptions.get(path).add(f);
+}
+
+// Merges per-file command surfaces (each from `parseBinLcm`) into one: command paths union,
+// each path's options union, global flags union. A path declared in more than one file (not
+// expected today, but not assumed impossible) simply gets the combined option set.
+function mergeCommandSurfaces(surfaces) {
+  const pathOptions = new Map();
+  const pathSet = new Set();
+  const globalFlags = new Set();
+  for (const s of surfaces) {
+    for (const p of s.pathSet) pathSet.add(p);
+    for (const [path, flags] of s.pathOptions) addFlagsToPath(pathOptions, path, flags);
+    for (const f of s.globalFlags) globalFlags.add(f);
+  }
+  return { pathOptions, pathSet, globalFlags };
+}
+
 function cliSurface(rootDir) {
-  const binText = readFileSync(join(rootDir, "bin/lcm.ts"), "utf8");
+  const sourceFiles = commandSourceFiles(rootDir);
+  const perFile = sourceFiles.map((rel) => parseBinLcm(readFileSync(join(rootDir, rel), "utf8")));
+  const bin = mergeCommandSurfaces(perFile);
+
   const helpText = readFileSync(join(rootDir, "src/cli-help.ts"), "utf8");
-  const bin = parseBinLcm(binText);
   const help = parseCliHelp(helpText, bin.pathSet);
 
   const pathSet = new Set([...bin.pathSet, ...help.pathSet]);

--- a/test/check-doc-claims.test.ts
+++ b/test/check-doc-claims.test.ts
@@ -77,7 +77,28 @@ const MCP_TOOL = `
 export const tool = { name: "lcm_test_tool" };
 `;
 
-function makeFixture() {
+// A command source split out of bin/lcm.ts the way a later PR will do it: the function takes
+// `program` as a parameter — never a local `const program = new Command()` — so this exercises
+// the root-parameter case directly. `standalone` is declared straight on that parameter (root
+// path); `foo`/`bar` mirrors a group command with its own child, nested exactly one file away
+// from bin/lcm.ts's own `program`.
+const CLI_FOO_TS = `
+import { Command } from "commander";
+
+export function registerFooCommands(program) {
+  program
+    .command("standalone")
+    .option("--root-flag", "Declared on the root path");
+
+  const fooCmd = new Command("foo");
+  fooCmd
+    .command("bar")
+    .option("--flag", "Only valid on foo bar");
+  program.addCommand(fooCmd);
+}
+`;
+
+function makeFixture(opts: { cliFiles?: Record<string, string> } = {}) {
   const root = mkdtempSync(join(tmpdir(), "lcm-check-doc-claims-"));
   tempDirs.push(root);
   execFileSync("git", ["init", "-q"], { cwd: root });
@@ -93,6 +114,13 @@ function makeFixture() {
   // Read only under test/: exercises the INTERNAL_ENV case (LCM_SKIP_CACHE_SYNC is listed
   // there as test/script/CI-only), never under a production dir.
   writeFileSync(join(root, "test", "fixture.test.ts"), `const skip = process.env.LCM_SKIP_CACHE_SYNC;\n`);
+
+  if (opts.cliFiles) {
+    mkdirSync(join(root, "src", "cli"), { recursive: true });
+    for (const [name, content] of Object.entries(opts.cliFiles)) {
+      writeFileSync(join(root, "src", "cli", name), content);
+    }
+  }
 
   return root;
 }
@@ -186,5 +214,35 @@ describe("checkDocClaims — per-path CLI options", () => {
 
     const { warnings } = checkDocClaims(root);
     expect(warnings.some((w) => w.includes("LCM_SKIP_CACHE_SYNC"))).toBe(false);
+  });
+});
+
+describe("checkDocClaims — command sources under src/cli/", () => {
+  it("accepts a flag declared in src/cli/foo.ts on the command path it was declared on", () => {
+    const root = makeFixture({ cliFiles: { "foo.ts": CLI_FOO_TS } });
+    writeDoc(root, "README.md", "`lcm foo bar --flag`\n");
+
+    const { errors } = checkDocClaims(root);
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects that same flag claimed on a different command path", () => {
+    const root = makeFixture({ cliFiles: { "foo.ts": CLI_FOO_TS } });
+    // `compact` is a real path (declared in bin/lcm.ts) that does not declare --flag.
+    writeDoc(root, "README.md", "`lcm compact --flag`\n");
+
+    const { errors } = checkDocClaims(root);
+    expect(errors.some((e) => e.includes("--flag") && e.includes("lcm compact"))).toBe(true);
+  });
+
+  it("attributes a src/cli file's root-parameter command to the root path", () => {
+    const root = makeFixture({ cliFiles: { "foo.ts": CLI_FOO_TS } });
+    // `standalone` is declared directly on the `program` parameter passed into
+    // registerFooCommands — never a local `new Command()` in that file — so it must resolve
+    // to the root path (`lcm standalone`), not go unrecognised.
+    writeDoc(root, "README.md", "`lcm standalone --root-flag`\n");
+
+    const { errors } = checkDocClaims(root);
+    expect(errors).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Prepares `scripts/check-doc-claims.mjs` for a later series of PRs that move command registrations out of `bin/lcm.ts` into `src/cli/<group>.ts` files (each exporting `register<Group>Commands(program, deps?)`). Before this change the checker's CLI extraction only ever read `bin/lcm.ts` and `src/cli-help.ts` — commands defined in a split-out `src/cli/*.ts` file would silently vanish from doc checking.

- `cliSurface()` now reads `bin/lcm.ts` plus every `src/cli/*.ts` file (via `commandSourceFiles()`: glob, sorted, existing files only), running `parseBinLcm` on each and merging the per-file command surfaces (`mergeCommandSurfaces()`: union of option sets per command path, union of global flags) before `parseCliHelp` runs against the merged path set. `src/cli-help.ts` stays the hand-written help source only — it is not treated as a command source.
- `parseBinLcm` needed no change: an identifier that receives `.command(...)` but was never declared in that file with `new Command(...)` already resolves to the root (empty) path — the `.command` branch falls back to `[]` when the identifier isn't in `varPath`, and `program` is pre-seeded into `varPath` at the top of the function. So a file like `src/cli/foo.ts` whose exported function takes `program` as a parameter attributes commands declared on it correctly today; a new test (see below) proves this rather than changing behavior.
- All existing hand-parsed `sensitive` coverage, per-path flag attribution, `INTERNAL_ENV`, and warning behavior are unchanged.

**Check-docs output is unchanged on the current tree**: ran `node scripts/check-doc-claims.mjs` against a throwaway `git worktree` at the PR's base commit and against this branch — the two outputs are byte-identical (same 37 documents / 39 command paths / 98 options / 45 env tokens / 7 MCP tools / 48 warnings, no errors).

## New tests (`test/check-doc-claims.test.ts`)

Added a `src/cli/foo.ts`-style fixture (`registerFooCommands(program)`, no local `new Command()` for the root) and three tests:
- a flag declared only in `src/cli/foo.ts` on path `foo bar` is accepted by a doc naming `lcm foo bar --flag`;
- that same flag is rejected when a doc claims it on a different real path (`lcm compact --flag`);
- a command declared directly on the root `program` parameter (`lcm standalone`) is attributed to the root path.

No changeset (repository tooling only, not published behaviour). No doc edits.

## Test plan
- [x] `LCM_SKIP_CACHE_SYNC=1 npm run build`
- [x] `npm run check-docs`
- [x] `npm run check-agents`
- [x] `npm run typecheck`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a