### PR TITLE
refactor(cli): help, setup, sensitive and the fallback move to src/cli/; main() only wires

### DIFF
--- a/bin/lcm.ts
+++ b/bin/lcm.ts
@@ -14,6 +14,9 @@ import { registerHookCommands } from "../src/cli/hooks.js";
 import { registerDaemonCommands } from "../src/cli/daemon.js";
 import { registerCompactCommand } from "../src/cli/compact.js";
 import { registerImportCommand, registerKnowledgeCommands } from "../src/cli/knowledge.js";
+import { registerHelpCommand, registerUnknownCommandFallback } from "../src/cli/root.js";
+import { registerSetupCommands } from "../src/cli/setup.js";
+import { registerSensitiveCommand } from "../src/cli/sensitive.js";
 
 export { helpRequested } from "../src/cli/support.js";
 
@@ -95,15 +98,7 @@ async function main() {
   // Disable Commander's built-in help entirely — we handle it manually below
   program.helpOption(false);
 
-  // ─── help command ──────────────────────────────────────────────────────────
-  program
-    .command("help [command]")
-    .description("Show help for a command")
-    .action(async (subcommand?: string) => {
-      const { printHelp } = await import("../src/cli-help.js");
-      printHelp(subcommand);
-      exit(0);
-    });
+  registerHelpCommand(program);
 
   registerDaemonCommands(program);
 
@@ -111,68 +106,7 @@ async function main() {
 
   registerHookCommands(program);
 
-  // ─── mcp ───────────────────────────────────────────────────────────────────
-  program
-    .command("mcp")
-    .description("Start the lcm MCP server")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("mcp"); exit(0);
-      }
-      const { startMcpServer } = await import("../src/mcp/server.js");
-      await startMcpServer();
-    });
-
-  // ─── install ───────────────────────────────────────────────────────────────
-  program
-    .command("install")
-    .description("Set up lcm: register hooks, configure daemon, connect MCP")
-    .option("--dry-run", "Preview all changes without writing anything")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("install"); exit(0);
-      }
-      const dryRun: boolean = opts.dryRun ?? false;
-      const { install } = await import("../installer/install.js");
-      if (dryRun) {
-        const { DryRunServiceDeps } = await import("../installer/dry-run-deps.js");
-        console.log("\n  lcm install --dry-run\n");
-        await install(new DryRunServiceDeps());
-        console.log("\n  No changes written.");
-      } else {
-        await install();
-      }
-    });
-
-  // ─── uninstall ─────────────────────────────────────────────────────────────
-  program
-    .command("uninstall")
-    .description("Remove lcm hooks and MCP registration")
-    .option("--dry-run", "Preview removals without writing anything")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("uninstall"); exit(0);
-      }
-      const dryRun: boolean = opts.dryRun ?? false;
-      const { uninstall } = await import("../installer/uninstall.js");
-      if (dryRun) {
-        const { DryRunServiceDeps } = await import("../installer/dry-run-deps.js");
-        console.log("\n  lcm uninstall --dry-run\n");
-        await uninstall(new DryRunServiceDeps());
-        console.log("\n  No changes written.");
-      } else {
-        await uninstall();
-      }
-    });
+  registerSetupCommands(program);
 
   registerDiagnosticsCommands(program, { createDaemonClientOrExit });
 
@@ -182,26 +116,7 @@ async function main() {
 
   registerConnectorsCommands(program);
 
-  // ─── sensitive ─────────────────────────────────────────────────────────────
-  program
-    .command("sensitive [args...]")
-    .description("Manage sensitive patterns for automatic redaction")
-    .helpOption(false)
-    .option("-h, --help", "Show help")
-    .allowUnknownOption(true)
-    .action(async (args: string[], opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../src/cli-help.js");
-        printHelp("sensitive"); exit(0);
-      }
-      const { handleSensitive } = await import("../src/sensitive.js");
-      const { join } = await import("node:path");
-      const { homedir } = await import("node:os");
-      const configPath = lcmPath("config.json");
-      const r = await handleSensitive(args, process.cwd(), configPath);
-      if (r.stdout) stdout.write(r.stdout);
-      exit(r.exitCode);
-    });
+  registerSensitiveCommand(program);
 
   registerImportCommand(program, { createDaemonClientOrExit });
 
