### PR TITLE
refactor(cli): memory and bench commands move to src/cli/

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -2,11 +2,13 @@
 import { realpathSync } from "node:fs";
 import { argv, exit, stdin, stdout } from "node:process";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command, Option } from "commander";
 import { DaemonClient } from "../src/daemon/client.js";
 import { lcmHome, lcmPath } from "../src/lcm-home.js";
+import { registerMemoryCommands } from "../src/cli/memory.js";
+import { registerBenchCommands } from "../src/cli/bench.js";
 
 function readStdin(): Promise<string> {
   return new Promise((resolve) => {
@@ -54,165 +56,6 @@ export function shouldRunMain(invokedPath: string | undefined, currentFilePath: 
 
 
 
-export function registerMemoryCommands(program: Command): void {
-  program
-    .command("search <query>")
-    .description("Search memory across episodic and promoted layers")
-    .option("--limit <n>", "Max results per layer", "5")
-    .option("--layer <name>", "Layer to search: episodic or promoted (repeatable)", collectRepeatedOption, [])
-    .option("--tag <tag>", "Require a tag on matching entries (repeatable)", collectRepeatedOption, [])
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (query: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("search"); exit(0);
-      }
-
-      const layers = normalizeStringList(opts.layer);
-      const tags = normalizeStringList(opts.tag) ?? [];
-      ensureAllowedValues(layers, ["episodic", "promoted"], "--layer");
-
-      const client = await createDaemonClientOrExit();
-      const result = await client.post("/search", {
-        cwd: process.cwd(),
-        query,
-        limit: parsePositiveInteger(String(opts.limit ?? "5"), "--limit"),
-        layers,
-        tags,
-      });
-      printJson(result);
-    });
-
-  program
-    .command("grep <query>")
-    .description("Search raw messages and summaries by keyword or regex")
-    .option("--mode <mode>", "Search mode: full_text or regex", "full_text")
-    .option("--scope <scope>", "Scope: messages, summaries, or both", "both")
-    .option("--since <iso>", "Only include matches on or after this ISO timestamp")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (query: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("grep"); exit(0);
-      }
-
-      const mode = ensureAllowedValue(opts.mode, ["full_text", "regex"], "--mode");
-      const scope = ensureAllowedValue(opts.scope, ["messages", "summaries", "both"], "--scope");
-
-      const client = await createDaemonClientOrExit();
-      const result = await client.post("/grep", {
-        cwd: process.cwd(),
-        query,
-        mode,
-        scope,
-        since: typeof opts.since === "string" && opts.since.length > 0 ? opts.since : undefined,
-      });
-      printJson(result);
-    });
-
-  program
-    .command("describe <nodeId>")
-    .description("Inspect metadata for a summary or stored memory node")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (nodeId: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("describe"); exit(0);
-      }
-
-      const client = await createDaemonClientOrExit();
-      const result = await client.post("/describe", { cwd: process.cwd(), nodeId });
-      printJson(result);
-    });
-
-  program
-    .command("expand <nodeId>")
-    .description("Expand a summary node back into source detail")
-    .option("--depth <n>", "Traversal depth", "1")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (nodeId: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("expand"); exit(0);
-      }
-
-      const client = await createDaemonClientOrExit();
-      const result = await client.post("/expand", {
-        cwd: process.cwd(),
-        nodeId,
-        depth: parsePositiveInteger(String(opts.depth ?? "1"), "--depth"),
-      });
-      printJson(result);
-    });
-
-  program
-    .command("store <text>")
-    .description("Store a durable memory entry for the current project")
-    .option("--tag <tag>", "Attach a tag to the stored memory (repeatable)", collectRepeatedOption, [])
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (text: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("store"); exit(0);
-      }
-
-      const client = await createDaemonClientOrExit();
-      const result = await client.post("/store", {
-        cwd: process.cwd(),
-        text,
-        tags: normalizeStringList(opts.tag) ?? [],
-        metadata: {},
-      });
-      printJson(result);
-    });
-}
-
-function collectRepeatedOption(value: string, previous: string[] = []): string[] {
-  return [...previous, value];
-}
-
-function normalizeStringList(value: unknown): string[] | undefined {
-  if (!Array.isArray(value)) return undefined;
-  const normalized = value.filter((item): item is string => typeof item === "string" && item.length > 0);
-  return normalized.length > 0 ? normalized : undefined;
-}
-
-function parsePositiveInteger(value: string, optionName: string): number {
-  const parsed = Number(value);
-  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
-    console.error(`Invalid ${optionName}: ${value}`);
-    exit(1);
-  }
-  return parsed;
-}
-
-function ensureAllowedValues(values: string[] | undefined, allowed: readonly string[], optionName: string): void {
-  if (!values) return;
-  const invalid = values.filter((value) => !allowed.includes(value));
-  if (invalid.length > 0) {
-    console.error(`Invalid ${optionName}: ${invalid.join(", ")}`);
-    exit(1);
-  }
-}
-
-function ensureAllowedValue(value: unknown, allowed: readonly string[], optionName: string): string | undefined {
-  if (value === undefined) return undefined;
-  if (typeof value !== "string" || !allowed.includes(value)) {
-    console.error(`Invalid ${optionName}: ${String(value)}`);
-    exit(1);
-  }
-  return value;
-}
-
-function printJson(value: unknown): void {
-  stdout.write(JSON.stringify(value, null, 2) + "\n");
-}
-
 let cliDaemonActivity: (() => void) | undefined;
 
 async function admitCliDatabaseWork(): Promise<void> {
@@ -257,61 +100,6 @@ async function createDaemonClientOrExit(spawnTimeoutMs = 5000): Promise<DaemonCl
   }
 
   return new DaemonClient(`http://127.0.0.1:${port}`, tokenPath);
