### PR TITLE
refactor(cli): connectors commands move to src/cli/connectors.ts

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -1,7 +1,6 @@
 #!/usr/bin/env node
 import { realpathSync } from "node:fs";
 import { argv, exit, stdin, stdout } from "node:process";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command, Option } from "commander";
@@ -9,6 +8,8 @@ import { DaemonClient } from "../src/daemon/client.js";
 import { lcmHome, lcmPath } from "../src/lcm-home.js";
 import { registerMemoryCommands } from "../src/cli/memory.js";
 import { registerBenchCommands } from "../src/cli/bench.js";
+import { registerConnectorsCommands } from "../src/cli/connectors.js";
+import { helpRequested } from "../src/cli/support.js";
 
 function readStdin(): Promise<string> {
   return new Promise((resolve) => {
@@ -25,18 +26,7 @@ function readStdin(): Promise<string> {
   });
 }
 
-/**
- * True when `--help` was asked for on this command or on the parent it hangs from.
- *
- * Commander routes a flag declared on both a parent and its subcommand to the
- * parent's options, so a subcommand that only reads its own would never see it:
- * `lcm daemon stop --help` ran the action and stopped the daemon. Both command
- * trees that carry a hand-rolled help option — `daemon` and `connectors` —
- * declare it on the parent as well, so both need the parent consulted.
- */
-export function helpRequested(parent: Command, opts: { help?: boolean }): boolean {
-  return Boolean(opts.help || (parent.opts() as { help?: boolean }).help);
-}
+export { helpRequested } from "../src/cli/support.js";
 
 async function withCustomHelp(cmd: Command, commandName: string): Promise<void> {
   const { printHelp } = await import("../src/cli-help.js");
@@ -753,163 +743,7 @@ async function main() {
       }
     });
 
