### PR TITLE
refactor(cli): hook commands move to src/cli/hooks.ts

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { realpathSync } from "node:fs";
-import { argv, exit, stdin, stdout } from "node:process";
+import { argv, exit, stdout } from "node:process";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Command, Option } from "commander";
@@ -10,22 +10,8 @@ import { registerMemoryCommands } from "../src/cli/memory.js";
 import { registerBenchCommands } from "../src/cli/bench.js";
 import { registerConnectorsCommands } from "../src/cli/connectors.js";
 import { registerDiagnosticsCommands, registerDiagnoseCommand } from "../src/cli/diagnostics.js";
-import { helpRequested } from "../src/cli/support.js";
-
-function readStdin(): Promise<string> {
-  return new Promise((resolve) => {
-    if (stdin.isTTY) { resolve(""); return; }
-    const chunks: Buffer[] = [];
-    let resolved = false;
-    const timer = setTimeout(() => {
-      if (!resolved) { resolved = true; stdin.destroy(); resolve(Buffer.concat(chunks).toString("utf-8")); }
-    }, 5000);
-    stdin.on("data", (chunk: Buffer) => chunks.push(chunk));
-    stdin.on("end", () => {
-      if (!resolved) { resolved = true; clearTimeout(timer); resolve(Buffer.concat(chunks).toString("utf-8")); }
-    });
-  });
-}
+import { registerHookCommands } from "../src/cli/hooks.js";
+import { helpRequested, readStdin } from "../src/cli/support.js";
 
 export { helpRequested } from "../src/cli/support.js";
 
@@ -403,100 +389,7 @@ async function main() {
       exit(r.exitCode);
     });
 
-  program
-    .command("codex-hook")
-    .description("Dispatch a native Codex lifecycle hook")
-    .action(async () => {
-      const { dispatchCodexHook } = await import("../src/hooks/codex.js");
-      const result = await dispatchCodexHook(await readStdin());
-      if (result.stdout) stdout.write(result.stdout + "\n");
-      exit(result.exitCode);
-    });
-
-  // ─── restore (hook) ────────────────────────────────────────────────────────
-  program
-    .command("restore")
-    .description("Dispatch the restore hook")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("restore"); exit(0);
-      }
-      const { dispatchHook } = await import("../src/hooks/dispatch.js");
-      const input = await readStdin();
-      const r = await dispatchHook("restore", input);
-      if (r.stdout) stdout.write(r.stdout);
-      exit(r.exitCode);
-    });
-
-  // ─── session-end (hook) ────────────────────────────────────────────────────
-  program
-    .command("session-end")
-    .description("Dispatch the session-end hook")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("session-end"); exit(0);
-      }
-      const { dispatchHook } = await import("../src/hooks/dispatch.js");
-      const input = await readStdin();
-      const r = await dispatchHook("session-end", input);
-      if (r.stdout) stdout.write(r.stdout);
-      exit(r.exitCode);
-    });
-
-  // ─── user-prompt (hook) ────────────────────────────────────────────────────
-  program
-    .command("user-prompt")
-    .description("Dispatch the user-prompt hook")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("user-prompt"); exit(0);
-      }
-      const { dispatchHook } = await import("../src/hooks/dispatch.js");
-      const input = await readStdin();
-      const r = await dispatchHook("user-prompt", input);
-      if (r.stdout) stdout.write(r.stdout);
-      exit(r.exitCode);
-    });
-
-  // ─── post-tool (hook) ──────────────────────────────────────────────────────
-  program
-    .command("post-tool")
-    .description("Dispatch the post-tool hook (PostToolUse event)")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("post-tool"); exit(0);
-      }
-      const { dispatchHook } = await import("../src/hooks/dispatch.js");
-      const input = await readStdin();
-      const r = await dispatchHook("post-tool", input);
-      if (r.stdout) stdout.write(r.stdout);
-      exit(r.exitCode);
-    });
-
-  // ─── session-snapshot (hook) ─────────────────────────────────────────────
-  program
-    .command("session-snapshot")
-    .description("Rolling ingest snapshot (called by Stop hook)")
-    .helpOption(false)
-    .action(async () => {
-      const { dispatchHook } = await import("../src/hooks/dispatch.js");
-      const input = await readStdin();
-      const r = await dispatchHook("session-snapshot", input);
-      if (r.stdout) stdout.write(r.stdout);
-      exit(r.exitCode);
-    });
+  registerHookCommands(program);
 
   // ─── mcp ───────────────────────────────────────────────────────────────────
   program

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -1,0 +1,100 @@
+import { exit, stdout } from "node:process";
+import type { Command } from "commander";
+import { readStdin } from "./support.js";
+
+export function registerHookCommands(program: Command): void {
+  program
+    .command("codex-hook")
+    .description("Dispatch a native Codex lifecycle hook")
+    .action(async () => {
+      const { dispatchCodexHook } = await import("../hooks/codex.js");
+      const result = await dispatchCodexHook(await readStdin());
+      if (result.stdout) stdout.write(result.stdout + "\n");
+      exit(result.exitCode);
+    });
+
+  // ─── restore (hook) ────────────────────────────────────────────────────────
+  program
+    .command("restore")
+    .description("Dispatch the restore hook")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("restore"); exit(0);
+      }
+      const { dispatchHook } = await import("../hooks/dispatch.js");
+      const input = await readStdin();
+      const r = await dispatchHook("restore", input);
+      if (r.stdout) stdout.write(r.stdout);
+      exit(r.exitCode);
+    });
+
+  // ─── session-end (hook) ────────────────────────────────────────────────────
+  program
+    .command("session-end")
+    .description("Dispatch the session-end hook")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("session-end"); exit(0);
+      }
+      const { dispatchHook } = await import("../hooks/dispatch.js");
+      const input = await readStdin();
+      const r = await dispatchHook("session-end", input);
+      if (r.stdout) stdout.write(r.stdout);
+      exit(r.exitCode);
+    });
+
+  // ─── user-prompt (hook) ────────────────────────────────────────────────────
+  program
+    .command("user-prompt")
+    .description("Dispatch the user-prompt hook")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("user-prompt"); exit(0);
+      }
+      const { dispatchHook } = await import("../hooks/dispatch.js");
+      const input = await readStdin();
+      const r = await dispatchHook("user-prompt", input);
+      if (r.stdout) stdout.write(r.stdout);
+      exit(r.exitCode);
+    });
+
+  // ─── post-tool (hook) ──────────────────────────────────────────────────────
+  program
+    .command("post-tool")
+    .description("Dispatch the post-tool hook (PostToolUse event)")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("post-tool"); exit(0);
+      }
+      const { dispatchHook } = await import("../hooks/dispatch.js");
+      const input = await readStdin();
+      const r = await dispatchHook("post-tool", input);
+      if (r.stdout) stdout.write(r.stdout);
+      exit(r.exitCode);
+    });
+
+  // ─── session-snapshot (hook) ─────────────────────────────────────────────
+  program
+    .command("session-snapshot")
+    .description("Rolling ingest snapshot (called by Stop hook)")
+    .helpOption(false)
+    .action(async () => {
+      const { dispatchHook } = await import("../hooks/dispatch.js");
+      const input = await readStdin();
+      const r = await dispatchHook("session-snapshot", input);
+      if (r.stdout) stdout.write(r.stdout);
+      exit(r.exitCode);
+    });
+}

