### PR TITLE
refactor(cli): showHelpAndExit and fail replace the repeated help and error-exit blocks

### DIFF
--- a/src/cli/compact.ts
+++ b/src/cli/compact.ts
@@ -3,7 +3,7 @@ import { Option } from "commander";
 import type { Command } from "commander";
 import type { DaemonClient } from "../daemon/client.js";
 import { lcmPath } from "../lcm-home.js";
-import { readStdin } from "./support.js";
+import { readStdin, showHelpAndExit } from "./support.js";
 
 export interface CompactCommandDeps {
   createDaemonClientOrExit: (spawnTimeoutMs?: number) => Promise<DaemonClient>;
@@ -26,10 +26,7 @@ export function registerCompactCommand(program: Command, deps: CompactCommandDep
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("compact"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("compact");
       const all: boolean = opts.all ?? false;
       const dryRun: boolean = opts.dryRun ?? false;
       const verbose: boolean = opts.verbose ?? false;

--- a/src/cli/connectors.ts
+++ b/src/cli/connectors.ts
@@ -1,19 +1,15 @@
-import { exit, stdout } from "node:process";
+import { stdout } from "node:process";
 import { homedir } from "node:os";
 import { Command } from "commander";
-import { helpRequested } from "./support.js";
+import { fail, helpRequested, showHelpAndExit } from "./support.js";
 
 export function registerConnectorsCommands(program: Command): void {
   // ─── connectors ────────────────────────────────────────────────────────────
   const connectorsCmd = new Command("connectors").description("Manage connectors for coding agents");
   connectorsCmd.helpOption(false).option("-h, --help", "Show help");
   connectorsCmd.action(async (opts) => {
-    if (helpRequested(connectorsCmd, opts)) {
-      const { printHelp } = await import("../cli-help.js");
-      printHelp("connectors"); exit(0);
-    }
-    console.error("Usage: lcm connectors <list|install|remove|doctor> [options]");
-    exit(1);
+    if (helpRequested(connectorsCmd, opts)) await showHelpAndExit("connectors");
+    fail("Usage: lcm connectors <list|install|remove|doctor> [options]");
   });
 
   connectorsCmd
@@ -24,10 +20,7 @@ export function registerConnectorsCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (helpRequested(connectorsCmd, opts)) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("connectors"); exit(0);
-      }
+      if (helpRequested(connectorsCmd, opts)) await showHelpAndExit("connectors");
       const format: string = opts.format ?? "text";
       const { listConnectors } = await import("../connectors/installer.js");
       const { AGENTS } = await import("../connectors/registry.js");
@@ -67,11 +60,8 @@ export function registerConnectorsCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (agentName: string | undefined, opts) => {
-      if (helpRequested(connectorsCmd, opts)) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("connectors"); exit(0);
-      }
-      if (!agentName) { console.error("Usage: lcm connectors install <agent> [--type rules|mcp|skill|hooks] [--global]"); exit(1); }
+      if (helpRequested(connectorsCmd, opts)) await showHelpAndExit("connectors");
+      if (!agentName) fail("Usage: lcm connectors install <agent> [--type rules|mcp|skill|hooks] [--global]");
       const type: any = opts.type;
       const { installConnector } = await import("../connectors/installer.js");
       try {
@@ -86,8 +76,7 @@ export function registerConnectorsCommands(program: Command): void {
           console.log();
         }
       } catch (err: any) {
-        console.error(`  Error: ${err.message}`);
-        exit(1);
+        fail(`  Error: ${err.message}`);
       }
     });
 
@@ -99,11 +88,8 @@ export function registerConnectorsCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (agentName: string | undefined, opts) => {
-      if (helpRequested(connectorsCmd, opts)) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("connectors"); exit(0);
-      }
-      if (!agentName) { console.error("Usage: lcm connectors remove <agent> [--type rules|mcp|skill|hooks] [--global]"); exit(1); }
+      if (helpRequested(connectorsCmd, opts)) await showHelpAndExit("connectors");
+      if (!agentName) fail("Usage: lcm connectors remove <agent> [--type rules|mcp|skill|hooks] [--global]");
       const type: any = opts.type;
       const { removeConnector } = await import("../connectors/installer.js");
       try {
@@ -114,8 +100,7 @@ export function registerConnectorsCommands(program: Command): void {
           console.log(`\n  No connector found for ${agentName}\n`);
         }
       } catch (err: any) {
-        console.error(`  Error: ${err.message}`);
-        exit(1);
+        fail(`  Error: ${err.message}`);
       }
     });
 