-  // ─── connectors ────────────────────────────────────────────────────────────
-  const connectorsCmd = new Command("connectors").description("Manage connectors for coding agents");
-  connectorsCmd.helpOption(false).option("-h, --help", "Show help");
-  connectorsCmd.action(async (opts) => {
-    if (helpRequested(connectorsCmd, opts)) {
-      const { printHelp } = await import("../src/cli-help.js");
-      printHelp("connectors"); exit(0);
-    }
-    console.error("Usage: lcm connectors <list|install|remove|doctor> [options]");
-    exit(1);
-  });
-
-  connectorsCmd
-    .command("list")
-    .description("List available agents and installed connectors")
-    .option("--format <format>", "Output format: text or json", "text")
-    .option("--global", "Inspect the global agent config in your home directory")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (helpRequested(connectorsCmd, opts)) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("connectors"); exit(0);
-      }
-      const format: string = opts.format ?? "text";
-      const { listConnectors } = await import("../src/connectors/installer.js");
-      const { AGENTS } = await import("../src/connectors/registry.js");
-      const installed = listConnectors(opts.global ? homedir() : process.cwd());
-
-      if (format === "json") {
-        const result = AGENTS.map((a: any) => ({
-          id: a.id,
-          name: a.name,
-          category: a.category,
-          defaultType: a.defaultType,
-          supportedTypes: a.supportedTypes,
-          installed: installed.filter((c: any) => c.agentId === a.id).map((c: any) => c.type),
-        }));
-        stdout.write(JSON.stringify({ agents: result }, null, 2) + "\n");
-      } else {
-        console.log("\n  Available agents:\n");
-        console.log("  %-20s %-15s %-15s %s", "Agent", "Installed", "Default", "Supported");
-        console.log("  " + "─".repeat(70));
-        for (const agent of AGENTS) {
-          const agentInstalled = installed.filter((c: any) => c.agentId === (agent as any).id);
-          const installedStr = (agentInstalled as any[]).length > 0
-            ? (agentInstalled as any[]).map((c: any) => c.type).join(", ")
-            : "-";
-          console.log("  %-20s %-15s %-15s %s",
-            (agent as any).name, installedStr, (agent as any).defaultType, (agent as any).supportedTypes.join(", "));
-        }
-        console.log();
-      }
-    });
-
-  connectorsCmd
-    .command("install [agent]")
-    .description("Install a connector for an agent")
-    .option("--type <type>", "Connector type: rules, mcp, skill, or hooks")
-    .option("--global", "Install into the global agent config in your home directory")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (agentName: string | undefined, opts) => {
-      if (helpRequested(connectorsCmd, opts)) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("connectors"); exit(0);
-      }
-      if (!agentName) { console.error("Usage: lcm connectors install <agent> [--type rules|mcp|skill|hooks] [--global]"); exit(1); }
-      const type: any = opts.type;
-      const { installConnector } = await import("../src/connectors/installer.js");
-      try {
-        const result = installConnector(agentName, type, opts.global ? homedir() : process.cwd());
-        if ((result as any).manual) {
-          console.log(`\n  ${(result as any).manual}\n`);
-        } else {
-          console.log(`\n  ✓ Installed ${type ?? "default"} connector for ${agentName}`);
-          console.log(`    Path: ${(result as any).path}`);
-          if ((result as any).requiresRestart) console.log("    Restart the agent to activate.");
-          if (result.notice) console.log(`    ${result.notice}`);
-          console.log();
-        }
-      } catch (err: any) {
-        console.error(`  Error: ${err.message}`);
-        exit(1);
-      }
-    });
-
-  connectorsCmd
-    .command("remove [agent]")
-    .description("Remove a connector for an agent")
-    .option("--type <type>", "Connector type: rules, mcp, skill, or hooks")
-    .option("--global", "Remove from the global agent config in your home directory")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (agentName: string | undefined, opts) => {
-      if (helpRequested(connectorsCmd, opts)) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("connectors"); exit(0);
-      }
-      if (!agentName) { console.error("Usage: lcm connectors remove <agent> [--type rules|mcp|skill|hooks] [--global]"); exit(1); }
-      const type: any = opts.type;
-      const { removeConnector } = await import("../src/connectors/installer.js");
-      try {
-        const removed = removeConnector(agentName, type, opts.global ? homedir() : process.cwd());
-        if (removed) {
-          console.log(`\n  ✓ Removed connector for ${agentName}\n`);
-        } else {
-          console.log(`\n  No connector found for ${agentName}\n`);
-        }
-      } catch (err: any) {
-        console.error(`  Error: ${err.message}`);
-        exit(1);
-      }
-    });
-
-  connectorsCmd
-    .command("doctor [agent]")
-    .description("Check connector health")
-    .option("--global", "Inspect the global agent config in your home directory")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (agentName: string | undefined, opts) => {
-      if (helpRequested(connectorsCmd, opts)) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("connectors"); exit(0);
-      }
-      const { AGENTS } = await import("../src/connectors/registry.js");
-      const { listConnectors, diagnoseConnector } = await import("../src/connectors/installer.js");
-      const { findAgent } = await import("../src/connectors/registry.js");
-      const found = agentName ? findAgent(agentName) : undefined;
-      const agents = found ? [found] : agentName ? [] : AGENTS;
-
-      if (agents.length === 0) { console.error(`  Unknown agent: ${agentName}`); exit(1); }
-
-      const installed = listConnectors(opts.global ? homedir() : process.cwd());
-      console.log("\n  Connector health:\n");
-      for (const agent of agents) {
-        if (agent.id === "codex") {
-          const diagnosis = diagnoseConnector("codex", undefined, opts.global ? homedir() : process.cwd());
-          console.log(`  ${diagnosis.status === "installed" ? "○" : "⚠"} Codex: ${diagnosis.message}`);
-          console.log(`    Path: ${diagnosis.path}`);
-          for (const issue of diagnosis.issues) console.log(`    ${issue}`);
-        }
-        const agentConnectors = installed.filter((c: any) => c.agentId === (agent as any).id);
-        if ((agentConnectors as any[]).length === 0) {
-          console.log(`  ⚠ ${(agent as any).name}: no connectors installed`);
-        } else {
-          for (const c of agentConnectors as any[]) {
-            if (agent.id === "codex" && c.type === "hooks") continue;
-            console.log(`  ✓ ${(agent as any).name}: ${c.type} at ${c.path}`);
-          }
-        }
-      }
-      console.log();
-    });
-
-  program.addCommand(connectorsCmd);
+  registerConnectorsCommands(program);
 
   // ─── sensitive ─────────────────────────────────────────────────────────────
   program