@@ -209,13 +124,7 @@ async function main() {
 
   registerKnowledgeCommands(program, { admitCliDatabaseWork, createDaemonClientOrExit });
 
-  // ─── Unknown command fallback ──────────────────────────────────────────────
-  program.on("command:*", async (operands: string[]) => {
-    process.stderr.write(`lcm: unknown command '${operands[0]}'\n\n`);
-    const { printHelp } = await import("../src/cli-help.js");
-    printHelp();
-    exit(1);
-  });
+  registerUnknownCommandFallback(program);
 
   // Handle root-level help and no-args before Commander parses — this prevents
   // Commander from seeing --help at the root level and intercepting it before

--- a/src/cli/root.ts
+++ b/src/cli/root.ts
@@ -1,0 +1,24 @@
+import { exit } from "node:process";
+import type { Command } from "commander";
+
+export function registerHelpCommand(program: Command): void {
+  // ─── help command ──────────────────────────────────────────────────────────
+  program
+    .command("help [command]")
+    .description("Show help for a command")
+    .action(async (subcommand?: string) => {
+      const { printHelp } = await import("../cli-help.js");
+      printHelp(subcommand);
+      exit(0);
+    });
+}
+
+export function registerUnknownCommandFallback(program: Command): void {
+  // ─── Unknown command fallback ──────────────────────────────────────────────
+  program.on("command:*", async (operands: string[]) => {
+    process.stderr.write(`lcm: unknown command '${operands[0]}'\n\n`);
+    const { printHelp } = await import("../cli-help.js");
+    printHelp();
+    exit(1);
+  });
+}

--- a/src/cli/sensitive.ts
+++ b/src/cli/sensitive.ts
@@ -1,0 +1,26 @@
+import { exit, stdout } from "node:process";
+import type { Command } from "commander";
+import { lcmPath } from "../lcm-home.js";
+
+export function registerSensitiveCommand(program: Command): void {
+  // ─── sensitive ─────────────────────────────────────────────────────────────
+  program
+    .command("sensitive [args...]")
+    .description("Manage sensitive patterns for automatic redaction")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .allowUnknownOption(true)
+    .action(async (args: string[], opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("sensitive"); exit(0);
+      }
+      const { handleSensitive } = await import("../sensitive.js");
+      const { join } = await import("node:path");
+      const { homedir } = await import("node:os");
+      const configPath = lcmPath("config.json");
+      const r = await handleSensitive(args, process.cwd(), configPath);
+      if (r.stdout) stdout.write(r.stdout);
+      exit(r.exitCode);
+    });
+}

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,0 +1,67 @@
+import { exit } from "node:process";
+import type { Command } from "commander";
+
+export function registerSetupCommands(program: Command): void {
+  // ─── mcp ───────────────────────────────────────────────────────────────────
+  program
+    .command("mcp")
+    .description("Start the lcm MCP server")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("mcp"); exit(0);
+      }
+      const { startMcpServer } = await import("../mcp/server.js");
+      await startMcpServer();
+    });
+
+  // ─── install ───────────────────────────────────────────────────────────────
+  program
+    .command("install")
+    .description("Set up lcm: register hooks, configure daemon, connect MCP")
+    .option("--dry-run", "Preview all changes without writing anything")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("install"); exit(0);
+      }
+      const dryRun: boolean = opts.dryRun ?? false;
+      const { install } = await import("../../installer/install.js");
+      if (dryRun) {
+        const { DryRunServiceDeps } = await import("../../installer/dry-run-deps.js");
+        console.log("\n  lcm install --dry-run\n");
+        await install(new DryRunServiceDeps());
+        console.log("\n  No changes written.");
+      } else {
+        await install();
+      }
+    });
+
+  // ─── uninstall ─────────────────────────────────────────────────────────────
+  program
+    .command("uninstall")
+    .description("Remove lcm hooks and MCP registration")
+    .option("--dry-run", "Preview removals without writing anything")
+    .helpOption(false)
+    .option("-h, --help", "Show help")
+    .action(async (opts) => {
+      if (opts.help) {
+        const { printHelp } = await import("../cli-help.js");
+        printHelp("uninstall"); exit(0);
+      }
+      const dryRun: boolean = opts.dryRun ?? false;
+      const { uninstall } = await import("../../installer/uninstall.js");
+      if (dryRun) {
+        const { DryRunServiceDeps } = await import("../../installer/dry-run-deps.js");
+        console.log("\n  lcm uninstall --dry-run\n");
+        await uninstall(new DryRunServiceDeps());
+        console.log("\n  No changes written.");
+      } else {
+        await uninstall();
+      }
+    });
+}


### PR DESCRIPTION
## Summary