@@ -126,17 +111,14 @@ export function registerConnectorsCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (agentName: string | undefined, opts) => {
-      if (helpRequested(connectorsCmd, opts)) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("connectors"); exit(0);
-      }
+      if (helpRequested(connectorsCmd, opts)) await showHelpAndExit("connectors");
       const { AGENTS } = await import("../connectors/registry.js");
       const { listConnectors, diagnoseConnector } = await import("../connectors/installer.js");
       const { findAgent } = await import("../connectors/registry.js");
       const found = agentName ? findAgent(agentName) : undefined;
       const agents = found ? [found] : agentName ? [] : AGENTS;
 
-      if (agents.length === 0) { console.error(`  Unknown agent: ${agentName}`); exit(1); }
+      if (agents.length === 0) fail(`  Unknown agent: ${agentName}`);
 
       const installed = listConnectors(opts.global ? homedir() : process.cwd());
       console.log("\n  Connector health:\n");

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -2,7 +2,7 @@ import { exit } from "node:process";
 import { join } from "node:path";
 import { Command, Option } from "commander";
 import { lcmHome } from "../lcm-home.js";
-import { helpRequested, withCustomHelp } from "./support.js";
+import { fail, helpRequested, showHelpAndExit } from "./support.js";
 
 export function registerDaemonCommands(program: Command): void {
   // ─── daemon ────────────────────────────────────────────────────────────────
@@ -22,7 +22,7 @@ export function registerDaemonCommands(program: Command): void {
     .addOption(new Option("--automatic").hideHelp())
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (helpRequested(daemonCmd, opts)) { await withCustomHelp(daemonCmd, "daemon"); return; }
+      if (helpRequested(daemonCmd, opts)) await showHelpAndExit("daemon");
       const { ensureDaemon, checkDaemonHealth, isStaleDaemon, registerDaemonActivity } = await import("../daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../daemon/config.js");
       const { PKG_VERSION, BUILD_ID } = await import("../daemon/version.js");
@@ -62,8 +62,7 @@ export function registerDaemonCommands(program: Command): void {
         const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs: 10000 });
         if (!connected) {
           if (opts.automatic && readHold(pidFilePath)) { process.exitCode = 75; return; }
-          console.error(`lcm daemon did not answer on port ${port} within 10s — check ~/.lossless-claude/daemon.log`);
-          exit(1);
+          fail(`lcm daemon did not answer on port ${port} within 10s — check ~/.lossless-claude/daemon.log`);
         }
         const h = await checkDaemonHealth(port);
         console.log(`lcm daemon started in background on port ${port} (pid ${h?.pid ?? "?"})`);
@@ -109,15 +108,14 @@ export function registerDaemonCommands(program: Command): void {
     .option("--reason <text>", "Why the daemon is held down")
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (helpRequested(daemonCmd, opts)) { await withCustomHelp(daemonCmd, "daemon"); return; }
+      if (helpRequested(daemonCmd, opts)) await showHelpAndExit("daemon");
       const { stopDaemon, checkDaemonHealth } = await import("../daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../daemon/config.js");
       const { writeHold, DEFAULT_HOLD_MINUTES } = await import("../daemon/hold.js");
       const { pidFilePath, configPath } = daemonPaths();
       const port = loadDaemonConfig(configPath).daemon?.port ?? 3737;
       if (opts.minutes !== undefined && (!Number.isInteger(opts.minutes) || opts.minutes <= 0)) {
-        console.error("--minutes must be a positive integer");
-        exit(1);
+        fail("--minutes must be a positive integer");
       }
       const before = await checkDaemonHealth(port);
       // The hold goes down first: between the kill and the marker, a hook that
@@ -128,8 +126,7 @@ export function registerDaemonCommands(program: Command): void {
       }
       const { stopped, pid } = await stopDaemon({ port, pidFilePath });
       if (!stopped) {
-        console.error(`lcm daemon on port ${port} is still up (pid ${pid ?? "?"}) — stop it manually`);
-        exit(1);
+        fail(`lcm daemon on port ${port} is still up (pid ${pid ?? "?"}) — stop it manually`);
       }
       console.log(before ? `lcm daemon stopped (pid ${pid ?? before.pid ?? "?"})` : "lcm daemon was not running");
       if (held) {
@@ -141,7 +138,7 @@ export function registerDaemonCommands(program: Command): void {
     .description("Restart the background daemon")
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (helpRequested(daemonCmd, opts)) { await withCustomHelp(daemonCmd, "daemon"); return; }
+      if (helpRequested(daemonCmd, opts)) await showHelpAndExit("daemon");
       const { stopDaemon, ensureDaemon, checkDaemonHealth } = await import("../daemon/lifecycle.js");
       const { loadDaemonConfig } = await import("../daemon/config.js");
       const { PKG_VERSION, BUILD_ID } = await import("../daemon/version.js");
@@ -152,22 +149,20 @@ export function registerDaemonCommands(program: Command): void {
       if (clearHold(pidFilePath)) console.log("released the daemon hold");
       const { stopped, pid } = await stopDaemon({ port, pidFilePath });
       if (!stopped) {
-        console.error(`lcm daemon on port ${port} is still up (pid ${pid ?? "?"}) — stop it manually`);
-        exit(1);
+        fail(`lcm daemon on port ${port} is still up (pid ${pid ?? "?"}) — stop it manually`);
       }
       const { mkdirSync } = await import("node:fs");
       mkdirSync(lcDir, { recursive: true });
       const { connected } = await ensureDaemon({ port, pidFilePath, spawnTimeoutMs: 10000, expectedVersion: PKG_VERSION, expectedBuild: BUILD_ID });
       if (!connected) {
-        console.error(`lcm daemon did not answer on port ${port} within 10s — check ~/.lossless-claude/daemon.log`);
-        exit(1);
+        fail(`lcm daemon did not answer on port ${port} within 10s — check ~/.lossless-claude/daemon.log`);
       }
       const h = await checkDaemonHealth(port);
       console.log(`lcm daemon restarted on port ${port} (pid ${h?.pid ?? "?"}, v${h?.version ?? "?"})`);
     });
 
   daemonCmd.action(async (opts) => {
-    if (helpRequested(daemonCmd, opts)) { await withCustomHelp(daemonCmd, "daemon"); return; }
+    if (helpRequested(daemonCmd, opts)) await showHelpAndExit("daemon");
   });
   program.addCommand(daemonCmd);
 }

--- a/src/cli/diagnostics.ts
+++ b/src/cli/diagnostics.ts
@@ -2,6 +2,7 @@ import { exit, stdout } from "node:process";
 import type { Command } from "commander";
 import type { DaemonClient } from "../daemon/client.js";
 import { lcmPath } from "../lcm-home.js";
+import { fail, showHelpAndExit } from "./support.js";
 
 export interface DiagnosticsCommandDeps {
   createDaemonClientOrExit: (spawnTimeoutMs?: number) => Promise<DaemonClient>;
@@ -18,10 +19,7 @@ export function registerDiagnosticsCommands(program: Command, deps: DiagnosticsC
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("status"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("status");
       const { loadDaemonConfig } = await import("../daemon/config.js");
       const { join } = await import("node:path");
       const { homedir } = await import("node:os");
@@ -84,10 +82,7 @@ export function registerDiagnosticsCommands(program: Command, deps: DiagnosticsC
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("stats"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("stats");
 
       if (opts.pool) {
         const jsonFlag: boolean = opts.json ?? false;
@@ -97,8 +92,7 @@ export function registerDiagnosticsCommands(program: Command, deps: DiagnosticsC
         try {
           poolData = await client.get("/stats/pool");
         } catch (err) {
-          console.error(`Error: ${err instanceof Error ? err.message : "could not load pool stats"}`);
-          exit(1);
+          fail(`Error: ${err instanceof Error ? err.message : "could not load pool stats"}`);
         }
 
         if (jsonFlag) {
@@ -145,10 +139,7 @@ export function registerDiagnosticsCommands(program: Command, deps: DiagnosticsC
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("doctor"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("doctor");
       const { runDoctor, printResults } = await import("../doctor/doctor.js");
       const results = await runDoctor();
       printResults(results);
@@ -169,18 +160,14 @@ export function registerDiagnoseCommand(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("diagnose"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("diagnose");
       const all: boolean = opts.all ?? false;
       const verbose: boolean = opts.verbose ?? false;
       const json: boolean = opts.json ?? false;
       const days = Number(opts.days);
 
       if (!Number.isFinite(days) || days <= 0 || !Number.isInteger(days)) {
-        console.error("Usage: lcm diagnose [--all] [--days N] [--verbose] [--json]");
-        exit(1);
+        fail("Usage: lcm diagnose [--all] [--days N] [--verbose] [--json]");
       }
 
       const { diagnose, formatDiagnoseResult } = await import("../diagnose.js");

--- a/src/cli/hooks.ts
+++ b/src/cli/hooks.ts
@@ -1,6 +1,6 @@
 import { exit, stdout } from "node:process";
 import type { Command } from "commander";
-import { readStdin } from "./support.js";
+import { readStdin, showHelpAndExit } from "./support.js";
 
 export function registerHookCommands(program: Command): void {
   program
@@ -20,10 +20,7 @@ export function registerHookCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("restore"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("restore");
       const { dispatchHook } = await import("../hooks/dispatch.js");
       const input = await readStdin();
       const r = await dispatchHook("restore", input);
@@ -38,10 +35,7 @@ export function registerHookCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("session-end"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("session-end");
       const { dispatchHook } = await import("../hooks/dispatch.js");
       const input = await readStdin();
       const r = await dispatchHook("session-end", input);
@@ -56,10 +50,7 @@ export function registerHookCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("user-prompt"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("user-prompt");
       const { dispatchHook } = await import("../hooks/dispatch.js");
       const input = await readStdin();
       const r = await dispatchHook("user-prompt", input);
@@ -74,10 +65,7 @@ export function registerHookCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("post-tool"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("post-tool");
       const { dispatchHook } = await import("../hooks/dispatch.js");
       const input = await readStdin();
       const r = await dispatchHook("post-tool", input);

--- a/src/cli/knowledge.ts
+++ b/src/cli/knowledge.ts
@@ -2,6 +2,7 @@ import { exit } from "node:process";
 import type { Command } from "commander";
 import type { DaemonClient } from "../daemon/client.js";
 import { lcmPath } from "../lcm-home.js";
+import { fail, showHelpAndExit } from "./support.js";
 
 export interface ImportCommandDeps {
   createDaemonClientOrExit: (spawnTimeoutMs?: number) => Promise<DaemonClient>;
@@ -24,10 +25,7 @@ export function registerImportCommand(program: Command, deps: ImportCommandDeps)
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("import"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("import");
       const all: boolean = opts.all ?? false;
       const verbose: boolean = opts.verbose ?? false;
       const dryRun: boolean = opts.dryRun ?? false;
@@ -45,16 +43,14 @@ export function registerImportCommand(program: Command, deps: ImportCommandDeps)
 
       let provider: ImportProvider = opts.codex ? "codex" : replay ? "all" : "claude";
       if (opts.codex && opts.provider && opts.provider !== "codex") {
-        console.error("  --codex cannot be combined with a different --provider");
-        exit(1);
+        fail("  --codex cannot be combined with a different --provider");
       }
       if (opts.provider) {
         const provVal = opts.provider as string;
         if (provVal === "claude" || provVal === "codex" || provVal === "all") {
           provider = provVal as ImportProvider;
         } else {
-          console.error(`  Unknown provider "${provVal}". Use: claude, codex, all`);
-          exit(1);
+          fail(`  Unknown provider "${provVal}". Use: claude, codex, all`);
         }
       }
 
@@ -131,10 +127,7 @@ export function registerKnowledgeCommands(program: Command, deps: KnowledgeComma
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("promote"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("promote");
       const all: boolean = opts.all ?? false;
       const verbose: boolean = opts.verbose ?? false;
       const dryRun: boolean = opts.dryRun ?? false;
@@ -225,10 +218,7 @@ export function registerKnowledgeCommands(program: Command, deps: KnowledgeComma
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("export"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("export");
 
       await admitCliDatabaseWork();
       const { exportKnowledge } = await import("../portable-knowledge.js");
@@ -295,10 +285,7 @@ export function registerKnowledgeCommands(program: Command, deps: KnowledgeComma
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (file: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("import-knowledge"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("import-knowledge");
 
       await admitCliDatabaseWork();
       const { importKnowledge } = await import("../portable-knowledge.js");
@@ -310,29 +297,25 @@ export function registerKnowledgeCommands(program: Command, deps: KnowledgeComma
         : undefined;
 
       if (confidence !== undefined && (isNaN(confidence) || confidence < 0 || confidence > 1)) {
-        console.error("  --confidence must be a number between 0.0 and 1.0");
-        exit(1);
+        fail("  --confidence must be a number between 0.0 and 1.0");
       }
 
       let raw: string;
       try {
         raw = readFileSync(file, "utf-8");
       } catch (err: any) {
-        console.error(`  Cannot read file: ${err.message}`);
-        exit(1);
+        fail(`  Cannot read file: ${err.message}`);
       }
 
       let doc: any;
       try {
         doc = JSON.parse(raw);
       } catch {
-        console.error("  Invalid JSON in export file");
-        exit(1);
+        fail("  Invalid JSON in export file");
       }
 
       if (!doc || typeof doc.version !== "number" || !Array.isArray(doc.entries)) {
-        console.error("  File does not look like an lcm export (missing version or entries)");
-        exit(1);
+        fail("  File does not look like an lcm export (missing version or entries)");
       }
 
       const cwd = process.cwd();
@@ -351,8 +334,7 @@ export function registerKnowledgeCommands(program: Command, deps: KnowledgeComma
           console.log(`\n  Imported ${result.imported} entries (${result.skipped} skipped) into ${cwd}\n`);
         }
       } catch (err: any) {
-        console.error(`  Import failed: ${err.message}`);
-        exit(1);
+        fail(`  Import failed: ${err.message}`);
       }
     });
 }

--- a/src/cli/memory.ts
+++ b/src/cli/memory.ts
@@ -1,7 +1,7 @@
-import { exit, stdout } from "node:process";
+import { stdout } from "node:process";
 import type { Command } from "commander";
 import type { DaemonClient } from "../daemon/client.js";
-import { parsePositiveInteger } from "./support.js";
+import { fail, parsePositiveInteger, showHelpAndExit } from "./support.js";
 
 export interface MemoryCommandDeps {
   createDaemonClientOrExit: (spawnTimeoutMs?: number) => Promise<DaemonClient>;
@@ -19,10 +19,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryCommandDeps
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (query: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("search"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("search");
 
       const layers = normalizeStringList(opts.layer);
       const tags = normalizeStringList(opts.tag) ?? [];
@@ -48,10 +45,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryCommandDeps
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (query: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("grep"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("grep");
 
       const mode = ensureAllowedValue(opts.mode, ["full_text", "regex"], "--mode");
       const scope = ensureAllowedValue(opts.scope, ["messages", "summaries", "both"], "--scope");
@@ -73,10 +67,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryCommandDeps
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (nodeId: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("describe"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("describe");
 
       const client = await createDaemonClientOrExit();
       const result = await client.post("/describe", { cwd: process.cwd(), nodeId });
@@ -90,10 +81,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryCommandDeps
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (nodeId: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("expand"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("expand");
 
       const client = await createDaemonClientOrExit();
       const result = await client.post("/expand", {
@@ -111,10 +99,7 @@ export function registerMemoryCommands(program: Command, deps: MemoryCommandDeps
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (text: string, opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("store"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("store");
 
       const client = await createDaemonClientOrExit();
       const result = await client.post("/store", {
@@ -141,16 +126,14 @@ function ensureAllowedValues(values: string[] | undefined, allowed: readonly str
   if (!values) return;
   const invalid = values.filter((value) => !allowed.includes(value));
   if (invalid.length > 0) {
-    console.error(`Invalid ${optionName}: ${invalid.join(", ")}`);
-    exit(1);
+    fail(`Invalid ${optionName}: ${invalid.join(", ")}`);
   }
 }
 
 function ensureAllowedValue(value: unknown, allowed: readonly string[], optionName: string): string | undefined {
   if (value === undefined) return undefined;
   if (typeof value !== "string" || !allowed.includes(value)) {
-    console.error(`Invalid ${optionName}: ${String(value)}`);
-    exit(1);
+    fail(`Invalid ${optionName}: ${String(value)}`);
   }
   return value;
 }

--- a/src/cli/sensitive.ts
+++ b/src/cli/sensitive.ts
@@ -1,6 +1,7 @@
 import { exit, stdout } from "node:process";
 import type { Command } from "commander";
 import { lcmPath } from "../lcm-home.js";
+import { showHelpAndExit } from "./support.js";
 
 export function registerSensitiveCommand(program: Command): void {
   // ─── sensitive ─────────────────────────────────────────────────────────────
@@ -11,10 +12,7 @@ export function registerSensitiveCommand(program: Command): void {
     .option("-h, --help", "Show help")
     .allowUnknownOption(true)
     .action(async (args: string[], opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("sensitive"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("sensitive");
       const { handleSensitive } = await import("../sensitive.js");
       const { join } = await import("node:path");
       const { homedir } = await import("node:os");

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,5 +1,6 @@
 import { exit } from "node:process";
 import type { Command } from "commander";
+import { showHelpAndExit } from "./support.js";
 
 export function registerSetupCommands(program: Command): void {
   // ─── mcp ───────────────────────────────────────────────────────────────────
@@ -9,10 +10,7 @@ export function registerSetupCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("mcp"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("mcp");
       const { startMcpServer } = await import("../mcp/server.js");
       await startMcpServer();
     });
@@ -25,10 +23,7 @@ export function registerSetupCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("install"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("install");
       const dryRun: boolean = opts.dryRun ?? false;
       const { install } = await import("../../installer/install.js");
       if (dryRun) {
@@ -49,10 +44,7 @@ export function registerSetupCommands(program: Command): void {
     .helpOption(false)
     .option("-h, --help", "Show help")
     .action(async (opts) => {
-      if (opts.help) {
-        const { printHelp } = await import("../cli-help.js");
-        printHelp("uninstall"); exit(0);
-      }
+      if (opts.help) await showHelpAndExit("uninstall");
       const dryRun: boolean = opts.dryRun ?? false;
       const { uninstall } = await import("../../installer/uninstall.js");
       if (dryRun) {

--- a/src/cli/support.ts
+++ b/src/cli/support.ts
@@ -17,8 +17,7 @@ export function helpRequested(parent: Command, opts: { help?: boolean }): boolea
 export function parsePositiveInteger(value: string, optionName: string): number {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed <= 0 || !Number.isInteger(parsed)) {
-    console.error(`Invalid ${optionName}: ${value}`);
-    exit(1);
+    fail(`Invalid ${optionName}: ${value}`);
   }
   return parsed;
 }
@@ -38,8 +37,13 @@ export function readStdin(): Promise<string> {
   });
 }
 
-export async function withCustomHelp(cmd: Command, commandName: string): Promise<void> {
+export async function showHelpAndExit(commandName: string): Promise<never> {
   const { printHelp } = await import("../cli-help.js");
   printHelp(commandName);
   exit(0);
+}
+
+export function fail(message: string): never {
+  console.error(message);
+  exit(1);
 }


### PR DESCRIPTION
Last step of the bin/lcm.ts series, behaviour-preserving and proven by the golden guard (357 snapshots byte-identical, no regeneration).

- `showHelpAndExit(name)` in `src/cli/support.ts` replaces the 30 repeated `if (opts.help) { lazy-import printHelp; printHelp(name); exit(0); }` blocks (and the `helpRequested(...)` variant on the daemon and connectors trees). The condition and the help name at every site are unchanged; the import stays lazy inside the helper. `bench` keeps Commander's own help; the `help` command and the unknown-command fallback keep their own calls.
- `fail(message)` replaces the 23 `console.error(message); exit(1);` pairs. Only that exact shape was touched: exit codes other than 1, `process.stderr.write`, and pairs with code in between stay as they were.
- `printHelp(` in `src/cli/`: 30 to 3. `exit(1)`: 25 to 3.

Verification after rebase onto main: build, check-docs (unchanged summary), check-agents, typecheck, full test suite, `golden-capture --verify` byte-identical. No changeset: nothing published changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JB5dRq1GhMvNXTHsrsFN3a