### PR TITLE
refactor(cli): status, stats, doctor and diagnose move to src/cli/diagnostics.ts

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -9,6 +9,7 @@ import { lcmHome, lcmPath } from "../src/lcm-home.js";
 import { registerMemoryCommands } from "../src/cli/memory.js";
 import { registerBenchCommands } from "../src/cli/bench.js";
 import { registerConnectorsCommands } from "../src/cli/connectors.js";
+import { registerDiagnosticsCommands, registerDiagnoseCommand } from "../src/cli/diagnostics.js";
 import { helpRequested } from "../src/cli/support.js";
 
 function readStdin(): Promise<string> {
@@ -560,188 +561,11 @@ async function main() {
       }
     });
 
-  // ─── status ────────────────────────────────────────────────────────────────
-  program
-    .command("status")
-    .description("Show daemon status and project memory statistics")
-    .option("--json", "Output structured JSON")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("status"); exit(0);
-      }
-      const { loadDaemonConfig } = await import("../src/daemon/config.js");
-      const { join } = await import("node:path");
-      const { homedir } = await import("node:os");
-      const config = loadDaemonConfig(lcmPath("config.json"));
-      const jsonFlag: boolean = opts.json ?? false;
-      const client = await createDaemonClientOrExit();
-
-      let daemonStatus = "down";
-      let statusData: any = null;
-
-      try {
-        const health = await client.health();
-        if (health) daemonStatus = "up";
-
-        // Also fetch /status endpoint if daemon is up
-        if (daemonStatus === "up") {
-          statusData = await client.post("/status", { cwd: process.cwd() });
-        }
-      } catch {}
-
-      if (jsonFlag) {
-        const result = {
-          daemon: daemonStatus === "up" ? statusData?.daemon : { status: "down" },
-          project: statusData?.project,
-        };
-        stdout.write(JSON.stringify(result, null, 2) + "\n");
-      } else {
-        const provider = config.llm?.provider ?? "unknown";
-        const providerDisplay = provider === "auto"
-          ? "auto (Claude->claude-process, Codex->codex-process)"
-          : provider;
-
-        if (statusData) {
-          console.log(`Daemon: ${daemonStatus}`);
-          console.log(`  Version: ${statusData.daemon.version}`);
-          console.log(`  Uptime: ${statusData.daemon.uptime}s`);
-          console.log(`  Port: ${statusData.daemon.port}`);
-          console.log(`  Provider: ${providerDisplay}`);
-          console.log();
-          console.log("Project:");
-          console.log(`  Messages: ${statusData.project.messageCount}`);
-          console.log(`  Summaries: ${statusData.project.summaryCount}`);
-          console.log(`  Promoted: ${statusData.project.promotedCount}`);
-          if (statusData.project.lastIngest) console.log(`  Last Ingest: ${statusData.project.lastIngest}`);
-          if (statusData.project.lastCompact) console.log(`  Last Compact: ${statusData.project.lastCompact}`);
-          if (statusData.project.lastPromote) console.log(`  Last Promote: ${statusData.project.lastPromote}`);
-        } else {
-          console.log(`daemon: ${daemonStatus} · provider: ${providerDisplay}`);
-        }
-      }
-    });
-
-  // ─── stats ─────────────────────────────────────────────────────────────────
-  program
-    .command("stats")
-    .description("Show memory inventory and compression ratios")
-    .option("-v, --verbose", "Show per-conversation breakdown")
-    .option("--pool", "Show connection pool statistics from the daemon")
-    .option("--json", "Output structured JSON (use with --pool)")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("stats"); exit(0);
-      }
-
-      if (opts.pool) {
-        const jsonFlag: boolean = opts.json ?? false;
-        const client = await createDaemonClientOrExit();
-
-        let poolData: any = null;
-        try {
-          poolData = await client.get("/stats/pool");
-        } catch (err) {
-          console.error(`Error: ${err instanceof Error ? err.message : "could not load pool stats"}`);
-          exit(1);
-        }
-
-        if (jsonFlag) {
-          stdout.write(JSON.stringify(poolData, null, 2) + "\n");
-        } else {
-          const dim = "\x1b[2m";
-          const cyan = "\x1b[36m";
-          const bold = "\x1b[1m";
-          const reset = "\x1b[0m";
-          console.log();
-          console.log(`    ${bold}${cyan}🔌 Connection Pool${reset}`);
-          console.log();
-          const rows: [string, string][] = [
-            ["Total", String(poolData.totalConnections)],
-            ["Active", String(poolData.activeConnections)],
-            ["Idle", String(poolData.idleConnections)],
-          ];
-          const labelWidth = Math.max(...rows.map(([l]) => l.length));
-          for (const [label, value] of rows) {
-            console.log(`    ${dim}${label.padEnd(labelWidth)}${reset}  ${value}`);
-          }
-          if (poolData.connections && poolData.connections.length > 0) {
-            console.log();
-            console.log(`    ${dim}Connections:${reset}`);
-            for (const conn of poolData.connections) {
-              const status = conn.status === "active" ? `${cyan}active${reset}` : `${dim}idle${reset}`;
-              console.log(`    ${dim}refs=${conn.refs}${reset}  ${status}  ${conn.path}`);
-            }
-          }
-          console.log();
-        }
-        return;
-      }
-
-      const verbose: boolean = opts.verbose ?? false;
-      const { collectStats, printStats } = await import("../src/stats.js");
-      printStats(collectStats(), verbose);
-    });
-
-  // ─── doctor ────────────────────────────────────────────────────────────────
-  program
-    .command("doctor")
-    .description("Run diagnostics: daemon, hooks, MCP, summarizer")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("doctor"); exit(0);
-      }
-      const { runDoctor, printResults } = await import("../src/doctor/doctor.js");
-      const results = await runDoctor();
-      printResults(results);
-      const failures = results.filter((r: { status: string }) => r.status === "fail");
-      exit(failures.length > 0 ? 1 : 0);
-    });
+  registerDiagnosticsCommands(program, { createDaemonClientOrExit });
 
   registerMemoryCommands(program, { createDaemonClientOrExit });
 