Last move of the CLI-extraction series. `main()` in `bin/lcm.ts` now contains only program setup, the register calls in original order, the root help/no-args short-circuit, and `parseAsync`.

Moved commands, verbatim, per file:

- `// ─── help command` block -> `src/cli/root.ts`, called as `registerHelpCommand(program)` (bin/lcm.ts:101, same position it occupied)
- `// ─── mcp`, `// ─── install`, `// ─── uninstall` (one contiguous block) -> `src/cli/setup.ts`, called as `registerSetupCommands(program)` (bin/lcm.ts:109)
- `// ─── sensitive` block -> `src/cli/sensitive.ts`, called as `registerSensitiveCommand(program)` (bin/lcm.ts:119); kept its unused dynamic imports of `node:path` and `node:os` exactly as they were
- `program.on("command:*", ...)` (`// ─── Unknown command fallback`) -> `src/cli/root.ts`, called as `registerUnknownCommandFallback(program)` (bin/lcm.ts:127), at the same position: after `registerKnowledgeCommands`, before the root short-circuit

New static import lines added at bin/lcm.ts:17-19:
```ts
import { registerHelpCommand, registerUnknownCommandFallback } from "../src/cli/root.js";
import { registerSetupCommands } from "../src/cli/setup.js";
import { registerSensitiveCommand } from "../src/cli/sensitive.js";
```

Dynamic import specifier rewrites (only as far as the new location requires):
- `../src/cli-help.js` -> `../cli-help.js` (all three new files)
- `../src/mcp/server.js` -> `../mcp/server.js` (src/cli/setup.ts)
- `../installer/install.js`, `../installer/dry-run-deps.js`, `../installer/uninstall.js` -> `../../installer/...` (src/cli/setup.ts)
- `../src/sensitive.js` -> `../sensitive.js` (src/cli/sensitive.ts)

No other lines changed: every function body, string literal, option declaration, option order, default value, exit code, and console channel is copied verbatim from `bin/lcm.ts` at the prior commit.

## Verification

All from the worktree, against a fresh build:
- `LCM_SKIP_CACHE_SYNC=1 npm run build` — exit 0
- `npm run check-docs` — exit 0, summary unchanged: 39 command paths, 98 options, 45 env tokens, 7 MCP tools, 48 warnings
- `npm run check-agents` — exit 0
- `npm run typecheck` — exit 0
- `npm test` — exit 0, 180 files / 1908 tests passed, 2 files / 6 tests skipped
- `git diff --color-moved` against the base commit reviewed: every non-moved line is an allowed edit (new static imports, function wrapper lines, call sites)
- Byte-compare: each moved block extracted from the base commit, specifier-normalized, diffs empty against the corresponding new function body

## Final main()

```ts
async function main() {
  // PKG_VERSION resolves the package root for both dist/ and source layouts;
  // a hand-rolled `../../package.json` here only worked from dist/.
  const { PKG_VERSION } = await import("../src/daemon/version.js");

  const program = new Command();
  program
    .name("lcm")
    .description("lossless context management for coding agents")
    .version(PKG_VERSION ?? "unknown", "-V, --version")
    .helpCommand(false)
    .addHelpCommand(false)
    .configureOutput({
      writeOut: (str) => stdout.write(str),
      writeErr: (str) => process.stderr.write(str),
    });

  // Disable Commander's built-in help entirely — we handle it manually below
  program.helpOption(false);

  registerHelpCommand(program);

  registerDaemonCommands(program);

  registerCompactCommand(program, { createDaemonClientOrExit });

  registerHookCommands(program);

  registerSetupCommands(program);

  registerDiagnosticsCommands(program, { createDaemonClientOrExit });

  registerMemoryCommands(program, { createDaemonClientOrExit });

  registerDiagnoseCommand(program);

  registerConnectorsCommands(program);

  registerSensitiveCommand(program);

  registerImportCommand(program, { createDaemonClientOrExit });

  registerBenchCommands(program, { admitCliDatabaseWork });

  registerKnowledgeCommands(program, { admitCliDatabaseWork, createDaemonClientOrExit });

  registerUnknownCommandFallback(program);

  // Handle root-level help and no-args before Commander parses — this prevents
  // Commander from seeing --help at the root level and intercepting it before
  // dispatching to subcommands (lcm import --help would otherwise show root help).
  if (argv.length <= 2 || (argv.length === 3 && (argv[2] === "-h" || argv[2] === "--help"))) {
    const { printHelp } = await import("../src/cli-help.js");
    printHelp();
    exit(0);
  }

  await program.parseAsync(argv);
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a