--- a/src/cli/support.ts
+++ b/src/cli/support.ts
@@ -1,4 +1,4 @@
-import { exit } from "node:process";
+import { exit, stdin } from "node:process";
 import type { Command } from "commander";
 
 /**
@@ -21,4 +21,19 @@ export function parsePositiveInteger(value: string, optionName: string): number 
     exit(1);
   }
   return parsed;
+}
+
+export function readStdin(): Promise<string> {
+  return new Promise((resolve) => {
+    if (stdin.isTTY) { resolve(""); return; }
+    const chunks: Buffer[] = [];
+    let resolved = false;
+    const timer = setTimeout(() => {
+      if (!resolved) { resolved = true; stdin.destroy(); resolve(Buffer.concat(chunks).toString("utf-8")); }
+    }, 5000);
+    stdin.on("data", (chunk: Buffer) => chunks.push(chunk));
+    stdin.on("end", () => {
+      if (!resolved) { resolved = true; clearTimeout(timer); resolve(Buffer.concat(chunks).toString("utf-8")); }
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Pure move, continuing the bin/lcm.ts decomposition started in #463, #464, #466.

Moved from `bin/lcm.ts` `main()` into `registerHookCommands(program)` in `src/cli/hooks.ts`, called at the exact position the block occupied (registration order unchanged, immediately before `mcp`):

- `codex-hook`
- `restore`
- `session-end`
- `user-prompt`
- `post-tool`
- `session-snapshot`

`registerHookCommands` takes only `program` — the block calls neither `admitCliDatabaseWork` nor `createDaemonClientOrExit`, so no `deps` parameter is needed.

## Helpers

- `readStdin` moves from a local function in `bin/lcm.ts` into `src/cli/support.ts` (exported), since it's used by both the moved hook commands and the `compact` block that stays in `bin/lcm.ts`.
- `dispatchHook` / `dispatchCodexHook` are dynamic imports from `src/hooks/*.js`, not local helpers — callers import them directly, unchanged.
- Admission functions (`admitCliDatabaseWork`, `createDaemonClientOrExit`) and the `cliDaemonActivity` singleton stay in `bin/lcm.ts`; the moved block never calls them.

## Non-moved edits

- `bin/lcm.ts:3` — drop unused `stdin` import (moved into support.ts with `readStdin`)
- `bin/lcm.ts:13-14` — add `registerHookCommands` import; add `readStdin` to the existing `support.js` import
- `bin/lcm.ts:392` (new) — call site `registerHookCommands(program);` replacing the moved block
- `src/cli/support.ts:1` — add `stdin` to the `node:process` import
- `src/cli/support.ts` — new `readStdin` export, body byte-identical to the original

## Verification

All from the worktree, against BASE_SHA 81d40ac:

- `LCM_SKIP_CACHE_SYNC=1 npm run build` — exit 0
- `npm run check-docs` — exit 0, summary unchanged: `37 documents against 39 command paths, 98 options, 45 env tokens, 7 MCP tools; 48 warning(s)`
- `npm run check-agents` — exit 0
- `npm run typecheck` — exit 0
- `npm test` — exit 0 (1908 passed, 6 skipped)
- `git diff --color-moved` against 81d40ac: every non-dimmed (non-moved) line is one of the allowed edits above
- Byte-compare: the extracted `bin/lcm.ts:406-499` block (with `../src/` → `../` rewrites) is identical to the `registerHookCommands` body in `src/cli/hooks.ts`; the extracted `readStdin` function is identical to the one now in `src/cli/support.ts`

No doc changes: `docs/hook-protocol.md` doesn't name `bin/lcm.ts`; the only doc mentioning `bin/lcm.ts` (`docs/codex-parity.md:17`) refers to unrelated replay-discovery behavior, not the moved commands.

No changeset: internal file reorganization, no published behavior change.

## Test plan

- [x] Build, check-docs, check-agents, typecheck, test all pass
- [x] Diff-review confirms only allowed edits outside the moved blocks
- [x] Byte-compare confirms moved code is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a