-  // ─── diagnose ──────────────────────────────────────────────────────────────
-  program
-    .command("diagnose")
-    .description("Scan recent sessions for hook failures and issues")
-    .option("--all", "Scan all tracked projects")
-    .option("--days <n>", "Scan the last N days (default: 7)", "7")
-    .option("--verbose", "Include full event details")
-    .option("--json", "Output structured JSON")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("diagnose"); exit(0);
-      }
-      const all: boolean = opts.all ?? false;
-      const verbose: boolean = opts.verbose ?? false;
-      const json: boolean = opts.json ?? false;
-      const days = Number(opts.days);
-
-      if (!Number.isFinite(days) || days <= 0 || !Number.isInteger(days)) {
-        console.error("Usage: lcm diagnose [--all] [--days N] [--verbose] [--json]");
-        exit(1);
-      }
-
-      const { diagnose, formatDiagnoseResult } = await import("../src/diagnose.js");
-      const result = await diagnose({ all, days, verbose });
-
-      if (json) {
-        stdout.write(JSON.stringify(result, null, 2) + "\n");
-      } else {
-        stdout.write(formatDiagnoseResult(result, { days, verbose }));
-      }
-    });
+  registerDiagnoseCommand(program);
 
   registerConnectorsCommands(program);
 

--- a/src/cli/diagnostics.ts
+++ b/src/cli/diagnostics.ts
@@ -1,0 +1,195 @@
+import { exit, stdout } from "node:process";
+import type { Command } from "commander";
+import type { DaemonClient } from "../daemon/client.js";
+import { lcmPath } from "../lcm-home.js";
+
+export interface DiagnosticsCommandDeps {
+  createDaemonClientOrExit: (spawnTimeoutMs?: number) => Promise<DaemonClient>;
+}
+
+export function registerDiagnosticsCommands(program: Command, deps: DiagnosticsCommandDeps): void {
+  const { createDaemonClientOrExit } = deps;
+
+  // ─── status ────────────────────────────────────────────────────────────────
+  program
+    .command("status")
+    .description("Show daemon status and project memory statistics")
+    .option("--json", "Output structured JSON")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("status"); exit(0);
+      }
+      const { loadDaemonConfig } = await import("../daemon/config.js");
+      const { join } = await import("node:path");
+      const { homedir } = await import("node:os");
+      const config = loadDaemonConfig(lcmPath("config.json"));
+      const jsonFlag: boolean = opts.json ?? false;
+      const client = await createDaemonClientOrExit();
+
+      let daemonStatus = "down";
+      let statusData: any = null;
+
+      try {
+        const health = await client.health();
+        if (health) daemonStatus = "up";
+
+        // Also fetch /status endpoint if daemon is up
+        if (daemonStatus === "up") {
+          statusData = await client.post("/status", { cwd: process.cwd() });
+        }
+      } catch {}
+
+      if (jsonFlag) {
+        const result = {
+          daemon: daemonStatus === "up" ? statusData?.daemon : { status: "down" },
+          project: statusData?.project,
+        };
+        stdout.write(JSON.stringify(result, null, 2) + "\n");
+      } else {
+        const provider = config.llm?.provider ?? "unknown";
+        const providerDisplay = provider === "auto"
+          ? "auto (Claude->claude-process, Codex->codex-process)"
+          : provider;
+
+        if (statusData) {
+          console.log(`Daemon: ${daemonStatus}`);
+          console.log(`  Version: ${statusData.daemon.version}`);
+          console.log(`  Uptime: ${statusData.daemon.uptime}s`);
+          console.log(`  Port: ${statusData.daemon.port}`);
+          console.log(`  Provider: ${providerDisplay}`);
+          console.log();
+          console.log("Project:");
+          console.log(`  Messages: ${statusData.project.messageCount}`);
+          console.log(`  Summaries: ${statusData.project.summaryCount}`);
+          console.log(`  Promoted: ${statusData.project.promotedCount}`);
+          if (statusData.project.lastIngest) console.log(`  Last Ingest: ${statusData.project.lastIngest}`);
+          if (statusData.project.lastCompact) console.log(`  Last Compact: ${statusData.project.lastCompact}`);
+          if (statusData.project.lastPromote) console.log(`  Last Promote: ${statusData.project.lastPromote}`);
+        } else {
+          console.log(`daemon: ${daemonStatus} · provider: ${providerDisplay}`);
+        }
+      }
+    });
+
+  // ─── stats ─────────────────────────────────────────────────────────────────
+  program
+    .command("stats")
+    .description("Show memory inventory and compression ratios")
+    .option("-v, --verbose", "Show per-conversation breakdown")
+    .option("--pool", "Show connection pool statistics from the daemon")
+    .option("--json", "Output structured JSON (use with --pool)")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("stats"); exit(0);
+      }
+
+      if (opts.pool) {
+        const jsonFlag: boolean = opts.json ?? false;
+        const client = await createDaemonClientOrExit();
+
+        let poolData: any = null;
+        try {
+          poolData = await client.get("/stats/pool");
+        } catch (err) {
+          console.error(`Error: ${err instanceof Error ? err.message : "could not load pool stats"}`);
+          exit(1);
+        }
+
+        if (jsonFlag) {
+          stdout.write(JSON.stringify(poolData, null, 2) + "\n");
+        } else {
+          const dim = "\x1b[2m";
+          const cyan = "\x1b[36m";
+          const bold = "\x1b[1m";
+          const reset = "\x1b[0m";
+          console.log();
+          console.log(`    ${bold}${cyan}🔌 Connection Pool${reset}`);
+          console.log();
+          const rows: [string, string][] = [
+            ["Total", String(poolData.totalConnections)],
+            ["Active", String(poolData.activeConnections)],
+            ["Idle", String(poolData.idleConnections)],
+          ];
+          const labelWidth = Math.max(...rows.map(([l]) => l.length));
+          for (const [label, value] of rows) {
+            console.log(`    ${dim}${label.padEnd(labelWidth)}${reset}  ${value}`);
+          }
+          if (poolData.connections && poolData.connections.length > 0) {
+            console.log();
+            console.log(`    ${dim}Connections:${reset}`);
+            for (const conn of poolData.connections) {
+              const status = conn.status === "active" ? `${cyan}active${reset}` : `${dim}idle${reset}`;
+              console.log(`    ${dim}refs=${conn.refs}${reset}  ${status}  ${conn.path}`);
+            }
+          }
+          console.log();
+        }
+        return;
+      }
+
+      const verbose: boolean = opts.verbose ?? false;
+      const { collectStats, printStats } = await import("../stats.js");
+      printStats(collectStats(), verbose);
+    });
+
+  // ─── doctor ────────────────────────────────────────────────────────────────
+  program
+    .command("doctor")
+    .description("Run diagnostics: daemon, hooks, MCP, summarizer")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("doctor"); exit(0);
+      }
+      const { runDoctor, printResults } = await import("../doctor/doctor.js");
+      const results = await runDoctor();
+      printResults(results);
+      const failures = results.filter((r: { status: string }) => r.status === "fail");
+      exit(failures.length > 0 ? 1 : 0);
+    });
+}
+
+export function registerDiagnoseCommand(program: Command): void {
+  // ─── diagnose ──────────────────────────────────────────────────────────────
+  program
+    .command("diagnose")
+    .description("Scan recent sessions for hook failures and issues")
+    .option("--all", "Scan all tracked projects")
+    .option("--days <n>", "Scan the last N days (default: 7)", "7")
+    .option("--verbose", "Include full event details")
+    .option("--json", "Output structured JSON")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("diagnose"); exit(0);
+      }
+      const all: boolean = opts.all ?? false;
+      const verbose: boolean = opts.verbose ?? false;
+      const json: boolean = opts.json ?? false;
+      const days = Number(opts.days);
+
+      if (!Number.isFinite(days) || days <= 0 || !Number.isInteger(days)) {
+        console.error("Usage: lcm diagnose [--all] [--days N] [--verbose] [--json]");
+        exit(1);
+      }
+
+      const { diagnose, formatDiagnoseResult } = await import("../diagnose.js");
+      const result = await diagnose({ all, days, verbose });
+
+      if (json) {
+        stdout.write(JSON.stringify(result, null, 2) + "\n");
+      } else {
+        stdout.write(formatDiagnoseResult(result, { days, verbose }));
+      }
+    });
+}