-}
-
-export function registerBenchCommands(program: Command): void {
-  // ─── bench ─────────────────────────────────────────────────────────────────
-  const benchCmd = new Command("bench").description(
-    "Build and run a natural-language retrieval benchmark from this project's ingested sessions",
-  );
-  benchCmd.action(() => { benchCmd.outputHelp(); });
-
-  benchCmd
-    .command("build")
-    .description("Sample ingested sessions and write a local benchmark file")
-    .option("--project <path>", "Project directory (default: cwd)")
-    .option("--n <count>", "Number of questions to generate", "20")
-    .option("--out <file>", "Benchmark file path (default: project memory directory)")
-    .option("--generator <mode>", "Question generator: llm or mechanical", "mechanical")
-    .option("--seed <n>", "Deterministic sampling seed", "42")
-    .option("--language <tag>", "Language to write LLM questions in (BCP 47, e.g. pt-BR); default: detected from the corpus")
-    .action(async (opts) => {
-      const cwd = typeof opts.project === "string" ? resolve(opts.project) : process.cwd();
-      const n = parsePositiveInteger(String(opts.n ?? "20"), "--n");
-      const seed = parsePositiveInteger(String(opts.seed ?? "42"), "--seed");
-      if (!["llm", "mechanical"].includes(opts.generator)) throw new Error("--generator must be llm or mechanical");
-      await admitCliDatabaseWork();
-      const { buildBench } = await import("../src/bench.js");
-      const result = await buildBench({ cwd, n, seed, out: opts.out, generator: opts.generator, language: opts.language });
-      stdout.write(result.stdout);
-      exit(result.exitCode);
-    });
-
-  benchCmd
-    .command("run")
-    .description("Run the benchmark against search and a grep baseline")
-    .option("--project <path>", "Project directory (default: cwd)")
-    .option("--k <n>", "Hit-rate cutoff (default: 5)", "5")
-    .option("--bench-file <file>", "Benchmark file path (default: project memory directory)")
-    .option("--json", "Output structured JSON")
-    .option("--union", "Score against every checkout of this repository, not this project alone")
-    .action(async (opts) => {
-      const cwd = typeof opts.project === "string" ? resolve(opts.project) : process.cwd();
-      const k = parsePositiveInteger(String(opts.k ?? "5"), "--k");
-      await admitCliDatabaseWork();
-      const { runBench } = await import("../src/bench.js");
-      const result = await runBench({
-        cwd,
-        k,
-        benchFile: opts.benchFile,
-        json: opts.json ?? false,
-        union: opts.union ?? false,
-      });
-      stdout.write(result.stdout);
-      exit(result.exitCode);
-    });
-
-  program.addCommand(benchCmd);
 }
 
 async function main() {
@@ -928,7 +716,7 @@ async function main() {
       exit(failures.length > 0 ? 1 : 0);
     });
 