--- a/src/cli/connectors.ts
+++ b/src/cli/connectors.ts
@@ -1,0 +1,164 @@
+import { exit, stdout } from "node:process";
+import { homedir } from "node:os";
+import { Command } from "commander";
+import { helpRequested } from "./support.js";
+
+export function registerConnectorsCommands(program: Command): void {
+  // ─── connectors ────────────────────────────────────────────────────────────
+  const connectorsCmd = new Command("connectors").description("Manage connectors for coding agents");
+  connectorsCmd.helpOption(false).option("-h, --help", "Show help");
+  connectorsCmd.action(async (opts) => {
+    if (helpRequested(connectorsCmd, opts)) {
+      const { printHelp } = await import("../cli-help.js");
+      printHelp("connectors"); exit(0);
+    }
+    console.error("Usage: lcm connectors <list|install|remove|doctor> [options]");
+    exit(1);
+  });
+
+  connectorsCmd
+    .command("list")
+    .description("List available agents and installed connectors")
+    .option("--format <format>", "Output format: text or json", "text")
+    .option("--global", "Inspect the global agent config in your home directory")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (helpRequested(connectorsCmd, opts)) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("connectors"); exit(0);
+      }
+      const format: string = opts.format ?? "text";
+      const { listConnectors } = await import("../connectors/installer.js");
+      const { AGENTS } = await import("../connectors/registry.js");
+      const installed = listConnectors(opts.global ? homedir() : process.cwd());
+
+      if (format === "json") {
+        const result = AGENTS.map((a: any) => ({
+          id: a.id,
+          name: a.name,
+          category: a.category,
+          defaultType: a.defaultType,
+          supportedTypes: a.supportedTypes,
+          installed: installed.filter((c: any) => c.agentId === a.id).map((c: any) => c.type),
+        }));
+        stdout.write(JSON.stringify({ agents: result }, null, 2) + "\n");
+      } else {
+        console.log("\n  Available agents:\n");
+        console.log("  %-20s %-15s %-15s %s", "Agent", "Installed", "Default", "Supported");
+        console.log("  " + "─".repeat(70));
+        for (const agent of AGENTS) {
+          const agentInstalled = installed.filter((c: any) => c.agentId === (agent as any).id);
+          const installedStr = (agentInstalled as any[]).length > 0
+            ? (agentInstalled as any[]).map((c: any) => c.type).join(", ")
+            : "-";
+          console.log("  %-20s %-15s %-15s %s",
+            (agent as any).name, installedStr, (agent as any).defaultType, (agent as any).supportedTypes.join(", "));
+        }
+        console.log();
+      }
+    });
+
+  connectorsCmd
+    .command("install [agent]")
+    .description("Install a connector for an agent")
+    .option("--type <type>", "Connector type: rules, mcp, skill, or hooks")
+    .option("--global", "Install into the global agent config in your home directory")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (agentName: string | undefined, opts) => {
+      if (helpRequested(connectorsCmd, opts)) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("connectors"); exit(0);
+      }
+      if (!agentName) { console.error("Usage: lcm connectors install <agent> [--type rules|mcp|skill|hooks] [--global]"); exit(1); }
+      const type: any = opts.type;
+      const { installConnector } = await import("../connectors/installer.js");
+      try {
+        const result = installConnector(agentName, type, opts.global ? homedir() : process.cwd());
+        if ((result as any).manual) {
+          console.log(`\n  ${(result as any).manual}\n`);
+        } else {
+          console.log(`\n  ✓ Installed ${type ?? "default"} connector for ${agentName}`);
+          console.log(`    Path: ${(result as any).path}`);
+          if ((result as any).requiresRestart) console.log("    Restart the agent to activate.");
+          if (result.notice) console.log(`    ${result.notice}`);
+          console.log();
+        }
+      } catch (err: any) {
+        console.error(`  Error: ${err.message}`);
+        exit(1);
+      }
+    });
+
+  connectorsCmd
+    .command("remove [agent]")
+    .description("Remove a connector for an agent")
+    .option("--type <type>", "Connector type: rules, mcp, skill, or hooks")
+    .option("--global", "Remove from the global agent config in your home directory")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (agentName: string | undefined, opts) => {
+      if (helpRequested(connectorsCmd, opts)) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("connectors"); exit(0);
+      }
+      if (!agentName) { console.error("Usage: lcm connectors remove <agent> [--type rules|mcp|skill|hooks] [--global]"); exit(1); }
+      const type: any = opts.type;
+      const { removeConnector } = await import("../connectors/installer.js");
+      try {
+        const removed = removeConnector(agentName, type, opts.global ? homedir() : process.cwd());
+        if (removed) {
+          console.log(`\n  ✓ Removed connector for ${agentName}\n`);
+        } else {
+          console.log(`\n  No connector found for ${agentName}\n`);
+        }
+      } catch (err: any) {
+        console.error(`  Error: ${err.message}`);
+        exit(1);
+      }
+    });
+
+  connectorsCmd
+    .command("doctor [agent]")
+    .description("Check connector health")
+    .option("--global", "Inspect the global agent config in your home directory")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (agentName: string | undefined, opts) => {
+      if (helpRequested(connectorsCmd, opts)) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("connectors"); exit(0);
+      }
+      const { AGENTS } = await import("../connectors/registry.js");
+      const { listConnectors, diagnoseConnector } = await import("../connectors/installer.js");
+      const { findAgent } = await import("../connectors/registry.js");
+      const found = agentName ? findAgent(agentName) : undefined;
+      const agents = found ? [found] : agentName ? [] : AGENTS;
+
+      if (agents.length === 0) { console.error(`  Unknown agent: ${agentName}`); exit(1); }
+
+      const installed = listConnectors(opts.global ? homedir() : process.cwd());
+      console.log("\n  Connector health:\n");
+      for (const agent of agents) {
+        if (agent.id === "codex") {
+          const diagnosis = diagnoseConnector("codex", undefined, opts.global ? homedir() : process.cwd());
+          console.log(`  ${diagnosis.status === "installed" ? "○" : "⚠"} Codex: ${diagnosis.message}`);
+          console.log(`    Path: ${diagnosis.path}`);
+          for (const issue of diagnosis.issues) console.log(`    ${issue}`);
+        }
+        const agentConnectors = installed.filter((c: any) => c.agentId === (agent as any).id);
+        if ((agentConnectors as any[]).length === 0) {
+          console.log(`  ⚠ ${(agent as any).name}: no connectors installed`);
+        } else {
+          for (const c of agentConnectors as any[]) {
+            if (agent.id === "codex" && c.type === "hooks") continue;
+            console.log(`  ✓ ${(agent as any).name}: ${c.type} at ${c.path}`);
+          }
+        }
+      }
+      console.log();
+    });
+
+  program.addCommand(connectorsCmd);
+}