### PR DESCRIPTION
## Summary

Pure move of the diagnostics command group out of `main()` in `bin/lcm.ts` into `src/cli/diagnostics.ts`, following the shape established by prior CLI-extraction PRs (#463, #464).

Moved commands: `status`, `stats`, `doctor`, `diagnose`.

## Two exported functions

- `registerDiagnosticsCommands(program, deps)` — registers `status`, `stats`, `doctor`. Called first, in the same position the `status` block previously occupied.
- `registerDiagnoseCommand(program)` — registers `diagnose`. Called after `registerMemoryCommands`, in the same position the `diagnose` block previously occupied (memory registration sits between `doctor` and `diagnose`, so it stays where it was between the two new calls).

Registration order in `main()` is unchanged: `registerDiagnosticsCommands` → `registerMemoryCommands` → `registerDiagnoseCommand` → `registerConnectorsCommands`.

## Helpers

- `createDaemonClientOrExit` (used by `status` and `stats`) stays in `bin/lcm.ts` and is passed through `DiagnosticsCommandDeps`, same pattern as `registerMemoryCommands`.
- `doctor` and `diagnose` use none of the admission/help helpers (`printJson`, `ensureAllowedValue(s)`, `withCustomHelp`, `readStdin`, `helpRequested`, `admitCliDatabaseWork`), so `registerDiagnoseCommand` takes no `deps` — matching the precedent set by `registerConnectorsCommands`, which also takes no deps since it doesn't need any bin-local admission function.
- `lcmPath` (from `src/lcm-home.js`) is used by both the moved `status` block and remaining code in `bin/lcm.ts`; it was already its own module import (not a bin-local helper), so both files import it directly — no move needed.

## Non-moved edits (all in bin/lcm.ts)

- Added import: `import { registerDiagnosticsCommands, registerDiagnoseCommand } from "../src/cli/diagnostics.js";`
- Three call sites in `main()` replacing the moved blocks:
  - `registerDiagnosticsCommands(program, { createDaemonClientOrExit });` (position of the former `status` block)
  - `registerDiagnoseCommand(program);` (position of the former `diagnose` block)
  - (unchanged) `registerMemoryCommands(program, { createDaemonClientOrExit });` and `registerConnectorsCommands(program);` stay exactly where they were

No other lines in `bin/lcm.ts` changed.

## Verification

- `LCM_SKIP_CACHE_SYNC=1 npm run build` — exit 0
- `npm run check-docs` — exit 0, summary unchanged: `37 documents against 39 command paths, 98 options, 45 env tokens, 7 MCP tools; 48 warning(s)`
- `npm run check-agents` — exit 0
- `npm run typecheck` — exit 0
- `npm test` — exit 0 (180 files / 1908 tests passed, 2 files / 6 tests skipped, matching baseline)
- Byte-compare: each moved block extracted from `git show <base>:bin/lcm.ts`, rewritten only for the `../src/` → `../` import-specifier change, diffs byte-identical against the corresponding function body in `src/cli/diagnostics.ts`.

No changeset (pure internal move, no published behavior change). No doc edits (no doc names the moved code by file path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