-  registerMemoryCommands(program);
+  registerMemoryCommands(program, { createDaemonClientOrExit });
 
   // ─── diagnose ──────────────────────────────────────────────────────────────
   program
@@ -1246,7 +1034,7 @@ async function main() {
       }
     });
 
-  registerBenchCommands(program);
+  registerBenchCommands(program, { admitCliDatabaseWork });
 
   // ─── promote ───────────────────────────────────────────────────────────────
   program

--- a/src/cli/bench.ts
+++ b/src/cli/bench.ts
@@ -1,0 +1,65 @@
+import { exit, stdout } from "node:process";
+import { resolve } from "node:path";
+import { Command } from "commander";
+import { parsePositiveInteger } from "./support.js";
+
+export interface BenchCommandDeps {
+  admitCliDatabaseWork: () => Promise<void>;
+}
+
+export function registerBenchCommands(program: Command, deps: BenchCommandDeps): void {
+  const { admitCliDatabaseWork } = deps;
+
+  // ─── bench ─────────────────────────────────────────────────────────────────
+  const benchCmd = new Command("bench").description(
+    "Build and run a natural-language retrieval benchmark from this project's ingested sessions",
+  );
+  benchCmd.action(() => { benchCmd.outputHelp(); });
+
+  benchCmd
+    .command("build")
+    .description("Sample ingested sessions and write a local benchmark file")
+    .option("--project <path>", "Project directory (default: cwd)")
+    .option("--n <count>", "Number of questions to generate", "20")
+    .option("--out <file>", "Benchmark file path (default: project memory directory)")
+    .option("--generator <mode>", "Question generator: llm or mechanical", "mechanical")
+    .option("--seed <n>", "Deterministic sampling seed", "42")
+    .option("--language <tag>", "Language to write LLM questions in (BCP 47, e.g. pt-BR); default: detected from the corpus")
+    .action(async (opts) => {
+      const cwd = typeof opts.project === "string" ? resolve(opts.project) : process.cwd();
+      const n = parsePositiveInteger(String(opts.n ?? "20"), "--n");
+      const seed = parsePositiveInteger(String(opts.seed ?? "42"), "--seed");
+      if (!["llm", "mechanical"].includes(opts.generator)) throw new Error("--generator must be llm or mechanical");
+      await admitCliDatabaseWork();
+      const { buildBench } = await import("../bench.js");
+      const result = await buildBench({ cwd, n, seed, out: opts.out, generator: opts.generator, language: opts.language });
+      stdout.write(result.stdout);
+      exit(result.exitCode);
+    });
+
+  benchCmd
+    .command("run")
+    .description("Run the benchmark against search and a grep baseline")
+    .option("--project <path>", "Project directory (default: cwd)")
+    .option("--k <n>", "Hit-rate cutoff (default: 5)", "5")
+    .option("--bench-file <file>", "Benchmark file path (default: project memory directory)")
+    .option("--json", "Output structured JSON")
+    .option("--union", "Score against every checkout of this repository, not this project alone")
+    .action(async (opts) => {
+      const cwd = typeof opts.project === "string" ? resolve(opts.project) : process.cwd();
+      const k = parsePositiveInteger(String(opts.k ?? "5"), "--k");
+      await admitCliDatabaseWork();
+      const { runBench } = await import("../bench.js");
+      const result = await runBench({
+        cwd,
+        k,
+        benchFile: opts.benchFile,
+        json: opts.json ?? false,
+        union: opts.union ?? false,
+      });
+      stdout.write(result.stdout);
+      exit(result.exitCode);
+    });
+
+  program.addCommand(benchCmd);
+}

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,0 +1,160 @@
+import { exit, stdout } from "node:process";
+import type { Command } from "commander";
+import type { DaemonClient } from "../daemon/client.js";
+import { parsePositiveInteger } from "./support.js";
+
+export interface MemoryCommandDeps {
+  createDaemonClientOrExit: (spawnTimeoutMs?: number) => Promise<DaemonClient>;
+}
+
+export function registerMemoryCommands(program: Command, deps: MemoryCommandDeps): void {
+  const { createDaemonClientOrExit } = deps;
+
+  program
+    .command("search <query>")
+    .description("Search memory across episodic and promoted layers")
+    .option("--limit <n>", "Max results per layer", "5")
+    .option("--layer <name>", "Layer to search: episodic or promoted (repeatable)", collectRepeatedOption, [])
+    .option("--tag <tag>", "Require a tag on matching entries (repeatable)", collectRepeatedOption, [])
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (query: string, opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("search"); exit(0);
+      }
+
+      const layers = normalizeStringList(opts.layer);
+      const tags = normalizeStringList(opts.tag) ?? [];
+      ensureAllowedValues(layers, ["episodic", "promoted"], "--layer");
+
+      const client = await createDaemonClientOrExit();
+      const result = await client.post("/search", {
+        cwd: process.cwd(),
+        query,
+        limit: parsePositiveInteger(String(opts.limit ?? "5"), "--limit"),
+        layers,
+        tags,
+      });
+      printJson(result);
+    });
+
+  program
+    .command("grep <query>")
+    .description("Search raw messages and summaries by keyword or regex")
+    .option("--mode <mode>", "Search mode: full_text or regex", "full_text")
+    .option("--scope <scope>", "Scope: messages, summaries, or both", "both")
+    .option("--since <iso>", "Only include matches on or after this ISO timestamp")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (query: string, opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("grep"); exit(0);
+      }
+
+      const mode = ensureAllowedValue(opts.mode, ["full_text", "regex"], "--mode");
+      const scope = ensureAllowedValue(opts.scope, ["messages", "summaries", "both"], "--scope");
+
+      const client = await createDaemonClientOrExit();
+      const result = await client.post("/grep", {
+        cwd: process.cwd(),
+        query,
+        mode,
+        scope,
+        since: typeof opts.since === "string" && opts.since.length > 0 ? opts.since : undefined,
+      });
+      printJson(result);
+    });
+
+  program
+    .command("describe <nodeId>")
+    .description("Inspect metadata for a summary or stored memory node")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (nodeId: string, opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("describe"); exit(0);
+      }
+
+      const client = await createDaemonClientOrExit();
+      const result = await client.post("/describe", { cwd: process.cwd(), nodeId });
+      printJson(result);
+    });
+
+  program
+    .command("expand <nodeId>")
+    .description("Expand a summary node back into source detail")
+    .option("--depth <n>", "Traversal depth", "1")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (nodeId: string, opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("expand"); exit(0);
+      }
+
+      const client = await createDaemonClientOrExit();
+      const result = await client.post("/expand", {
+        cwd: process.cwd(),
+        nodeId,
+        depth: parsePositiveInteger(String(opts.depth ?? "1"), "--depth"),
+      });
+      printJson(result);
+    });
+
+  program
+    .command("store <text>")
+    .description("Store a durable memory entry for the current project")
+    .option("--tag <tag>", "Attach a tag to the stored memory (repeatable)", collectRepeatedOption, [])
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (text: string, opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("store"); exit(0);
+      }
+
+      const client = await createDaemonClientOrExit();
+      const result = await client.post("/store", {
+        cwd: process.cwd(),
+        text,
+        tags: normalizeStringList(opts.tag) ?? [],
+        metadata: {},
+      });
+      printJson(result);
+    });
+}
+
+function collectRepeatedOption(value: string, previous: string[] = []): string[] {
+  return [...previous, value];
+}
+
+function normalizeStringList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) return undefined;
+  const normalized = value.filter((item): item is string => typeof item === "string" && item.length > 0);
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function ensureAllowedValues(values: string[] | undefined, allowed: readonly string[], optionName: string): void {
+  if (!values) return;
+  const invalid = values.filter((value) => !allowed.includes(value));
+  if (invalid.length > 0) {
+    console.error(`Invalid ${optionName}: ${invalid.join(", ")}`);
+    exit(1);
+  }
+}
+
+function ensureAllowedValue(value: unknown, allowed: readonly string[], optionName: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string" || !allowed.includes(value)) {
+    console.error(`Invalid ${optionName}: ${String(value)}`);
+    exit(1);
+  }
+  return value;
+}
+
+function printJson(value: unknown): void {
+  stdout.write(JSON.stringify(value, null, 2) + "\n");
+}