--- a/src/cli/support.ts
+++ b/src/cli/support.ts
@@ -1,4 +1,18 @@
 import { exit } from "node:process";
+import type { Command } from "commander";
+
+/**
+ * True when `--help` was asked for on this command or on the parent it hangs from.
+ *
+ * Commander routes a flag declared on both a parent and its subcommand to the
+ * parent's options, so a subcommand that only reads its own would never see it:
+ * `lcm daemon stop --help` ran the action and stopped the daemon. Both command
+ * trees that carry a hand-rolled help option — `daemon` and `connectors` —
+ * declare it on the parent as well, so both need the parent consulted.
+ */
+export function helpRequested(parent: Command, opts: { help?: boolean }): boolean {
+  return Boolean(opts.help || (parent.opts() as { help?: boolean }).help);
+}
 
 export function parsePositiveInteger(value: string, optionName: string): number {
   const parsed = Number(value);


### PR DESCRIPTION
## Summary

Pure move of the `connectors` command group out of `main()` in `bin/lcm.ts` into `src/cli/connectors.ts`, following the shape established for `memory` and `bench` in the previous PR.

Moved commands (unchanged behavior, options, and registration order):
- `connectors` (parent, with its own `--help`/usage fallback)
- `connectors list`
- `connectors install [agent]`
- `connectors remove [agent]`
- `connectors doctor [agent]`

`registerConnectorsCommands(program)` is called at the exact point `program.addCommand(connectorsCmd)` previously occupied in `main()`, so command registration order is unchanged.

**Helpers:**
- `helpRequested` is used by the moved `connectors` block AND by the remaining `daemon` block in `bin/lcm.ts`, so it moved verbatim (with its doc comment) into `src/cli/support.ts`. `bin/lcm.ts` now does `import { helpRequested } from "../src/cli/support.js";` for its own use and `export { helpRequested } from "../src/cli/support.js";` so the existing `test/bin/subcommand-help-routing.test.ts` import from `bin/lcm.js` keeps working.
- No other helpers (`printJson`, `ensureAllowedValue`, `withCustomHelp`) are used by the connectors block.

**Injected deps:** none — the connectors block calls no admission function (`admitCliDatabaseWork` / `createDaemonClientOrExit`), so `registerConnectorsCommands` takes only `program: Command`.

**Non-moved edits (all in `bin/lcm.ts` and `src/cli/support.ts`):**
- `bin/lcm.ts:4` — removed now-unused `import { homedir } from "node:os"` (every `homedir()` call moved with the connectors block)
- `bin/lcm.ts:10-11` — added `import { registerConnectorsCommands } from "../src/cli/connectors.js";` and `import { helpRequested } from "../src/cli/support.js";`
- `bin/lcm.ts` — replaced the `helpRequested` function body with `export { helpRequested } from "../src/cli/support.js";`, moving its doc comment to `src/cli/support.ts`
- `bin/lcm.ts` — call site: `registerConnectorsCommands(program);` replaces `program.addCommand(connectorsCmd);` at the same position
- `src/cli/support.ts` — added `import type { Command } from "commander";` and the moved `helpRequested` function with its doc comment

Relative import specifiers inside the moved block were rewritten only as far as the new file location requires (e.g. `../src/cli-help.js` → `../cli-help.js`, `../src/connectors/installer.js` → `../connectors/installer.js`).

## Verification

All run from the worktree, logs saved alongside:
- `LCM_SKIP_CACHE_SYNC=1 npm run build` — exit 0
- `npm run check-docs` — exit 0, summary line identical to base: `check-doc-claims: OK (37 documents against 39 command paths, 98 options, 45 env tokens, 7 MCP tools; 48 warning(s))`
- `npm run check-agents` — exit 0
- `npm run typecheck` — exit 0
- `npm test` — exit 0 (180 passed / 2 skipped test files, 1908 passed / 6 skipped tests), including golden, offline-hold, and compact-hold suites, unmodified and unskipped
- `git diff --cached --color-moved` against base reviewed: every non-dimmed (non-moved) line is one of the edits listed above

## Test plan
- [x] Build, check-docs, check-agents, typecheck, and test all pass locally
- [x] Diff-against-base review confirms the moved block is byte-identical apart from required relative import rewrites

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a