--- a/src/cli/support.ts
+++ b/src/cli/support.ts
@@ -1,0 +1,10 @@
+import { exit } from "node:process";
+
+export function parsePositiveInteger(value: string, optionName: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
+    console.error(`Invalid ${optionName}: ${value}`);
+    exit(1);
+  }
+  return parsed;
+}

--- a/test/bin/bench-command-routing.test.ts
+++ b/test/bin/bench-command-routing.test.ts
@@ -1,13 +1,15 @@
 import { Command } from "commander";
 import { describe, expect, it } from "vitest";
-import { registerBenchCommands } from "../../bin/lcm.js";
+import { registerBenchCommands } from "../../src/cli/bench.js";
+
+const benchDeps = { admitCliDatabaseWork: async () => {} };
 
 describe("benchmark help", () => {
   it.each(["build", "run"])("%s --help stops before its action executes", async (subcommand) => {
     const program = new Command("lcm");
     let output = "";
     program.exitOverride().configureOutput({ writeOut: (text) => { output += text; } });
-    registerBenchCommands(program);
+    registerBenchCommands(program, benchDeps);
     for (const child of program.commands[0].commands) {
       child.exitOverride().configureOutput({ writeOut: (text) => { output += text; } });
     }

--- a/test/bin/memory-command-routing.test.ts
+++ b/test/bin/memory-command-routing.test.ts
@@ -3,12 +3,15 @@ import { Command } from "commander";
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { registerMemoryCommands, shouldRunMain } from "../../bin/lcm.js";
+import { shouldRunMain } from "../../bin/lcm.js";
+import { registerMemoryCommands } from "../../src/cli/memory.js";
+
+const memoryDeps = { createDaemonClientOrExit: async () => { throw new Error("not used in this test"); } };
 
 describe("memory command registration", () => {
   it("registers all daemon-backed memory commands", () => {
     const program = new Command("lcm");
-    registerMemoryCommands(program);
+    registerMemoryCommands(program, memoryDeps);
 
     const commandNames = program.commands.map((command) => command.name());
 
@@ -21,7 +24,7 @@ describe("memory command registration", () => {
 
   it("search keeps the repeatable layer and tag options", () => {
     const program = new Command("lcm");
-    registerMemoryCommands(program);
+    registerMemoryCommands(program, memoryDeps);
 
     const searchCommand = program.commands.find((command) => command.name() === "search");
     expect(searchCommand).toBeDefined();


### PR DESCRIPTION
## Summary

First move of a series pulling command groups out of `bin/lcm.ts`. Pure move — no behavior, option, string, or exit-code changes.

- `registerMemoryCommands` (search, grep, describe, expand, store) → `src/cli/memory.ts`
- `registerBenchCommands` (`bench` root with `build`/`run`) → `src/cli/bench.ts`

### Helper placement

- `parsePositiveInteger` → new `src/cli/support.ts`. It is the one helper used by *both* moved groups (search/expand in memory.ts, build/run in bench.ts) but by neither the rest of `bin/lcm.ts` nor only one group, so it lives in the shared support module the two new files import from. `bin/lcm.ts` does not import from `support.ts`.
- `collectRepeatedOption`, `normalizeStringList`, `ensureAllowedValues`, `ensureAllowedValue`, `printJson` → moved into `src/cli/memory.ts` (used only by that group).
- `helpRequested`, `withCustomHelp`, `readStdin`, `admitCliDatabaseWork`, `createDaemonClientOrExit` stay untouched in `bin/lcm.ts` per the task rules — `helpRequested`/`withCustomHelp`/`readStdin` because neither moved group calls them, `admitCliDatabaseWork`/`createDaemonClientOrExit` by explicit exception (daemon admission and the `cliDaemonActivity` singleton stay in the entrypoint). No re-export was needed: `test/bin/subcommand-help-routing.test.ts` still imports `helpRequested` from `../../bin/lcm.js` unchanged.

### Injected deps

- `registerMemoryCommands(program, { createDaemonClientOrExit })`
- `registerBenchCommands(program, { admitCliDatabaseWork })`

Both modules receive the original bin/lcm.ts functions through `deps` and never import from `bin/lcm.ts`.

### Non-moved edits (every line outside the moved blocks)

- `bin/lcm.ts:5` — `import { join, resolve } from "node:path"` → `import { join } from "node:path"` (bench.ts was the only user of the top-level `resolve`; the local `resolve` inside `readStdin`'s Promise executor is an unrelated shadowed parameter and is untouched)
- `bin/lcm.ts:10-11` — added `import { registerMemoryCommands } from "../src/cli/memory.js"` and `import { registerBenchCommands } from "../src/cli/bench.js"`
- `bin/lcm.ts:719` — call site: `registerMemoryCommands(program)` → `registerMemoryCommands(program, { createDaemonClientOrExit })`
- `bin/lcm.ts:1037` — call site: `registerBenchCommands(program)` → `registerBenchCommands(program, { admitCliDatabaseWork })`
- `src/cli/memory.ts` / `src/cli/bench.ts` — new files; only the import lines, the `*CommandDeps` interfaces, the exported function signatures, the `const { … } = deps` destructures, and the rewritten `await import(...)` specifiers (`../src/cli-help.js` → `../cli-help.js`, `../src/bench.js` → `../bench.js`) are new text — every command body, option, string and exit code is copied verbatim.
- `src/cli/support.ts` — new file holding only `parsePositiveInteger`, copied verbatim, plus its `node:process` import.
- `test/bin/memory-command-routing.test.ts` — split the import (`shouldRunMain` stays from `../../bin/lcm.js`; `registerMemoryCommands` now from `../../src/cli/memory.js`) and added a minimal `memoryDeps` stub passed to both direct calls.
- `test/bin/bench-command-routing.test.ts` — import now from `../../src/cli/bench.js`, added a minimal `benchDeps` stub passed to the one direct call.

No doc edits: `docs/codex-parity.md:17` names `bin/lcm.ts` for replay/provider-selection discovery, unrelated to this move and untouched.

## Verification

- `LCM_SKIP_CACHE_SYNC=1 npm run build` — exit 0
- `npm run check-docs` — exit 0, summary unchanged: `37 documents against 39 command paths, 98 options, 45 env tokens, 7 MCP tools; 48 warning(s)` (identical before/after)
- `npm run check-agents` — exit 0
- `npm run typecheck` — exit 0
- `npm test` — exit 0, 180 files / 1908 tests passed (2 files / 6 tests skipped, same as baseline), including `test/bin/golden.test.ts`, `test/bin/offline-hold.test.ts`, `test/bin/compact-hold.test.ts` with no skips
- Full `git diff --color-moved=dimmed-zebra` against `105f3e5` reviewed: every non-dimmed line matches the non-moved edits listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
